### PR TITLE
Block incoming connections that are on a different version than the latest release

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -204,6 +204,7 @@ namespace nodetool
 
     bool connections_maker();
     bool peer_sync_idle_maker();
+    bool do_request_peer_id(peerid_type& pi, p2p_connection_context& context, bool just_take_peerlist = false);
     bool do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context, bool just_take_peerlist = false);
     bool do_peer_timed_sync(const epee::net_utils::connection_context_base& context, peerid_type peer_id);
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,12 +715,12 @@ namespace nodetool
  
        if (rsp.version.size() == 0)
        {
-         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+         MINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
          hsh_result = false;
       }
       else if (rsp.version != SUMOKOIN_VERSION)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
+        MINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -754,7 +754,7 @@ namespace nodetool
       }
           if (rsp.node_data.version.size() == 0)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+        MCLOG_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -718,7 +718,7 @@ namespace nodetool
          MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
          hsh_result = false;
       }
-      else if (rsp.version != MONERO_VERSION)
+      else if (rsp.version != SUMOKOIN_VERSION)
       {
         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
@@ -737,7 +737,7 @@ namespace nodetool
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
-      else if (rsp.node_data.version != MONERO_VERSION)
+      else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -731,28 +731,7 @@ namespace nodetool
      return hsh_result;
    }
  
