### PR TITLE
Improvement of sweep_* command 

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7929,7 +7929,9 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       const size_t estimated_tx_size = estimate_tx_size(use_rct, tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof);
       needed_fee = calculate_fee(fee_per_kb, estimated_tx_size, fee_multiplier);
 
-      tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
+            // add N - 1 outputs for correct initial fee estimation
+      for (size_t i = 0; i < ((outputs > 1) ? outputs - 1 : outputs); ++i)
+        tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
 
       LOG_PRINT_L2("Trying to create a tx now, with " << tx.dsts.size() << " destinations and " <<
         tx.selected_transfers.size() << " outputs");
@@ -7941,15 +7943,36 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
           detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx);
       auto txBlob = t_serializable_object_to_blob(test_ptx.tx);
       needed_fee = calculate_fee(fee_per_kb, txBlob, fee_multiplier);
-      available_for_fee = test_ptx.fee + test_ptx.dests[0].amount + test_ptx.change_dts.amount;
+            available_for_fee = test_ptx.fee + test_ptx.change_dts.amount;
+      for (auto &dt: test_ptx.dests)
+        available_for_fee += dt.amount;
       LOG_PRINT_L2("Made a " << get_size_string(txBlob) << " tx, with " << print_money(available_for_fee) << " available for fee (" <<
         print_money(needed_fee) << " needed)");
+	    
+	     // add last output, missed for fee estimation
+      if (outputs > 1)
+        tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
 
       THROW_WALLET_EXCEPTION_IF(needed_fee > available_for_fee, error::wallet_internal_error, "Transaction cannot pay for itself");
 
       do {
         LOG_PRINT_L2("We made a tx, adjusting fee and saving it");
-        tx.dsts[0].amount = available_for_fee - needed_fee;
+	      
+                // distribute total transferred amount between outputs
+        uint64_t amount_transferred = available_for_fee - needed_fee;
+        uint64_t dt_amount = amount_transferred / outputs;
+        // residue is distributed as one atomic unit per output until it reaches zero
+        uint64_t residue = amount_transferred % outputs;
+        for (auto &dt: tx.dsts)
+        {
+          uint64_t dt_residue = 0;
+          if (residue > 0)
+          {
+            dt_residue = 1;
+            residue -= 1;
+          }
+          dt.amount = dt_amount + dt_residue;
+        }
         if (use_rct)
           transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, unlock_time, needed_fee, extra, 
             test_tx, test_ptx, bulletproof);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7960,9 +7960,9 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
 	      
                 // distribute total transferred amount between outputs
         uint64_t amount_transferred = available_for_fee - needed_fee;
-        uint64_t dt_amount = amount_transferred / outputs;
+        uint64_t dt_amount = amount_transferred / outs;
         // residue is distributed as one atomic unit per output until it reaches zero
-        uint64_t residue = amount_transferred % outputs;
+        uint64_t residue = amount_transferred % outs;
         for (auto &dt: tx.dsts)
         {
           uint64_t dt_residue = 0;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7930,7 +7930,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       needed_fee = calculate_fee(fee_per_kb, estimated_tx_size, fee_multiplier);
 
             // add N - 1 outputs for correct initial fee estimation
-      for (size_t i = 0; i < ((outputs > 1) ? outputs - 1 : outputs); ++i)
+      for (size_t i = 0; i < ((outs > 1) ? outs - 1 : outs); ++i)
         tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
 
       LOG_PRINT_L2("Trying to create a tx now, with " << tx.dsts.size() << " destinations and " <<
@@ -7950,7 +7950,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
         print_money(needed_fee) << " needed)");
 	    
 	     // add last output, missed for fee estimation
-      if (outputs > 1)
+      if (outs > 1)
         tx.dsts.push_back(tx_destination_entry(1, address, is_subaddress));
 
       THROW_WALLET_EXCEPTION_IF(needed_fee > available_for_fee, error::wallet_internal_error, "Transaction cannot pay for itself");


### PR DESCRIPTION
wallet: implement coin splitting for sweep_* 'outputs' option

Implemented strategy splits total amount into N equal parts,
where N is a specified number of outputs. If N > 1, dummy
change output is NOT created.
Authored by mrwhythat 
rebased and comitted by moneromooo on Monero

https://github.com/monero-project/monero/commit/4ed30bab500dbe2ad94dcb44a0f198f94615836a#diff-9d580668dab930045943902048e2ac22L8523

Few adjustments were made to make it compatible with sumokoin's code (vars renaming). 
Compiles without issues
Needs real time testing