### PR TITLE
Adjust difficulty calculation algorithm

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -78,7 +78,7 @@
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 
 #define DIFFICULTY_WINDOW_V2							              31
-#define DIFFICULTY_CUT_V2                               3
+#define DIFFICULTY_CUT_V2                               6
 #define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2 + DIFFICULTY_CUT_V2*2
 
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS       1

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -49,8 +49,8 @@
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             10
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
 
-#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           60*30
-#define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V2            15
+#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           60*24
+#define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V2            12
 
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)88888888000000000)

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -42,7 +42,7 @@
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
 #define CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW            60
 #define CURRENT_TRANSACTION_VERSION                     2
-#define MIN_TRANSACTION_VERSION							2
+#define MIN_TRANSACTION_VERSION							            2
 #define CURRENT_BLOCK_MAJOR_VERSION                     1
 #define CURRENT_BLOCK_MINOR_VERSION                     1
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              60*60*2
@@ -77,11 +77,9 @@
 #define DIFFICULTY_CUT                                  60   // timestamps to cut after sorting
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 
-#define DIFFICULTY_WINDOW_V2							              17
-#define DIFFICULTY_CUT_V2                               6
+#define DIFFICULTY_WINDOW_V2							              31
+#define DIFFICULTY_CUT_V2                               3
 #define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2 + DIFFICULTY_CUT_V2*2
-
-
 
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS       1
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS      DIFFICULTY_TARGET * CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS
@@ -157,19 +155,19 @@ namespace config
   uint16_t const RPC_DEFAULT_PORT = 19734;
 
   boost::uuids::uuid const NETWORK_ID = { {
-		  0x04, 0x06, 0xdf, 0xce, 0xfc, 0x7c, 0x27, 0x4a, 0x24, 0xd4, 0xf3, 0x8d, 0x42, 0x44, 0x60, 0xa8
+      0x04, 0x06, 0xdf, 0xce, 0xfc, 0x7c, 0x27, 0x4a, 0x24, 0xd4, 0xf3, 0x8d, 0x42, 0x44, 0x60, 0xa8
     } }; // Bender's nightmare
   std::string const GENESIS_TX = "023c01ff0001808098d0daf1d00f028be379aa57a70fa19c0ee5765fdc3d2aae0b1034158f4963e157d9042c24fbec21013402fc7071230f1f86f33099119105a7b1f64a898526060ab871e685059c223100";
   uint32_t const GENESIS_NONCE = 10000;
 
   namespace testnet
   {
-	  uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 0x37751a; // Suto
-	  uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 0x34f51a; // Suti
+    uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 0x37751a; // Suto
+    uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 0x34f51a; // Suti
     uint16_t const P2P_DEFAULT_PORT = 29733;
     uint16_t const RPC_DEFAULT_PORT = 29734;
     boost::uuids::uuid const NETWORK_ID = { {
-			0x12, 0x04, 0x06, 0xdf, 0xce, 0xfc, 0x7c, 0x27, 0x4a, 0x24, 0xd4, 0xf3, 0x8d, 0x42, 0x44, 0x60
+        0x12, 0x04, 0x06, 0xdf, 0xce, 0xfc, 0x7c, 0x27, 0x4a, 0x24, 0xd4, 0xf3, 0x8d, 0x42, 0x44, 0x60
       } }; // Bender's daydream
     std::string const GENESIS_TX = "023c01ff0001808098d0daf1d00f028d7bbb5a23ab085e05230bd45d938c71f669f94c2a170b96b64827b7bc2cbde521012b6ed837a56ef72f57b4e46410bdea82e382c43ae8797a0f3e8419b5d4f8e6fe00";
     uint32_t const GENESIS_NONCE = 10001;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -78,8 +78,8 @@
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 
 #define DIFFICULTY_WINDOW_V2							              17
-#define DIFFICULTY_CUT_V2                               8
-#define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2 + DIFFICULTY_CUT_V2
+#define DIFFICULTY_CUT_V2                               6
+#define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2 + DIFFICULTY_CUT_V2*2
 
 
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -75,6 +75,9 @@
 #define DIFFICULTY_CUT                                  60   // timestamps to cut after sorting
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 
+#define DIFFICULTY_WINDOW_V2							              35
+#define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2
+
 
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS       1
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS      DIFFICULTY_TARGET * CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -47,8 +47,10 @@
 #define CURRENT_BLOCK_MINOR_VERSION                     1
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              60*60*2
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             10
-
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
+
+#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           60*30
+#define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V2            15
 
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY                                    ((uint64_t)88888888000000000)
@@ -75,8 +77,10 @@
 #define DIFFICULTY_CUT                                  60   // timestamps to cut after sorting
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 
-#define DIFFICULTY_WINDOW_V2							              35
-#define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2
+#define DIFFICULTY_WINDOW_V2							              17
+#define DIFFICULTY_CUT_V2                               8
+#define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2 + DIFFICULTY_CUT_V2
+
 
 
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS       1

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -83,7 +83,7 @@ static const struct {
   time_t time;
 } mainnet_hard_forks[] = {
   { 1, 1, 0, 1482806500 },
-  { 2, 21352, 0, 1497657600 }
+  { 2, 21300, 0, 1497657600 }
 };
 static const uint64_t mainnet_hard_fork_version_1_till = (uint64_t)-1;
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -83,6 +83,7 @@ static const struct {
   time_t time;
 } mainnet_hard_forks[] = {
   { 1, 1, 0, 1482806500 },
+  { 2, 21241, 0, 1497657600 }
 };
 static const uint64_t mainnet_hard_fork_version_1_till = (uint64_t) - 1;
 
@@ -93,6 +94,7 @@ static const struct {
   time_t time;
 } testnet_hard_forks[] = {
   { 1, 1, 0, 1482806500 },
+  { 2, 5150, 0, 1497181713 }
 };
 static const uint64_t testnet_hard_fork_version_1_till = (uint64_t) - 1;
 
@@ -673,6 +675,8 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type> difficulties;
   auto height = m_db->height();
+  size_t difficult_block_count = get_current_hard_fork_version() < 2 ? DIFFICULTY_BLOCKS_COUNT : DIFFICULTY_BLOCKS_COUNT_V2;
+
   // ND: Speedup
   // 1. Keep a list of the last 735 (or less) blocks that is used to compute difficulty,
   //    then when the next block difficulty is queried, push the latest height data and
@@ -684,9 +688,9 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
     m_timestamps.push_back(m_db->get_block_timestamp(index));
     m_difficulties.push_back(m_db->get_block_cumulative_difficulty(index));
 
-    while (m_timestamps.size() > DIFFICULTY_BLOCKS_COUNT)
+	while (m_timestamps.size() > difficult_block_count)
       m_timestamps.erase(m_timestamps.begin());
-    while (m_difficulties.size() > DIFFICULTY_BLOCKS_COUNT)
+	while (m_difficulties.size() > difficult_block_count)
       m_difficulties.erase(m_difficulties.begin());
 
     m_timestamps_and_difficulties_height = height;
@@ -695,7 +699,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   }
   else
   {
-    size_t offset = height - std::min < size_t > (height, static_cast<size_t>(DIFFICULTY_BLOCKS_COUNT));
+	  size_t offset = height - std::min < size_t >(height, static_cast<size_t>(difficult_block_count));
     if (offset == 0)
       ++offset;
 
@@ -712,7 +716,9 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
     m_difficulties = difficulties;
   }
   size_t target = DIFFICULTY_TARGET;
