### PR TITLE
Fix compile bug patched in Monero

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(common
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
+    ${Boost_REGEX_LIBRARY}
   PRIVATE
     ${EXTRA_LIBRARIES})
 


### PR DESCRIPTION
Identical patch of
https://github.com/monero-project/monero/pull/1674

Failed to compile on ubuntu 16.04 with gcc6.30, build works after applying said patch.