### PR TITLE
Reduce default block sync size to 10

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -88,7 +88,7 @@
 
 
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              200    //by default, blocks count in blocks downloading
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              10    //by default, blocks count in blocks downloading
 #define CRYPTONOTE_PROTOCOL_HOP_RELAX_COUNT             3      //value of hop, after which we use only announce of new block
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                  86400 //seconds, one day


### PR DESCRIPTION
To address syncing stall when network connection is slow