-  return next_difficulty(timestamps, difficulties, target);
+  return get_current_hard_fork_version() < 2 ?
+    next_difficulty(timestamps, difficulties, target) :
+    next_difficulty_v2(timestamps, difficulties, target);
 }
 //------------------------------------------------------------------
 // This function removes blocks from the blockchain until it gets to the
@@ -860,16 +866,17 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   LOG_PRINT_L3("Blockchain::" << __func__);
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type> cumulative_difficulties;
+  size_t difficult_block_count = get_current_hard_fork_version() < 2 ? DIFFICULTY_BLOCKS_COUNT : DIFFICULTY_BLOCKS_COUNT_V2;
 
   // if the alt chain isn't long enough to calculate the difficulty target
   // based on its blocks alone, need to get more blocks from the main chain
-  if(alt_chain.size()< DIFFICULTY_BLOCKS_COUNT)
+  if (alt_chain.size()< difficult_block_count)
   {
     CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
     // Figure out start and stop offsets for main chain blocks
     size_t main_chain_stop_offset = alt_chain.size() ? alt_chain.front()->second.height : bei.height;
-    size_t main_chain_count = DIFFICULTY_BLOCKS_COUNT - std::min(static_cast<size_t>(DIFFICULTY_BLOCKS_COUNT), alt_chain.size());
+	size_t main_chain_count = difficult_block_count - std::min(static_cast<size_t>(difficult_block_count), alt_chain.size());
     main_chain_count = std::min(main_chain_count, main_chain_stop_offset);
     size_t main_chain_start_offset = main_chain_stop_offset - main_chain_count;
 
@@ -884,7 +891,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
     }
 
     // make sure we haven't accidentally grabbed too many blocks...maybe don't need this check?
