### PR TITLE
Change log file name in posix_fork.cpp

### DIFF
--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -76,7 +76,7 @@ void fork()
   }
 
   // Send standard output to a log file.
-  const char* output = "/tmp/bitmonero.daemon.stdout.stderr";
+  const char* output = "/tmp/sumokoin.daemon.stdout.stderr";
   const int flags = O_WRONLY | O_CREAT | O_APPEND;
   const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
   if (open(output, flags, mode) < 0)


### PR DESCRIPTION
request to change the name of the standard output log file from bitmonero.daemon.stdout.stderr to sumokoin.daemon.stdout.stderr. If sumokoind and monerod is started on the same machine a conflict occurs as both daemons try and write to the same file.

ERROR: sumokoin/src/daemonizer/posix_fork.cpp:22 Unable to open output file: /tmp/bitmonero.daemon.stdout.stderr