### PR TITLE
set confirmations to 0 for pool txes on wallet

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9633,13 +9633,13 @@ void wallet2::check_tx_key_helper(const crypto::hash &txid, const crypto::key_de
   }
 
   in_pool = res.txs.front().in_pool;
-  confirmations = (uint64_t)-1;
+  confirmations = 0;
   if (!in_pool)
   {
     std::string err;
     uint64_t bc_height = get_daemon_blockchain_height(err);
     if (err.empty())
-      confirmations = bc_height - (res.txs.front().block_height + 1);
+      confirmations = bc_height - res.txs.front().block_height;
   }
 }
 


### PR DESCRIPTION
Vu following our discussion, XMR has caught the bug which was reported with the 0 pool tx confirmations on cli (which i port here), please fix the similar bug on the rpc ( showin on get_transfer_by_txid, etc... for txs still on pool)  by explicitly declaring them to zero as per your suggestion so we can pull on Monero too 