-    CHECK_AND_ASSERT_MES((alt_chain.size() + timestamps.size()) <= DIFFICULTY_BLOCKS_COUNT, false, "Internal error, alt_chain.size()[" << alt_chain.size() << "] + vtimestampsec.size()[" << timestamps.size() << "] NOT <= DIFFICULTY_WINDOW[]" << DIFFICULTY_BLOCKS_COUNT);
+	CHECK_AND_ASSERT_MES((alt_chain.size() + timestamps.size()) <= difficult_block_count, false, "Internal error, alt_chain.size()[" << alt_chain.size() << "] + vtimestampsec.size()[" << timestamps.size() << "] NOT <= DIFFICULTY_WINDOW[]" << difficult_block_count);
 
     for (auto it : alt_chain)
     {
@@ -896,8 +903,8 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   // and timestamps from it alone
   else
   {
-    timestamps.resize(static_cast<size_t>(DIFFICULTY_BLOCKS_COUNT));
-    cumulative_difficulties.resize(static_cast<size_t>(DIFFICULTY_BLOCKS_COUNT));
+	  timestamps.resize(static_cast<size_t>(difficult_block_count));
+	  cumulative_difficulties.resize(static_cast<size_t>(difficult_block_count));
     size_t count = 0;
     size_t max_i = timestamps.size()-1;
     // get difficulties and timestamps from most recent blocks in alt chain
@@ -906,7 +913,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
       timestamps[max_i - count] = it->second.bl.timestamp;
       cumulative_difficulties[max_i - count] = it->second.cumulative_difficulty;
       count++;
-      if(count >= DIFFICULTY_BLOCKS_COUNT)
+	  if (count >= difficult_block_count)
         break;
     }
   }
@@ -915,7 +922,9 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   size_t target = DIFFICULTY_TARGET;
 
   // calculate the difficulty target for the block and return it
-  return next_difficulty(timestamps, cumulative_difficulties, target);
+  return get_current_hard_fork_version() < 2 ? 
+    next_difficulty(timestamps, cumulative_difficulties, target) : 
+    next_difficulty_v2(timestamps, cumulative_difficulties, target);
 }
 //------------------------------------------------------------------
 // This function does a sanity check on basic things that all miner

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1186,12 +1186,14 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
 bool Blockchain::complete_timestamps_vector(uint64_t start_top_height, std::vector<uint64_t>& timestamps)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-
-  if(timestamps.size() >= BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW)
+  size_t blockchain_timestamp_check_window = get_current_hard_fork_version() < 2 ? 
+                                                BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW : 
+                                                BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V2;
+  if (timestamps.size() >= blockchain_timestamp_check_window)
     return true;
 
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
-  size_t need_elements = BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW - timestamps.size();
+  size_t need_elements = blockchain_timestamp_check_window - timestamps.size();
   CHECK_AND_ASSERT_MES(start_top_height < m_db->height(), false, "internal error: passed start_height not < " << " m_db->height() -- " << start_top_height << " >= " << m_db->height());
   size_t stop_offset = start_top_height > need_elements ? start_top_height - need_elements : 0;
   while (start_top_height != stop_offset)
