### PR TITLE
Added the DNSSEC trust anchor for the upcoming KSK rollover

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -101,7 +101,7 @@ static const char*
 get_builtin_ds(void)
 {
   return
-". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n";
+". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n";
 }
 
 /************************************************************


### PR DESCRIPTION
Added the DNSSEC trust anchor for the upcoming KSK rollover
More information can be found at: https://www.icann.org/resources/pages/ksk-rollover