-   template<class t_payload_net_handler>
-   bool node_server<t_payload_net_handler>::do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
-   {
-     typename COMMAND_HANDSHAKE::request arg;
-     typename COMMAND_HANDSHAKE::response rsp;
-     get_local_node_data(arg.node_data);
-     m_payload_handler.get_payload_sync_data(arg.payload_data);
- 
-     epee::simple_event ev;
-     std::atomic<bool> hsh_result(false);
- 
-     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_.m_connection_id, COMMAND_HANDSHAKE::ID, arg, m_net_server.get_config_object(),
-       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
-     {
-       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
- 
-       if(code < 0)
-       {
-         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
-        return;
-      }
-       if (rsp.node_data.version.size() == 0)
+          if (rsp.node_data.version.size() == 0)
       {
         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION)
       {
-        MGLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.node_data.version.size() == 0)
       {
-        MCLOG_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -689,26 +689,29 @@ namespace nodetool
     return true;
   }
   //-----------------------------------------------------------------------------------
-   template<class t_payload_net_handler>
-   bool node_server<t_payload_net_handler>::do_request_peer_id(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
-   {
-     typename COMMAND_REQUEST_PEER_ID::request arg;
-     typename COMMAND_REQUEST_PEER_ID::response rsp;
- 
-     epee::simple_event ev;
-     std::atomic<bool> hsh_result(true);
- 
-     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_REQUEST_PEER_ID::response>(context_.m_connection_id, COMMAND_REQUEST_PEER_ID::ID, arg, m_net_server.get_config_object(),
-       [this, &ev, &hsh_result](int code, const typename COMMAND_REQUEST_PEER_ID::response& rsp, p2p_connection_context& context)
-     {
-       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
- 
-       if(code < 0)
-       {
-         LOG_WARNING_CC(context, "COMMAND_REQUEST_PEER_ID invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
-         hsh_result = false;
-         return;
-       }
+
+
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
+  {
+    typename COMMAND_HANDSHAKE::request arg;
+    typename COMMAND_HANDSHAKE::response rsp;
+    get_local_node_data(arg.node_data);
+    m_payload_handler.get_payload_sync_data(arg.payload_data);
+
+    epee::simple_event ev;
+    std::atomic<bool> hsh_result(false);
+
+    bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_.m_connection_id, COMMAND_HANDSHAKE::ID, arg, m_net_server.get_config_object(),
+      [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
+    {
+      epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
+
+      if(code < 0)
+      {
+        LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
+        return;
+      }
  
        if (rsp.version.size() == 0)
        {
@@ -717,7 +720,7 @@ namespace nodetool
       }
       else if (rsp.version != MONERO_VERSION)
       {
-         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -757,68 +760,68 @@ namespace nodetool
       }
       else if (rsp.node_data.version != MONERO_VERSION)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on incorrect version: " << rsp.node_data.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
-       if(rsp.node_data.network_id != m_network_id)
+      if(rsp.node_data.network_id != m_network_id)
       {
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE Failed, wrong network!  (" << epee::string_tools::get_str_from_guid_a(rsp.node_data.network_id) << "), closing connection.");
-         return;
-       }
- 
-       if(!handle_remote_peerlist(rsp.local_peerlist_new, rsp.node_data.local_time, context))
-       {
-         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE: failed to handle_remote_peerlist(...), closing connection.");
-         add_host_fail(context.m_remote_address);
-         return;
-       }
-       hsh_result = true;
-       if(!just_take_peerlist)
-       {
-         if(!m_payload_handler.process_payload_sync_data(rsp.payload_data, context, true))
-         {
-           LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoked, but process_payload_sync_data returned false, dropping connection.");
-           hsh_result = false;
-           return;
-         }
- 
-         pi = context.peer_id = rsp.node_data.peer_id;
-         m_peerlist.set_peer_just_seen(rsp.node_data.peer_id, context.m_remote_address);
- 
-         if(rsp.node_data.peer_id == m_config.m_peer_id)
-         {
-           LOG_DEBUG_CC(context, "Connection to self detected, dropping connection");
-           hsh_result = false;
-           return;
-         }
-         LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE INVOKED OK");
-       }else
-       {
-         LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE(AND CLOSE) INVOKED OK");
-       }
-     }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
- 
-     if(r)
-     {
-       ev.wait();
-     }
- 
-     if(!hsh_result)
-     {
-       LOG_WARNING_CC(context_, "COMMAND_HANDSHAKE Failed");
-       m_net_server.get_config_object().close(context_.m_connection_id);
-     }
-     else
-     {
-       try_get_support_flags(context_, [](p2p_connection_context& flags_context, const uint32_t& support_flags) 
-       {
-         flags_context.support_flags = support_flags;
-       });
-     }
- 
-     return hsh_result;
-   }
+        return;
+      }
+
+      if(!handle_remote_peerlist(rsp.local_peerlist_new, rsp.node_data.local_time, context))
+      {
+        LOG_WARNING_CC(context, "COMMAND_HANDSHAKE: failed to handle_remote_peerlist(...), closing connection.");
+        add_host_fail(context.m_remote_address);
+        return;
+      }
+      hsh_result = true;
+      if(!just_take_peerlist)
+      {
+        if(!m_payload_handler.process_payload_sync_data(rsp.payload_data, context, true))
+        {
+          LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoked, but process_payload_sync_data returned false, dropping connection.");
+          hsh_result = false;
+          return;
+        }
+
+        pi = context.peer_id = rsp.node_data.peer_id;
+        m_peerlist.set_peer_just_seen(rsp.node_data.peer_id, context.m_remote_address);
+
+        if(rsp.node_data.peer_id == m_config.m_peer_id)
+        {
+          LOG_DEBUG_CC(context, "Connection to self detected, dropping connection");
+          hsh_result = false;
+          return;
+        }
+        LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE INVOKED OK");
+      }else
+      {
+        LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE(AND CLOSE) INVOKED OK");
+      }
+    }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
+
+    if(r)
+    {
+      ev.wait();
+    }
+
+    if(!hsh_result)
+    {
+      LOG_WARNING_CC(context_, "COMMAND_HANDSHAKE Failed");
+      m_net_server.get_config_object().close(context_.m_connection_id);
+    }
+    else
+    {
+      try_get_support_flags(context_, [](p2p_connection_context& flags_context, const uint32_t& support_flags) 
+      {
+        flags_context.support_flags = support_flags;
+      });
+    }
+
+    return hsh_result;
+  }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::do_peer_timed_sync(const epee::net_utils::connection_context_base& context_, peerid_type peer_id)

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -713,9 +713,9 @@ namespace nodetool
         return;
       }
  
-      if (rsp.version != SUMOKOIN_VERSION)
+      if (rsp != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -747,15 +747,15 @@ namespace nodetool
          LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
         return;
       }
-          if (rsp.node_data.version.size() == 0)
+          if (rsp.size() == 0)
       {
         MLOG_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
-      else if (rsp.node_data.version != SUMOKOIN_VERSION)
+      else if (rsp != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -689,119 +689,137 @@ namespace nodetool
     return true;
   }
   //-----------------------------------------------------------------------------------
-  template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::do_request_peer_id(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
-  {
-    typename COMMAND_REQUEST_PEER_ID::request arg;
-    typename COMMAND_REQUEST_PEER_ID::response rsp;
+     template<class t_payload_net_handler>
+   bool node_server<t_payload_net_handler>::do_request_peer_id(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
+   {
+     typename COMMAND_REQUEST_PEER_ID::request arg;
+     typename COMMAND_REQUEST_PEER_ID::response rsp;
+ 
      epee::simple_event ev;
-    std::atomic<bool> hsh_result(true);
+     std::atomic<bool> hsh_result(true);
+ 
      bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_REQUEST_PEER_ID::response>(context_.m_connection_id, COMMAND_REQUEST_PEER_ID::ID, arg, m_net_server.get_config_object(),
-      [this, &ev, &hsh_result](int code, const typename COMMAND_REQUEST_PEER_ID::response& rsp, p2p_connection_context& context)
-    {
-      epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
+       [this, &ev, &hsh_result](int code, const typename COMMAND_REQUEST_PEER_ID::response& rsp, p2p_connection_context& context)
+     {
+       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
+ 
        if(code < 0)
-      {
-        LOG_WARNING_CC(context, "COMMAND_REQUEST_PEER_ID invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
-        hsh_result = false;
-        return;
-      }
+       {
+         LOG_WARNING_CC(context, "COMMAND_REQUEST_PEER_ID invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
+         hsh_result = false;
+         return;
+       }
+ 
        if (rsp.version.size() == 0)
-      {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
-        hsh_result = false;
+       {
+         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+         hsh_result = false;
       }
-      else if (rsp.version != MONERO_VERSION)
+      else if (rsp.version != SUMOKOIN_VERSION)
       {
         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " replied with incorrect version: " << rsp.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " has incorrect version: " << rsp.version);
         hsh_result = false;
       }
-     }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
+      }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
+ 
      if (r)
-      ev.wait();
+       ev.wait();
+ 
      return hsh_result;
-  }
-
-  template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
-  {
-    typename COMMAND_HANDSHAKE::request arg;
-    typename COMMAND_HANDSHAKE::response rsp;
-    get_local_node_data(arg.node_data);
-    m_payload_handler.get_payload_sync_data(arg.payload_data);
-
-    epee::simple_event ev;
-    std::atomic<bool> hsh_result(false);
-
-    bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_.m_connection_id, COMMAND_HANDSHAKE::ID, arg, m_net_server.get_config_object(),
-      [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
-    {
-      epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
-
-      if(code < 0)
-      {
-        LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
+   }
+ 
+   template<class t_payload_net_handler>
+   bool node_server<t_payload_net_handler>::do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
+   {
+     typename COMMAND_HANDSHAKE::request arg;
+     typename COMMAND_HANDSHAKE::response rsp;
+     get_local_node_data(arg.node_data);
+     m_payload_handler.get_payload_sync_data(arg.payload_data);
+ 
+     epee::simple_event ev;
+     std::atomic<bool> hsh_result(false);
+ 
+     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_.m_connection_id, COMMAND_HANDSHAKE::ID, arg, m_net_server.get_config_object(),
+       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
+     {
+       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
+ 
+       if(code < 0)
+       {
+         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
         return;
       }
-
-      if(rsp.node_data.network_id != m_network_id)
+       if (rsp.node_data.version.size() == 0)
+      {
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+        block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
+        return;
+      }
+      else if (rsp.node_data.version != SUMOKOIN_VERSION)
+      {
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " has incorrect version: " << rsp.node_data.version);
+        block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
+        return;
+      }
+       if(rsp.node_data.network_id != m_network_id)
       {
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE Failed, wrong network!  (" << epee::string_tools::get_str_from_guid_a(rsp.node_data.network_id) << "), closing connection.");
-        return;
-      }
-
-      if(!handle_remote_peerlist(rsp.local_peerlist_new, rsp.node_data.local_time, context))
-      {
-        LOG_WARNING_CC(context, "COMMAND_HANDSHAKE: failed to handle_remote_peerlist(...), closing connection.");
-        add_host_fail(context.m_remote_address);
-        return;
-      }
-      hsh_result = true;
-      if(!just_take_peerlist)
-      {
-        if(!m_payload_handler.process_payload_sync_data(rsp.payload_data, context, true))
-        {
-          LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoked, but process_payload_sync_data returned false, dropping connection.");
-          hsh_result = false;
-          return;
-        }
-
-        pi = context.peer_id = rsp.node_data.peer_id;
-        m_peerlist.set_peer_just_seen(rsp.node_data.peer_id, context.m_remote_address);
-
-        if(rsp.node_data.peer_id == m_config.m_peer_id)
-        {
-          LOG_DEBUG_CC(context, "Connection to self detected, dropping connection");
-          hsh_result = false;
-          return;
-        }
-        LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE INVOKED OK");
-      }else
-      {
-        LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE(AND CLOSE) INVOKED OK");
-      }
-    }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
-
-    if(r)
-    {
-      ev.wait();
-    }
-
-    if(!hsh_result)
-    {
-      LOG_WARNING_CC(context_, "COMMAND_HANDSHAKE Failed");
-      m_net_server.get_config_object().close(context_.m_connection_id);
-    }
-    else
-    {
-      try_get_support_flags(context_, [](p2p_connection_context& flags_context, const uint32_t& support_flags) 
-      {
-        flags_context.support_flags = support_flags;
-      });
-    }
-
-    return hsh_result;
-  }
+         return;
+       }
+ 
+       if(!handle_remote_peerlist(rsp.local_peerlist_new, rsp.node_data.local_time, context))
+       {
+         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE: failed to handle_remote_peerlist(...), closing connection.");
+         add_host_fail(context.m_remote_address);
+         return;
+       }
+       hsh_result = true;
+       if(!just_take_peerlist)
+       {
+         if(!m_payload_handler.process_payload_sync_data(rsp.payload_data, context, true))
+         {
+           LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoked, but process_payload_sync_data returned false, dropping connection.");
+           hsh_result = false;
+           return;
+         }
+ 
+         pi = context.peer_id = rsp.node_data.peer_id;
+         m_peerlist.set_peer_just_seen(rsp.node_data.peer_id, context.m_remote_address);
+ 
+         if(rsp.node_data.peer_id == m_config.m_peer_id)
+         {
+           LOG_DEBUG_CC(context, "Connection to self detected, dropping connection");
+           hsh_result = false;
+           return;
+         }
+         LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE INVOKED OK");
+       }else
+       {
+         LOG_DEBUG_CC(context, " COMMAND_HANDSHAKE(AND CLOSE) INVOKED OK");
+       }
+     }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
+ 
+     if(r)
+     {
+       ev.wait();
+     }
+ 
+     if(!hsh_result)
+     {
+       LOG_WARNING_CC(context_, "COMMAND_HANDSHAKE Failed");
+       m_net_server.get_config_object().close(context_.m_connection_id);
+     }
+     else
+     {
+       try_get_support_flags(context_, [](p2p_connection_context& flags_context, const uint32_t& support_flags) 
+       {
+         flags_context.support_flags = support_flags;
+       });
+     }
+ 
+     return hsh_result;
+   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::do_peer_timed_sync(const epee::net_utils::connection_context_base& context_, peerid_type peer_id)
@@ -1408,6 +1426,7 @@ namespace nodetool
     time(&local_time);
     node_data.local_time = local_time;
     node_data.peer_id = m_config.m_peer_id;
+    node_data.version = SUMOKOIN_VERSION;
     if(!m_hide_my_port)
       node_data.my_port = m_external_port ? m_external_port : m_listening_port;
     else
@@ -1680,7 +1699,21 @@ namespace nodetool
   template<class t_payload_net_handler>
   int node_server<t_payload_net_handler>::handle_handshake(int command, typename COMMAND_HANDSHAKE::request& arg, typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
   {
-    if(arg.node_data.network_id != m_network_id)
+    if (arg.node_data.version.size() == 0)
+    {
+      MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+      drop_connection(context);
+      block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
+      return 1;
+    }
+     if (arg.node_data.version != MONERO_VERSION)
+    {
+      MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << arg.node_data.version);
+      drop_connection(context);
+      block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
+      return 1;
+    }
+     if(arg.node_data.network_id != m_network_id)
     {
 
       LOG_INFO_CC(context, "WRONG NETWORK AGENT CONNECTED! id=" << epee::string_tools::get_str_from_guid_a(arg.node_data.network_id));

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -706,16 +706,16 @@ namespace nodetool
       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
     {
       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
-
+     rsp.version = SUMOKOIN_VERSION_FULL;
       if(code < 0)
       {
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
         return;
       }
  
-      if (rsp.version != SUMOKOIN_VERSION)
+      if (rsp.version != SUMOKOIN_VERSION_FULL)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.node_data.version.size() == 0)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+        MGINFO_CYAN("Peer " << context.m_remote_address.host_str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -713,9 +713,9 @@ namespace nodetool
         return;
       }
  
-      if (rsp.version != SUMOKOIN_VERSION_FULL)
+      if (rsp.version != SUMOKOIN_VERSION)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
+        MGLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -755,7 +755,7 @@ namespace nodetool
       }
       else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
+        MGLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -706,59 +706,13 @@ namespace nodetool
       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
     {
       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
-     
+
       if(code < 0)
       {
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
         return;
       }
- 
-      if (rsp.version != SUMOKOIN_VERSION)
-      {
-        MLOG_CYAN( context.m_remote_address() << "Peer is on an incorrect version");
-        hsh_result = false;
-      }
-      }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
- 
-     if (r)
-       ev.wait();
- 
-     return hsh_result;
-   }
-  
-   template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
-   {
-     typename COMMAND_HANDSHAKE::request arg;
-     typename COMMAND_HANDSHAKE::response rsp;
-     get_local_node_data(arg.node_data);
-     m_payload_handler.get_payload_sync_data(arg.payload_data);
- 
-     epee::simple_event ev;
-     std::atomic<bool> hsh_result(false);
- 
-     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_.m_connection_id, COMMAND_HANDSHAKE::ID, arg, m_net_server.get_config_object(),
-       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
-     {
-       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
- 
-       if(code < 0)
-       {
-         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
-        return;
-      }
-          if (rsp.size() == 0)
-      {
-        MLOG_CYAN( context.m_remote_address << "did not provide version information");
-        block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
-        return;
-      }
-      else if (rsp.version != SUMOKOIN_VERSION)
-      {
-        MLOG_CYAN( context.m_remote_address << "Peer is on an incorrect version");
-        block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
-        return;
-      }
+
       if(rsp.node_data.network_id != m_network_id)
       {
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE Failed, wrong network!  (" << epee::string_tools::get_str_from_guid_a(rsp.node_data.network_id) << "), closing connection.");

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION_FULL)
       {
-        MGLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.node_data.version.size() == 0)
       {
-        MGLOG_CYAN("Peer " << context.m_remote_address.host_str() << " did not provide version information");
+        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -706,14 +706,14 @@ namespace nodetool
       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
     {
       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
-     rsp.version = SUMOKOIN_VERSION_FULL;
+     
       if(code < 0)
       {
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
         return;
       }
  
-      if (rsp.version != SUMOKOIN_VERSION_FULL)
+      if (rsp.version != SUMOKOIN_VERSION)
       {
         MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN( context.m_remote_address.str() << "Peer is on an incorrect version");
+        MLOG_CYAN( context.m_remote_address() << "Peer is on an incorrect version");
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.size() == 0)
       {
-        MLOG_CYAN( context.m_remote_address.str() << "did not provide version information");
+        MLOG_CYAN( context.m_remote_address << "did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN( context.m_remote_address.str() << "Peer is on an incorrect version");
+        MLOG_CYAN( context.m_remote_address << "Peer is on an incorrect version");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1494,7 +1494,7 @@ namespace nodetool
   int node_server<t_payload_net_handler>::handle_get_peer_id(int command, COMMAND_REQUEST_PEER_ID::request& arg, COMMAND_REQUEST_PEER_ID::response& rsp, p2p_connection_context& context)
   {
     rsp.my_id = m_config.m_peer_id;
-    rsp.version = "0.0.0.0";
+    rsp.version = SUMOKOIN_VERSION;
     return 1;
   }
 #endif

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1706,7 +1706,7 @@ namespace nodetool
       block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
       return 1;
     }
-     if (arg.node_data.version != MONERO_VERSION)
+     if (arg.node_data.version != SUMOKOIN_VERSION)
     {
       MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << arg.node_data.version);
       drop_connection(context);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp);
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version");
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -755,7 +755,7 @@ namespace nodetool
       }
       else if (rsp != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp);
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,12 +715,12 @@ namespace nodetool
  
        if (rsp.version.size() == 0)
        {
-         MINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
          hsh_result = false;
       }
       else if (rsp.version != SUMOKOIN_VERSION)
       {
-        MINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
+        MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -713,7 +713,7 @@ namespace nodetool
         return;
       }
  
-      if (rsp != SUMOKOIN_VERSION)
+      if (rsp.version != SUMOKOIN_VERSION)
       {
         MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version");
         hsh_result = false;
@@ -753,7 +753,7 @@ namespace nodetool
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
-      else if (rsp != SUMOKOIN_VERSION)
+      else if (rsp.version != SUMOKOIN_VERSION)
       {
         MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() " is on an incorrect version");
+        MLOG_CYAN( context.m_remote_address.str() << "Peer is on an incorrect version");
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.size() == 0)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() " did not provide version information");
+        MLOG_CYAN( context.m_remote_address.str() << "did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() " is on an incorrect version");
+        MLOG_CYAN( context.m_remote_address.str() << "Peer is on an incorrect version");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.node_data.version.size() == 0)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " did not provide version information");
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
+        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION_FULL)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
+        MGLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.node_data.version.size() == 0)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.host_str() << " did not provide version information");
+        MGLOG_CYAN("Peer " << context.m_remote_address.host_str() << " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGINFO_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
+        MGLOG_CYAN("Peer " << context.m_remote_address.host_str() << " is on an incorrect version: " << rsp.node_data.version);
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -730,7 +730,28 @@ namespace nodetool
  
      return hsh_result;
    }
+  
+   template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::do_handshake_with_peer(peerid_type& pi, p2p_connection_context& context_, bool just_take_peerlist)
+   {
+     typename COMMAND_HANDSHAKE::request arg;
+     typename COMMAND_HANDSHAKE::response rsp;
+     get_local_node_data(arg.node_data);
+     m_payload_handler.get_payload_sync_data(arg.payload_data);
  
+     epee::simple_event ev;
+     std::atomic<bool> hsh_result(false);
+ 
+     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_.m_connection_id, COMMAND_HANDSHAKE::ID, arg, m_net_server.get_config_object(),
+       [this, &pi, &ev, &hsh_result, &just_take_peerlist](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
+     {
+       epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
+ 
+       if(code < 0)
+       {
+         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
+        return;
+      }
           if (rsp.node_data.version.size() == 0)
       {
         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -713,12 +713,7 @@ namespace nodetool
         return;
       }
  
-       if (rsp.version.size() == 0)
-       {
-         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
-         hsh_result = false;
-      }
-      else if (rsp.version != SUMOKOIN_VERSION)
+      if (rsp.version != SUMOKOIN_VERSION_FULL)
       {
         MGINFO_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version: " << rsp.version);
         hsh_result = false;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -715,7 +715,7 @@ namespace nodetool
  
       if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version");
+        MLOG_CYAN("Peer " << context.m_remote_address.str() " is on an incorrect version");
         hsh_result = false;
       }
       }, P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT);
@@ -749,13 +749,13 @@ namespace nodetool
       }
           if (rsp.size() == 0)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " did not provide version information");
+        MLOG_CYAN("Peer " << context.m_remote_address.str() " did not provide version information");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }
       else if (rsp.version != SUMOKOIN_VERSION)
       {
-        MLOG_CYAN("Peer " << context.m_remote_address.str() << " is on an incorrect version");
+        MLOG_CYAN("Peer " << context.m_remote_address.str() " is on an incorrect version");
         block_host(context.m_remote_address, P2P_IP_BLOCKTIME);
         return;
       }

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -155,12 +155,14 @@ namespace nodetool
     uint64_t local_time;
     uint32_t my_port;
     peerid_type peer_id;
+    std::string version;
 
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE_VAL_POD_AS_BLOB(network_id)
       KV_SERIALIZE(peer_id)
       KV_SERIALIZE(local_time)
       KV_SERIALIZE(my_port)
+      KV_SERIALIZE(version)
     END_KV_SERIALIZE_MAP()
   };
   

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -39,6 +39,7 @@
 #include "cryptonote_config.h"
 #ifdef ALLOW_DEBUG_COMMANDS
 #include "crypto/crypto.h"
+#include <version.h>
 #endif
 
 namespace nodetool
@@ -287,7 +288,6 @@ namespace nodetool
   };
 
   /************************************************************************/
-  /*                                                                      */
   /************************************************************************/
 
   struct COMMAND_PING
@@ -420,9 +420,11 @@ namespace nodetool
     struct response
     {
       peerid_type my_id;
+      std::string version;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(my_id)
+	KV_SERIALIZE(version)      
       END_KV_SERIALIZE_MAP()    
     };
   };


### PR DESCRIPTION
**This is most likely a feature to be merged on the next release.** (for reasons explained below)

What it does:

Daemon now transmits the version it is on so incoming connections are being firstly queried about their version number. If no version number is received or the version number received is not the latest then the handshake ends there. 

This provides very fast syncing as it prohibits syncing via connections to bad nodes of previous releases and the time lapse for these nodes to be blocked and black listed (when they reach their maximum "good" height) is avoided. Old alt chains remain completely isolated from the main one. 

**The daemon emits its version number so if its merged earlier than an official release and a user compiles from source, all incoming sources run from precompiled binaries will be blocked since they will not be emitting their version number. The update must be global for this to have the desired effect**

This nice feature was blatantly stolen from a nifty little coin called nerva
Their commits
https://github.com/angrywasp/nerva/commit/0553aa96794c6a593bbfbc255cb22cfa4d2f68e3
https://github.com/angrywasp/nerva/commit/6a0ff941325a5c169a1e43bf38831dae366df88d
https://github.com/angrywasp/nerva/commit/e95bb65c2b628dae04baab86b2397f0d1f72b860

