### PR TITLE
Add --block-notify to sumokoind and --tx-notify to sumo-wallet-{cli,rpc}

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -33,8 +33,10 @@ set(common_sources
   command_line.cpp
   dns_utils.cpp
   download.cpp
+  exec.cpp
   util.cpp
   i18n.cpp
+  notify.cpp
   password.cpp
   perf_timer.cpp
   threadpool.cpp
@@ -54,8 +56,10 @@ set(common_private_headers
   common_fwd.h
   dns_utils.h
   download.h
+  exec.h
   http_connection.h
   int-util.h
+  notify.h
   pod-class.h
   rpc_client.h
   scoped_message_writer.h

--- a/src/common/exec.cpp
+++ b/src/common/exec.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+ #include "misc_log_ex.h"
+#include "exec.h"
+ namespace tools
+{
+ int exec(const char *filename, char * const argv[], bool wait)
+{
+  pid_t pid = fork();
+  if (pid < 0)
+  {
+    MERROR("Error forking: " << strerror(errno));
+    return -1;
+  }
+   // child
+  if (pid == 0)
+  {
+    char *envp[] = {NULL};
+    execve(filename, argv, envp);
+    MERROR("Failed to execve: " << strerror(errno));
+    return -1;
+  }
+   // parent
+  if (pid > 0)
+  {
+    if (!wait)
+      return 0;
+     while (1)
+    {
+      int wstatus = 0;
+      pid_t w = waitpid(pid, &wstatus, WUNTRACED | WCONTINUED);
+      if (w  < 0) {
+        MERROR("Error waiting for child: " << strerror(errno));
+        return -1;
+      }
+      if (WIFEXITED(wstatus))
+      {
+        MINFO("Child exited with " << WEXITSTATUS(wstatus));
+        return WEXITSTATUS(wstatus);
+      }
+      if (WIFSIGNALED(wstatus))
+      {
+        MINFO("Child killed by " << WEXITSTATUS(wstatus));
+        return WEXITSTATUS(wstatus);
+      }
+    }
+  }
+  MERROR("Secret passage found");
+  return -1;
+}
+ }

--- a/src/common/exec.h
+++ b/src/common/exec.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #pragma once 
+ namespace tools
+{
+ int exec(const char *filename, char * const argv[], bool wait);
+ }

--- a/src/common/notify.cpp
+++ b/src/common/notify.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <boost/algorithm/string.hpp>
+#include "misc_log_ex.h"
+#include "file_io_utils.h"
+#include "exec.h"
+#include "notify.h"
+ namespace tools
+{
+ Notify::Notify(const char *spec)
+{
+  CHECK_AND_ASSERT_THROW_MES(spec, "Null spec");
+   boost::split(args, spec, boost::is_any_of(" "));
+  CHECK_AND_ASSERT_THROW_MES(args.size() > 0, "Failed to parse spec");
+  filename = args[0];
+  CHECK_AND_ASSERT_THROW_MES(epee::file_io_utils::is_file_exist(filename), "File not found: " << filename);
+}
+ int Notify::notify(const char *parameter)
+{
+  std::vector<std::string> margs = args;
+  for (std::string &s: margs)
+    boost::replace_all(s, "%s", parameter);
+   char **cargs = (char**)alloca(sizeof(char*) * (margs.size() + 1));
+  for (size_t n = 0; n < margs.size(); ++n)
+    cargs[n] = (char*)margs[n].c_str();
+  cargs[margs.size()] = NULL;
+  return tools::exec(filename.c_str(), cargs, false);
+}
+ }

--- a/src/common/notify.h
+++ b/src/common/notify.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #pragma once 
+ #include <string>
+#include <vector>
+ namespace tools
+{
+ class Notify
+{
+public:
+  Notify(const char *spec);
+   int notify(const char *parameter);
+ private:
+  std::string filename;
+  std::vector<std::string> args;
+};
+ }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -53,6 +53,7 @@
 #include "cryptonote_core.h"
 #include "ringct/rctSigs.h"
 #include "common/perf_timer.h"
+#include "common/notify.h"
 #if defined(PER_BLOCK_CHECKPOINT)
 #include "blocks/blocks.h"
 #endif
@@ -3590,6 +3591,10 @@ leave:
   // appears to be a NOP *and* is called elsewhere.  wat?
   m_tx_pool.on_blockchain_inc(new_height, id);
 
+	 std::shared_ptr<tools::Notify> block_notify = m_block_notify;
+  if (block_notify)
+    block_notify->notify(epee::string_tools::pod_to_hex(id).c_str());
+	
   return true;
 }
 //------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -55,6 +55,8 @@
 #include "cryptonote_basic/hardfork.h"
 #include "blockchain_db/blockchain_db.h"
 
+namespace tools { class Notify; }
+
 namespace cryptonote
 {
   class tx_memory_pool;
@@ -732,6 +734,13 @@ namespace cryptonote
      */
     void set_user_options(uint64_t maxthreads, uint64_t blocks_per_sync,
         blockchain_db_sync_mode sync_mode, bool fast_sync);
+    
+    /**
+     * @brief sets a block notify object to call for every new block
+     *
+     * @param notify the notify object to cal at every new block
+     */
+    void set_block_notify(const std::shared_ptr<tools::Notify> &notify) { m_block_notify = notify; }
 
     /**
      * @brief Put DB in safe sync mode
@@ -1030,9 +1039,12 @@ namespace cryptonote
     bool m_offline;
 
     std::atomic<bool> m_cancel;
-
+    
+    std::shared_ptr<tools::Notify> m_block_notify;
+    
     crypto::secret_key m_exchange_fund_view_key;
     crypto::public_key m_exchange_fund_spend_key;
+    
 
     /**
      * @brief collects the keys for all outputs being "spent" as an input

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -158,6 +158,11 @@ namespace cryptonote
   , "Set maximum txpool size in bytes."
   , DEFAULT_TXPOOL_MAX_SIZE
   };
+   static const command_line::arg_descriptor<std::string> arg_block_notify = {
+    "block-notify"
+  , "Run a program for each new block, '%s' will be replaced by the block hash"
+  , ""
+  };
 
   //-----------------------------------------------------------------------------------------------
   core::core(i_cryptonote_protocol* pprotocol):

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -53,6 +53,7 @@ using namespace epee;
 #include "ringct/rctTypes.h"
 #include "blockchain_db/blockchain_db.h"
 #include "ringct/rctSigs.h"
+#include "common/notify.h"
 #include "version.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -264,6 +265,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_offline);
     command_line::add_arg(desc, arg_disable_dns_checkpoints);
     command_line::add_arg(desc, arg_max_txpool_size);
+    command_line::add_arg(desc, arg_block_notify);
 
     miner::init_options(desc);
     BlockchainDB::init_options(desc);
@@ -507,6 +509,17 @@ namespace cryptonote
 
     m_blockchain_storage.set_user_options(blocks_threads,
         blocks_per_sync, sync_mode, fast_sync);
+    
+    try
+    {
+      if (!command_line::is_arg_defaulted(vm, arg_block_notify))
+        m_blockchain_storage.set_block_notify(std::shared_ptr<tools::Notify>(new tools::Notify(command_line::get_arg(vm, arg_block_notify).c_str())));
+    }
+    catch (const std::exception &e)
+    {
+      MERROR("Failed to parse block notify spec");
+    }
+
 
     r = m_blockchain_storage.init(db.release(), m_nettype, m_offline, test_options);
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -67,6 +67,7 @@ using namespace epee;
 #include "memwipe.h"
 #include "common/base58.h"
 #include "common/dns_utils.h"
+#include "common/notify.h"
 #include "ringct/rctSigs.h"
 #include "ringdb.h"
 
@@ -152,6 +153,7 @@ struct options {
       return val;
     }
   };
+  const command_line::arg_descriptor<std::string> tx_notify = { "tx-notify" , "Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash" , "" };
 };
 
 void do_prepare_file_names(const std::string& file_path, std::string& keys_file, std::string& wallet_file)
@@ -231,6 +233,17 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   wallet->init(std::move(daemon_address), std::move(login));
   boost::filesystem::path ringdb_path = command_line::get_arg(vm, opts.shared_ringdb_dir);
   wallet->set_ring_database(ringdb_path.string());
+	
+   try
+  {
+    if (!command_line::is_arg_defaulted(vm, opts.tx_notify))
+      wallet->set_tx_notify(std::shared_ptr<tools::Notify>(new tools::Notify(command_line::get_arg(vm, opts.tx_notify).c_str())));
+  }
+  catch (const std::exception &e)
+  {
+    MERROR("Failed to parse tx notify spec");
+  }
+
   return wallet;
 }
 
@@ -711,6 +724,7 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.stagenet);
   command_line::add_arg(desc_params, opts.restricted);
   command_line::add_arg(desc_params, opts.shared_ringdb_dir);
+  command_line::add_arg(desc_params, opts.tx_notify);
 }
 
 std::unique_ptr<wallet2> wallet2::make_from_json(const boost::program_options::variables_map& vm, const std::string& json_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
@@ -1111,6 +1125,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
   std::vector<size_t> outs;
   std::unordered_map<cryptonote::subaddress_index, uint64_t> tx_money_got_in_outs;  // per receiving subaddress index
   crypto::public_key tx_pub_key = null_pkey;
+  bool notify = false;
 
   std::vector<tx_extra_field> tx_extra_fields;
   if(!parse_tx_extra(tx.extra, tx_extra_fields))
@@ -1317,6 +1332,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 	      m_callback->on_money_received(height, txid, tx, td.m_amount, td.m_subaddr_index);
           }
           total_received_1 += amount;
+	  notify = true;
         }
 	else if (m_transfers[kit->second].m_spent || m_transfers[kit->second].amount() >= tx_scan_info[o].amount)
         {
@@ -1384,6 +1400,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 	      m_callback->on_money_received(height, txid, tx, td.m_amount, td.m_subaddr_index);
           }
           total_received_1 += extra_amount;
+	  notify = true;
         }
       }
     }
@@ -1541,6 +1558,14 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       LOG_PRINT_L2("Payment found in " << (pool ? "pool" : "block") << ": " << payment_id << " / " << payment.m_tx_hash << " / " << payment.m_amount);
     }
   }
+    
+	 if (notify)
+  {
+    std::shared_ptr<tools::Notify> tx_notify = m_tx_notify;
+    if (tx_notify)
+      tx_notify->notify(epee::string_tools::pod_to_hex(txid).c_str());
+  }
+	
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t height)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -67,6 +67,7 @@ class Serialization_portability_wallet_Test;
 namespace tools
 {
   class ringdb;
+  class Notify;
 
   class i_wallet2_callback
   {
@@ -1075,6 +1076,8 @@ namespace tools
     bool set_blackballed_outputs(const std::vector<crypto::public_key> &outputs, bool add = false);
     bool unblackball_output(const crypto::public_key &output);
     bool is_output_blackballed(const crypto::public_key &output) const;
+    
+    void set_tx_notify(const std::shared_ptr<tools::Notify> &notify) { m_tx_notify = notify; }
 
   private:
     /*!
@@ -1232,6 +1235,8 @@ namespace tools
     std::string m_ring_database;
     bool m_ring_history_saved;
     std::unique_ptr<ringdb> m_ringdb;
+    
+    std::shared_ptr<tools::Notify> m_tx_notify;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 24)


### PR DESCRIPTION
This is initially a bitcoin daemon/wallet flag/feature imported to Monero

Essentially **--block-notify** executes a program/file upon receipt of a new block on the chain while **--tx-notify** executes a program/file upon receipt 
of any tx on a wallet. This can be used to run scripts, update payment,mining and so on databases etc.

**How to test and verify --block-notify**
Create a bash file on root say clone.sh containing

#!/bin/bash
git clone https://github.com/monero-project/monero /root/test

Fully sync the chain.
Rerun sumokoind with the flag ./sumokoind --block-notify=/root/clone.sh
Upon receipt of a new block clone.sh shall be executed and clone monero on root/test/

**How to test and verify --tx-notify**
Create a bash file on root say clone.sh containing

#!/bin/bash
git clone https://github.com/monero-project/monero /root/test/

Run sumokoind and fully sync
Run a cli (or rpc) wallet with the flag ./sumo-wallet-cli --tx-notify=/root/clone.sh
Send some coins to the wallet's address and upon receipt clone.sh shall be executed and clone monero on root/test/

Quote Unquote from moneromooo-monero's comit

"Those take a command line of the form "A [B]", with A being the
name (and optional path, if not in the caller's CWD, but fully
qualified path is recommended, avoids possible security issues)
to a program, and optional arguments. Any occurence of the two
character string "%s" will be replaced by the hash of the block
or transaction which triggered the notification.

Tokenization is barebones. If you want things like pipes, calls
to paths with spaces, etc, then use a script (though exec time
will suffer).

block-notify is called when a new block is added onto the chain.

tx-notify is called when a new transaction happens with the
wallet as source and/or destination.

It is the notification program's responsibility to determine what
to do in those cases.

Note that this is asynchronous, so it is very possible that:
- the notification programs will be run out of order
- several events happen before the notification for the first one

A Windows port would be nice if someone wants to make one."

Ported from Monero's https://github.com/monero-project/monero/commit/734030046055f521a73e59b50fa2a16f48e34c8d commit by @moneromooo-monero (thank you)