@@ -2816,10 +2818,12 @@ bool Blockchain::check_block_timestamp(std::vector<uint64_t>& timestamps, const 
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   uint64_t median_ts = epee::misc_utils::median(timestamps);
-
+  size_t blockchain_timestamp_check_window = get_current_hard_fork_version() < 2 ?
+                                                BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW :
+                                                BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V2;
   if(b.timestamp < median_ts)
   {
-    LOG_PRINT_L1("Timestamp of block with id: " << get_block_hash(b) << ", " << b.timestamp << ", less than median of last " << BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW << " blocks, " << median_ts);
+    LOG_PRINT_L1("Timestamp of block with id: " << get_block_hash(b) << ", " << b.timestamp << ", less than median of last " << blockchain_timestamp_check_window << " blocks, " << median_ts);
     return false;
   }
 
@@ -2836,14 +2840,21 @@ bool Blockchain::check_block_timestamp(std::vector<uint64_t>& timestamps, const 
 bool Blockchain::check_block_timestamp(const block& b) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  if(b.timestamp > get_adjusted_time() + CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT)
+  uint64_t block_future_time_limit = get_current_hard_fork_version() < 2 ? 
+                                          CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT : 
+                                          CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2;
+  size_t blockchain_timestamp_check_window = get_current_hard_fork_version() < 2 ?
+                                                  BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW :
+                                                  BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V2;
+  if (b.timestamp > get_adjusted_time() + block_future_time_limit)
   {
-    LOG_PRINT_L1("Timestamp of block with id: " << get_block_hash(b) << ", " << b.timestamp << ", bigger than adjusted time + 2 hours");
+    LOG_PRINT_L1("Timestamp of block with id: " << get_block_hash(b) << ", " << b.timestamp << 
+      ", bigger than adjusted time + " << (get_current_hard_fork_version() < 2 ? "2 hours" : "30 minutes"));
     return false;
   }
 
   // if not enough blocks, no proper median yet, return true
-  if(m_db->height() < BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW)
+  if (m_db->height() < blockchain_timestamp_check_window)
   {
     return true;
   }
@@ -2852,7 +2863,7 @@ bool Blockchain::check_block_timestamp(const block& b) const
   auto h = m_db->height();
 
   // need most recent 60 blocks, get index of first of those
-  size_t offset = h - BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW;
+  size_t offset = h - blockchain_timestamp_check_window;
   for(;offset < h; ++offset)
   {
     timestamps.push_back(m_db->get_block_timestamp(offset));

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -83,9 +83,9 @@ static const struct {
   time_t time;
 } mainnet_hard_forks[] = {
   { 1, 1, 0, 1482806500 },
-  { 2, 21241, 0, 1497657600 }
+  { 2, 21352, 0, 1497657600 }
 };
-static const uint64_t mainnet_hard_fork_version_1_till = (uint64_t) - 1;
+static const uint64_t mainnet_hard_fork_version_1_till = (uint64_t)-1;
 
 static const struct {
   uint8_t version;
@@ -96,7 +96,7 @@ static const struct {
   { 1, 1, 0, 1482806500 },
   { 2, 5150, 0, 1497181713 }
 };
-static const uint64_t testnet_hard_fork_version_1_till = (uint64_t) - 1;
+static const uint64_t testnet_hard_fork_version_1_till = (uint64_t)-1;
 
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
@@ -688,9 +688,9 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
     m_timestamps.push_back(m_db->get_block_timestamp(index));
     m_difficulties.push_back(m_db->get_block_cumulative_difficulty(index));
 
-	while (m_timestamps.size() > difficult_block_count)
+    while (m_timestamps.size() > difficult_block_count)
       m_timestamps.erase(m_timestamps.begin());
-	while (m_difficulties.size() > difficult_block_count)
+    while (m_difficulties.size() > difficult_block_count)
       m_difficulties.erase(m_difficulties.begin());
 
     m_timestamps_and_difficulties_height = height;
@@ -699,7 +699,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   }
   else
   {
-	  size_t offset = height - std::min < size_t >(height, static_cast<size_t>(difficult_block_count));
+    size_t offset = height - std::min < size_t >(height, static_cast<size_t>(difficult_block_count));
     if (offset == 0)
       ++offset;
 
@@ -870,28 +870,28 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
 
   // if the alt chain isn't long enough to calculate the difficulty target
   // based on its blocks alone, need to get more blocks from the main chain
-  if (alt_chain.size()< difficult_block_count)
+  if (alt_chain.size() < difficult_block_count)
   {
     CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
     // Figure out start and stop offsets for main chain blocks
     size_t main_chain_stop_offset = alt_chain.size() ? alt_chain.front()->second.height : bei.height;
-	size_t main_chain_count = difficult_block_count - std::min(static_cast<size_t>(difficult_block_count), alt_chain.size());
+    size_t main_chain_count = difficult_block_count - std::min(static_cast<size_t>(difficult_block_count), alt_chain.size());
     main_chain_count = std::min(main_chain_count, main_chain_stop_offset);
     size_t main_chain_start_offset = main_chain_stop_offset - main_chain_count;
 
-    if(!main_chain_start_offset)
+    if (!main_chain_start_offset)
       ++main_chain_start_offset; //skip genesis block
 
     // get difficulties and timestamps from relevant main chain blocks
-    for(; main_chain_start_offset < main_chain_stop_offset; ++main_chain_start_offset)
+    for (; main_chain_start_offset < main_chain_stop_offset; ++main_chain_start_offset)
     {
       timestamps.push_back(m_db->get_block_timestamp(main_chain_start_offset));
       cumulative_difficulties.push_back(m_db->get_block_cumulative_difficulty(main_chain_start_offset));
     }
 
     // make sure we haven't accidentally grabbed too many blocks...maybe don't need this check?
-	CHECK_AND_ASSERT_MES((alt_chain.size() + timestamps.size()) <= difficult_block_count, false, "Internal error, alt_chain.size()[" << alt_chain.size() << "] + vtimestampsec.size()[" << timestamps.size() << "] NOT <= DIFFICULTY_WINDOW[]" << difficult_block_count);
+    CHECK_AND_ASSERT_MES((alt_chain.size() + timestamps.size()) <= difficult_block_count, false, "Internal error, alt_chain.size()[" << alt_chain.size() << "] + vtimestampsec.size()[" << timestamps.size() << "] NOT <= DIFFICULTY_WINDOW[]" << difficult_block_count);
 
     for (auto it : alt_chain)
     {
@@ -903,17 +903,17 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   // and timestamps from it alone
   else
   {
-	  timestamps.resize(static_cast<size_t>(difficult_block_count));
-	  cumulative_difficulties.resize(static_cast<size_t>(difficult_block_count));
+    timestamps.resize(static_cast<size_t>(difficult_block_count));
+    cumulative_difficulties.resize(static_cast<size_t>(difficult_block_count));
     size_t count = 0;
-    size_t max_i = timestamps.size()-1;
+    size_t max_i = timestamps.size() - 1;
     // get difficulties and timestamps from most recent blocks in alt chain
     BOOST_REVERSE_FOREACH(auto it, alt_chain)
     {
       timestamps[max_i - count] = it->second.bl.timestamp;
       cumulative_difficulties[max_i - count] = it->second.cumulative_difficulty;
       count++;
-	  if (count >= difficult_block_count)
+      if (count >= difficult_block_count)
         break;
     }
   }
@@ -922,8 +922,8 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   size_t target = DIFFICULTY_TARGET;
 
   // calculate the difficulty target for the block and return it
-  return get_current_hard_fork_version() < 2 ? 
-    next_difficulty(timestamps, cumulative_difficulties, target) : 
+  return get_current_hard_fork_version() < 2 ?
+    next_difficulty(timestamps, cumulative_difficulties, target) :
     next_difficulty_v2(timestamps, cumulative_difficulties, target);
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/difficulty.cpp
+++ b/src/cryptonote_core/difficulty.cpp
@@ -41,8 +41,8 @@
 #include "misc_language.h"
 #include "difficulty.h"
 
-#define MAX_AVERGAE_TIMESPAN          (uint64_t) 2400 // 40 minutes
-#define MIN_AVERAGE_TIMESPAN          (uint64_t) 3 // 3s
+#define MAX_AVERGAE_TIMESPAN          (uint64_t) DIFFICULTY_TARGET*10   // 40 minutes
+#define MIN_AVERAGE_TIMESPAN          (uint64_t) DIFFICULTY_TARGET/10   // 24s
 
 namespace cryptonote {
 
@@ -196,20 +196,17 @@ namespace cryptonote {
 	  uint64_t timespan_median = epee::misc_utils::median(time_spans);
     uint64_t timespan_average = (timestamps[length - 1] - timestamps[cut_end]) / (length - cut_end - 1);
   
-    uint64_t actual_average_timespan = timespan_median;
+    uint64_t actual_average_timespan = timespan_average;
     uint64_t average_adjust = 0;
     if (timespan_average < timespan_median)
-      average_adjust = (timespan_median - timespan_average)*2/3;
+      average_adjust = (timespan_median - timespan_average)/4;
     if (timespan_average > timespan_median)
-      average_adjust = (timespan_average - timespan_median)*2/3;
+      average_adjust = (timespan_average - timespan_median)/4;
 
-    if (average_adjust > timespan_median * 2)
-      average_adjust = timespan_median * 2;
-    
     if (timespan_average < timespan_median)
-      actual_average_timespan -= average_adjust;
-    if (timespan_average > timespan_median)
       actual_average_timespan += average_adjust;
+    if (timespan_average > timespan_median)
+      actual_average_timespan -= average_adjust;
 
     if (actual_average_timespan > MAX_AVERGAE_TIMESPAN)
       actual_average_timespan = MAX_AVERGAE_TIMESPAN;

--- a/src/cryptonote_core/difficulty.cpp
+++ b/src/cryptonote_core/difficulty.cpp
@@ -166,10 +166,10 @@ namespace cryptonote {
 
   difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds) {
 
-	  if (timestamps.size() > DIFFICULTY_WINDOW_V2)
+    if (timestamps.size() > DIFFICULTY_BLOCKS_COUNT_V2)
 	  {
-		  timestamps.resize(DIFFICULTY_WINDOW_V2);
-		  cumulative_difficulties.resize(DIFFICULTY_WINDOW_V2);
+      timestamps.resize(DIFFICULTY_BLOCKS_COUNT_V2);
+      cumulative_difficulties.resize(DIFFICULTY_BLOCKS_COUNT_V2);
 	  }
 
 	  size_t length = timestamps.size();
@@ -177,31 +177,36 @@ namespace cryptonote {
 	  if (length <= 1) {
 		  return 1;
 	  }
-	
-	  sort(timestamps.begin(), timestamps.end());
-	  std::vector<std::uint64_t> time_spans;
-	  for (size_t i = 0; i < length - 1; i++){
+
+    size_t cut_end = 0;
+    if (length > DIFFICULTY_WINDOW_V2) {
+      cut_end = length - DIFFICULTY_WINDOW_V2;
+    }
+    
+    sort(timestamps.begin(), timestamps.end());
+    std::vector<std::uint64_t> time_spans;
+    for (size_t i = cut_end; i < length - 1; i++){
 		  uint64_t time_span = timestamps[i + 1] - timestamps[i];
 		  if (time_span == 0) {
 			  time_span = 1;
 		  }
 		  time_spans.push_back(time_span);
 
-		  //LOG_PRINT_L1("Timespan " << i << ": " << (time_span / 60) / 60 << ":" << (time_span > 3600 ? (time_span % 3600) / 60 : time_span/60)  << ":" << time_span % 60 << " (" << time_span << ")");
+		  LOG_PRINT_L0("Timespan " << i << ": " << (time_span / 60) / 60 << ":" << (time_span > 3600 ? (time_span % 3600) / 60 : time_span/60)  << ":" << time_span % 60 << " (" << time_span << ")");
 	  }
 	
 	  uint64_t timespan_median = epee::misc_utils::median(time_spans);
-    uint64_t timespan_average = (timestamps[length - 1] - timestamps[0]) / (length - 1);
+    uint64_t timespan_average = (timestamps[length - 1] - timestamps[cut_end]) / (length - cut_end - 1);
   
     uint64_t actual_average_timespan = timespan_median;
     uint64_t average_adjust = 0;
     if (timespan_average < timespan_median)
-      average_adjust = (timespan_median - timespan_average) / 2;
+      average_adjust = (timespan_median - timespan_average)*2/3;
     if (timespan_average > timespan_median)
-      average_adjust = (timespan_average - timespan_median) / 2;
+      average_adjust = (timespan_average - timespan_median)*2/3;
 
-    if (average_adjust > actual_average_timespan/2)
-      average_adjust = actual_average_timespan/2;
+    if (average_adjust > timespan_median * 2)
+      average_adjust = timespan_median * 2;
     
     actual_average_timespan += average_adjust;
 
@@ -210,9 +215,9 @@ namespace cryptonote {
     if (actual_average_timespan < MIN_AVERAGE_TIMESPAN)
       actual_average_timespan = MIN_AVERAGE_TIMESPAN;
 
-    LOG_PRINT_L2("Timespan Median: " << timespan_median << ", Timespan Average: " << timespan_average << ", Actual Average Timespan (after adjusted/bounds): " << actual_average_timespan);
+    LOG_PRINT_L0("Timespan Median: " << timespan_median << ", Timespan Average: " << timespan_average << ", Actual Average Timespan (after adjusted/bounds): " << actual_average_timespan);
 
-	  difficulty_type total_work = cumulative_difficulties[length - 1] - cumulative_difficulties[0];
+    difficulty_type total_work = cumulative_difficulties[length - 1] - cumulative_difficulties[cut_end];
 	  assert(total_work > 0);
 	  
 	  uint64_t low, high;
@@ -221,10 +226,10 @@ namespace cryptonote {
 		  return 0;
 	  }
 
-    uint64_t next_diff = low / (actual_average_timespan * (length - 1));
-    if (next_diff < DIFFICULTY_TARGET) next_diff = DIFFICULTY_TARGET;
+    uint64_t next_diff = low / (actual_average_timespan * (length - cut_end - 1));
+    if (next_diff < 1) next_diff = 1;
 
-    LOG_PRINT_L2("Actual Timespan: " << actual_average_timespan * (length - 1) << ", Total work: " << total_work << ", Next diff: " << next_diff << ", Hashrate (H/s): " << next_diff / target_seconds);
+    LOG_PRINT_L0("Actual Timespan: " << actual_average_timespan * (length - 1) << ", Total work: " << total_work << ", Next diff: " << next_diff << ", Hashrate (H/s): " << next_diff / target_seconds);
 
     return next_diff;
   

--- a/src/cryptonote_core/difficulty.cpp
+++ b/src/cryptonote_core/difficulty.cpp
@@ -41,8 +41,8 @@
 #include "misc_language.h"
 #include "difficulty.h"
 
-#define MAX_AVERGAE_TIMESPAN          (uint64_t) DIFFICULTY_TARGET*5   // 20 minutes
-#define MIN_AVERAGE_TIMESPAN          (uint64_t) DIFFICULTY_TARGET/20   // 12s
+#define MAX_AVERAGE_TIMESPAN          (uint64_t) DIFFICULTY_TARGET*6   // 24 minutes
+#define MIN_AVERAGE_TIMESPAN          (uint64_t) DIFFICULTY_TARGET/12  // 20s
 
 namespace cryptonote {
 
@@ -101,21 +101,21 @@ namespace cryptonote {
   }
 
   static inline bool cadc(uint64_t a, uint64_t b, bool c) {
-    return a + b < a || (c && a + b == (uint64_t) -1);
+    return a + b < a || (c && a + b == (uint64_t)-1);
   }
 
   bool check_hash(const crypto::hash &hash, difficulty_type difficulty) {
     uint64_t low, high, top, cur;
     // First check the highest word, this will most likely fail for a random hash.
-    mul(swap64le(((const uint64_t *) &hash)[3]), difficulty, top, high);
+    mul(swap64le(((const uint64_t *)&hash)[3]), difficulty, top, high);
     if (high != 0) {
       return false;
     }
-    mul(swap64le(((const uint64_t *) &hash)[0]), difficulty, low, cur);
-    mul(swap64le(((const uint64_t *) &hash)[1]), difficulty, low, high);
+    mul(swap64le(((const uint64_t *)&hash)[0]), difficulty, low, cur);
+    mul(swap64le(((const uint64_t *)&hash)[1]), difficulty, low, high);
     bool carry = cadd(cur, low);
     cur = high;
-    mul(swap64le(((const uint64_t *) &hash)[2]), difficulty, low, high);
+    mul(swap64le(((const uint64_t *)&hash)[2]), difficulty, low, high);
     carry = cadc(cur, low, carry);
     carry = cadc(high, top, carry);
     return !carry;
@@ -123,7 +123,7 @@ namespace cryptonote {
 
   difficulty_type next_difficulty(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds) {
 
-    if(timestamps.size() > DIFFICULTY_WINDOW)
+    if (timestamps.size() > DIFFICULTY_WINDOW)
     {
       timestamps.resize(DIFFICULTY_WINDOW);
       cumulative_difficulties.resize(DIFFICULTY_WINDOW);
@@ -143,7 +143,8 @@ namespace cryptonote {
     if (length <= DIFFICULTY_WINDOW - 2 * DIFFICULTY_CUT) {
       cut_begin = 0;
       cut_end = length;
-    } else {
+    }
+    else {
       cut_begin = (length - (DIFFICULTY_WINDOW - 2 * DIFFICULTY_CUT) + 1) / 2;
       cut_end = cut_begin + (DIFFICULTY_WINDOW - 2 * DIFFICULTY_CUT);
     }
@@ -167,16 +168,16 @@ namespace cryptonote {
   difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds) {
 
     if (timestamps.size() > DIFFICULTY_BLOCKS_COUNT_V2)
-	  {
+    {
       timestamps.resize(DIFFICULTY_BLOCKS_COUNT_V2);
       cumulative_difficulties.resize(DIFFICULTY_BLOCKS_COUNT_V2);
-	  }
+    }
 
-	  size_t length = timestamps.size();
-	  assert(length == cumulative_difficulties.size());
-	  if (length <= 1) {
-		  return 1;
-	  }
+    size_t length = timestamps.size();
+    assert(length == cumulative_difficulties.size());
+    if (length <= 1) {
+      return 1;
+    }
 
     sort(timestamps.begin(), timestamps.end());
     size_t cut_begin, cut_end;
@@ -197,54 +198,43 @@ namespace cryptonote {
 
     std::vector<std::uint64_t> time_spans;
     for (size_t i = cut_begin; i < cut_end - 1; i++){
-		  uint64_t time_span = timestamps[i + 1] - timestamps[i];
-		  if (time_span == 0) {
-			  time_span = 1;
-		  }
-		  time_spans.push_back(time_span);
+    uint64_t time_span = timestamps[i + 1] - timestamps[i];
+      if (time_span == 0) {
+        time_span = 1;
+      }
+      time_spans.push_back(time_span);
 
-		  LOG_PRINT_L2("Timespan " << i << ": " << (time_span / 60) / 60 << ":" << (time_span > 3600 ? (time_span % 3600) / 60 : time_span/60)  << ":" << time_span % 60 << " (" << time_span << ")");
-	  }
-	
-	  uint64_t timespan_median = epee::misc_utils::median(time_spans);
-    uint64_t timespan_average = total_timespan / (length - cut_begin * 2 - 1);
-  
-    uint64_t adjusted_average_timespan = timespan_average;
-    uint64_t average_adjust = 0;
-    if (timespan_average < timespan_median)
-      average_adjust = (timespan_median - timespan_average)/4;
-    if (timespan_average > timespan_median)
-      average_adjust = (timespan_average - timespan_median)/4;
+      LOG_PRINT_L2("Timespan " << i << ": " << (time_span / 60) / 60 << ":" << (time_span > 3600 ? (time_span % 3600) / 60 : time_span / 60) << ":" << time_span % 60 << " (" << time_span << ")");
+    }
+    
+    uint64_t timespan_length = length - cut_begin * 2 - 1;
+    uint64_t timespan_median = epee::misc_utils::median(time_spans);
+    LOG_PRINT_L2("Timespan Median: " << timespan_median << ", Timespan Average: " << total_timespan / timespan_length);
 
-    if (timespan_average < timespan_median)
-      adjusted_average_timespan += average_adjust;
-    if (timespan_average > timespan_median)
-      adjusted_average_timespan -= average_adjust;
-
-    if (adjusted_average_timespan > MAX_AVERGAE_TIMESPAN)
-      adjusted_average_timespan = MAX_AVERGAE_TIMESPAN;
-    if (adjusted_average_timespan < MIN_AVERAGE_TIMESPAN)
-      adjusted_average_timespan = MIN_AVERAGE_TIMESPAN;
-
-    LOG_PRINT_L2("Timespan Median: " << timespan_median << ", Timespan Average: " << timespan_average << ", Actual Average Timespan (after adjusted/bounds): " << adjusted_average_timespan);
+    uint64_t total_timespan_median = timespan_median * timespan_length;
+    uint64_t adjusted_total_timespan = (total_timespan * 3 + total_timespan_median) / 4; //  0.75A + 0.25M
+    if (adjusted_total_timespan > MAX_AVERAGE_TIMESPAN * timespan_length){
+      adjusted_total_timespan = MAX_AVERAGE_TIMESPAN * timespan_length;
+    }
+    if (adjusted_total_timespan < MIN_AVERAGE_TIMESPAN * timespan_length){
+      adjusted_total_timespan = MIN_AVERAGE_TIMESPAN * timespan_length;
+    }
 
     difficulty_type total_work = cumulative_difficulties[cut_end - 1] - cumulative_difficulties[cut_begin];
-	  assert(total_work > 0);
-	  
-	  uint64_t low, high;
-    mul(total_work, target_seconds, low, high);
-	  if (high != 0) {
-		  return 1;
-	  }
+    assert(total_work > 0);
 
-    uint64_t adjusted_total_timespan = adjusted_average_timespan * (length - cut_begin * 2 - 1);
-    uint64_t next_diff = low / adjusted_total_timespan;
+    uint64_t low, high;
+    mul(total_work, target_seconds, low, high);
+    if (high != 0) {
+      return 1;
+    }
+
+    uint64_t next_diff = (low + adjusted_total_timespan - 1) / adjusted_total_timespan;
     if (next_diff < 1) next_diff = 1;
 
     LOG_PRINT_L2("Total timespan: " << total_timespan << ", Adjusted total timespan: " << adjusted_total_timespan << ", Total work: " << total_work << ", Next diff: " << next_diff << ", Hashrate (H/s): " << next_diff / target_seconds);
 
     return next_diff;
-  
   }
 
 }

--- a/src/cryptonote_core/difficulty.h
+++ b/src/cryptonote_core/difficulty.h
@@ -53,4 +53,5 @@ namespace cryptonote
      */
     bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
     difficulty_type next_difficulty(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
+	  difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
 }

--- a/src/cryptonote_core/difficulty.h
+++ b/src/cryptonote_core/difficulty.h
@@ -37,21 +37,21 @@
 
 namespace cryptonote
 {
-    typedef std::uint64_t difficulty_type;
+  typedef std::uint64_t difficulty_type;
 
-    /**
-     * @brief checks if a hash fits the given difficulty
-     *
-     * The hash passes if (hash * difficulty) < 2^192.
-     * Phrased differently, if (hash * difficulty) fits without overflow into
-     * the least significant 192 bits of the 256 bit multiplication result.
-     *
-     * @param hash the hash to check
-     * @param difficulty the difficulty to check against
-     *
-     * @return true if valid, else false
-     */
-    bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
-    difficulty_type next_difficulty(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
-	  difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
+  /**
+   * @brief checks if a hash fits the given difficulty
+   *
+   * The hash passes if (hash * difficulty) < 2^192.
+   * Phrased differently, if (hash * difficulty) fits without overflow into
+   * the least significant 192 bits of the 256 bit multiplication result.
+   *
+   * @param hash the hash to check
+   * @param difficulty the difficulty to check against
+   *
+   * @return true if valid, else false
+   */
+  bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
+  difficulty_type next_difficulty(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
+  difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
 }


### PR DESCRIPTION
- Problem: Current diff calculation inheriting from Cryptonote
codebase has serious flaw that cannot adjusted fast enough to multi-pool hashrate
flash (from Nicehash, for example). This was pointed out by MRL-0006 here:

https://www.overleaf.com/articles/difficulty-adjustment-algorithms-in-cryptocurrency-protocols/ytcxbjvzrpbp/viewer.pdf

- Some suggestions to solve the issue can be found here:

https://github.com/monero-project/research-lab/issues/3

and here:

https://github.com/zcash/zcash/issues/147

especially valuable one from @zawy12 (Zcash)

- Sumokoin follows Zcash approach to make difficulty more responsive to hashrate surge
leaving attackers much less profitable.

Please note that this will require a hardford however. Comments are welcome.