### PR TITLE
[ALL] Various fixes and updates for SSL, blockchain, tests...

### DIFF
--- a/contrib/epee/include/net/net_fwd.h
+++ b/contrib/epee/include/net/net_fwd.h
@@ -1,32 +1,21 @@
-/**
-@file
-@details
-
-
-Passing RPC commands:
-
-@image html images/other/runtime-commands.png
-
-*/
-
-// Copyright (c) 2014-2019, The Monero Project
-// 
+// Copyright (c) 2019, The Monero Project
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -39,43 +28,11 @@ Passing RPC commands:
 
 #pragma once
 
-#include <boost/optional/optional_fwd.hpp>
-#include "common/common_fwd.h"
-#include "console_handler.h"
-#include "daemon/command_parser_executor.h"
-#include "net/net_fwd.h"
-
-namespace daemonize {
-
-class t_command_server {
-private:
-  t_command_parser_executor m_parser;
-  epee::console_handlers_binder m_command_lookup;
-  bool m_is_rpc;
-
-public:
-  t_command_server(
-      uint32_t ip
-    , uint16_t port
-    , const boost::optional<tools::login>& login
-    , const epee::net_utils::ssl_options_t& ssl_options
-    , bool is_rpc = true
-    , cryptonote::core_rpc_server* rpc_server = NULL
-    );
-
-  bool process_command_str(const std::string& cmd);
-
-  bool process_command_vec(const std::vector<std::string>& cmd);
-
-  bool start_handling(std::function<void(void)> exit_handler = NULL);
-
-  void stop_handling();
-
-private:
-  bool help(const std::vector<std::string>& args);
-
-  std::string get_commands_str();
-  std::string get_command_usage(const std::vector<std::string> &args);
-};
-
-} // namespace daemonize
+namespace epee
+{
+  namespace net_utils
+  {
+    struct ssl_authentication_t;
+    class ssl_options_t;
+  }
+}

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -754,6 +754,21 @@ public:
   virtual void batch_stop() = 0;
 
   /**
+   * @brief aborts a batch transaction
+   *
+   * If the subclass implements batching, this function should abort the
+   * batch it is currently on.
+   *
+   * If no batch is in-progress, this function should throw a DB_ERROR.
+   * This exception may change in the future if it is deemed necessary to
+   * have a more granular exception type for this scenario.
+   *
+   * If any of this cannot be done, the subclass should throw the corresponding
+   * subclass of DB_EXCEPTION
+   */
+  virtual void batch_abort() = 0;
+
+  /**
    * @brief sets whether or not to batch transactions
    *
    * If the subclass implements batching, this function tells it to begin

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -54,6 +54,7 @@ public:
   virtual void unlock() override { }
   virtual bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0) override { return true; }
   virtual void batch_stop() override {}
+  virtual void batch_abort() override {}
   virtual void set_batch_transactions(bool) override {}
   virtual void block_wtxn_start() override {}
   virtual void block_wtxn_stop() override {}

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -36,6 +36,7 @@
 #include "storages/http_abstract_invoke.h"
 #include "net/http_auth.h"
 #include "net/http_client.h"
+#include "net/net_ssl.h"
 #include "string_tools.h"
 
 namespace tools
@@ -49,11 +50,12 @@ namespace tools
         uint32_t ip
       , uint16_t port
       , boost::optional<epee::net_utils::http::login> user
+      , epee::net_utils::ssl_options_t ssl_options
       )
       : m_http_client{}
     {
       m_http_client.set_server(
-        epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port), std::move(user)
+        epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port), std::move(user), std::move(ssl_options)
       );
     }
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1103,6 +1103,9 @@ namespace cryptonote
     uint64_t m_btc_expected_reward;
     bool m_btc_valid;
 
+
+    bool m_batch_success;
+
     std::shared_ptr<tools::Notify> m_block_notify;
     std::shared_ptr<tools::Notify> m_reorg_notify;
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -676,8 +676,14 @@ namespace cryptonote
     {
       // display a message if the blockchain is not pruned yet
       if (m_blockchain_storage.get_current_blockchain_height() > 1 && !m_blockchain_storage.get_blockchain_pruning_seed())
+      {
         MGINFO("Pruning blockchain...");
-      CHECK_AND_ASSERT_MES(m_blockchain_storage.prune_blockchain(), false, "Failed to prune blockchain");
+        CHECK_AND_ASSERT_MES(m_blockchain_storage.prune_blockchain(), false, "Failed to prune blockchain");
+      }
+      else
+      {
+        CHECK_AND_ASSERT_MES(m_blockchain_storage.update_blockchain_pruning(), false, "Failed to update blockchain pruning");
+      }
     }
 
     return load_state_data();

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -40,10 +40,11 @@ t_command_parser_executor::t_command_parser_executor(
     uint32_t ip
   , uint16_t port
   , const boost::optional<tools::login>& login
+  , const epee::net_utils::ssl_options_t& ssl_options
   , bool is_rpc
   , cryptonote::core_rpc_server* rpc_server
   )
-  : m_executor(ip, port, login, is_rpc, rpc_server)
+  : m_executor(ip, port, login, ssl_options, is_rpc, rpc_server)
 {}
 
 bool t_command_parser_executor::print_peer_list(const std::vector<std::string>& args)

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -40,6 +40,7 @@
 
 #include "daemon/rpc_command_executor.h"
 #include "common/common_fwd.h"
+#include "net/net_fwd.h"
 #include "rpc/core_rpc_server.h"
 
 namespace daemonize {
@@ -53,6 +54,7 @@ public:
       uint32_t ip
     , uint16_t port
     , const boost::optional<tools::login>& login
+    , const epee::net_utils::ssl_options_t& ssl_options
     , bool is_rpc
     , cryptonote::core_rpc_server* rpc_server = NULL
     );

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -43,10 +43,11 @@ t_command_server::t_command_server(
     uint32_t ip
   , uint16_t port
   , const boost::optional<tools::login>& login
+  , const epee::net_utils::ssl_options_t& ssl_options
   , bool is_rpc
   , cryptonote::core_rpc_server* rpc_server
   )
-  : m_parser(ip, port, login, is_rpc, rpc_server)
+  : m_parser(ip, port, login, ssl_options, is_rpc, rpc_server)
   , m_command_lookup()
   , m_is_rpc(is_rpc)
 {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -45,6 +45,7 @@
 #include "daemon/command_server.h"
 #include "daemon/command_server.h"
 #include "daemon/command_line_args.h"
+#include "net/net_ssl.h"
 #include "version.h"
 
 using namespace epee;
@@ -163,7 +164,7 @@ bool t_daemon::run(bool interactive)
     if (interactive && mp_internals->rpcs.size())
     {
       // The first three variables are not used when the fourth is false
-      rpc_commands.reset(new daemonize::t_command_server(0, 0, boost::none, false, mp_internals->rpcs.front()->get_server()));
+      rpc_commands.reset(new daemonize::t_command_server(0, 0, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled, false, mp_internals->rpcs.front()->get_server()));
       rpc_commands->start_handling(std::bind(&daemonize::t_daemon::stop_p2p, this));
     }
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -324,7 +324,11 @@ int main(int argc, char const * argv[])
           }
         }
 
-        daemonize::t_command_server rpc_commands{rpc_ip, rpc_port, std::move(login)};
+        auto ssl_options = cryptonote::rpc_args::process_ssl(vm, true);
+        if (!ssl_options)
+          return 1;
+
+        daemonize::t_command_server rpc_commands{rpc_ip, rpc_port, std::move(login), std::move(*ssl_options)};
         if (rpc_commands.process_command_vec(command))
         {
           return 0;

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -127,6 +127,7 @@ t_rpc_command_executor::t_rpc_command_executor(
     uint32_t ip
   , uint16_t port
   , const boost::optional<tools::login>& login
+  , const epee::net_utils::ssl_options_t& ssl_options
   , bool is_rpc
   , cryptonote::core_rpc_server* rpc_server
   )
@@ -137,7 +138,7 @@ t_rpc_command_executor::t_rpc_command_executor(
     boost::optional<epee::net_utils::http::login> http_login{};
     if (login)
       http_login.emplace(login->username, login->password.password());
-    m_rpc_client = new tools::t_rpc_client(ip, port, std::move(http_login));
+    m_rpc_client = new tools::t_rpc_client(ip, port, std::move(http_login), ssl_options);
   }
   else
   {

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -43,6 +43,7 @@
 #include "common/common_fwd.h"
 #include "common/rpc_client.h"
 #include "cryptonote_basic/cryptonote_basic.h"
+#include "net/net_fwd.h"
 #include "rpc/core_rpc_server.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -61,6 +62,7 @@ public:
       uint32_t ip
     , uint16_t port
     , const boost::optional<tools::login>& user
+    , const epee::net_utils::ssl_options_t& ssl_options
     , bool is_rpc = true
     , cryptonote::core_rpc_server* rpc_server = NULL
     );

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -90,15 +90,9 @@ namespace cryptonote
     command_line::add_arg(desc, arg_rpc_bind_port);
     command_line::add_arg(desc, arg_rpc_restricted_bind_port);
     command_line::add_arg(desc, arg_restricted_rpc);
-    command_line::add_arg(desc, arg_rpc_ssl);
-    command_line::add_arg(desc, arg_rpc_ssl_private_key);
-    command_line::add_arg(desc, arg_rpc_ssl_certificate);
-    command_line::add_arg(desc, arg_rpc_ssl_ca_certificates);
-    command_line::add_arg(desc, arg_rpc_ssl_allowed_fingerprints);
-    command_line::add_arg(desc, arg_rpc_ssl_allow_any_cert);
     command_line::add_arg(desc, arg_bootstrap_daemon_address);
     command_line::add_arg(desc, arg_bootstrap_daemon_login);
-    cryptonote::rpc_args::init_options(desc);
+    cryptonote::rpc_args::init_options(desc, true);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   core_rpc_server::core_rpc_server(
@@ -118,7 +112,7 @@ namespace cryptonote
     m_restricted = restricted;
     m_net_server.set_threads_prefix("RPC");
 
-    auto rpc_config = cryptonote::rpc_args::process(vm);
+    auto rpc_config = cryptonote::rpc_args::process(vm, true);
     if (!rpc_config)
       return false;
 
@@ -151,46 +145,9 @@ namespace cryptonote
     if (rpc_config->login)
       http_login.emplace(std::move(rpc_config->login->username), std::move(rpc_config->login->password).password());
 
-    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
-    if (command_line::get_arg(vm, arg_rpc_ssl_allow_any_cert))
-      ssl_options.verification = epee::net_utils::ssl_verification_t::none;
-    else
-    {
-      std::string ssl_ca_path = command_line::get_arg(vm, arg_rpc_ssl_ca_certificates);
-      const std::vector<std::string> ssl_allowed_fingerprint_strings = command_line::get_arg(vm, arg_rpc_ssl_allowed_fingerprints);
-      std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ ssl_allowed_fingerprint_strings.size() };
-      std::transform(ssl_allowed_fingerprint_strings.begin(), ssl_allowed_fingerprint_strings.end(), ssl_allowed_fingerprints.begin(), epee::from_hex::vector);
-      for (const auto &fpr: ssl_allowed_fingerprints)
-      {
-        if (fpr.size() != SSL_FINGERPRINT_SIZE)
-        {
-          MERROR("SHA-256 fingerprint should be " BOOST_PP_STRINGIZE(SSL_FINGERPRINT_SIZE) " bytes long.");
-          return false;
-        }
-      }
-
-      if (!ssl_ca_path.empty() || !ssl_allowed_fingerprints.empty())
-        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), std::move(ssl_ca_path)};
-    }
-
-    ssl_options.auth = epee::net_utils::ssl_authentication_t{
-      command_line::get_arg(vm, arg_rpc_ssl_private_key), command_line::get_arg(vm, arg_rpc_ssl_certificate)
-    };
-
-    // user specified CA file or fingeprints implies enabled SSL by default
-    if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_rpc_ssl))
-    {
-      const std::string ssl = command_line::get_arg(vm, arg_rpc_ssl);
-      if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl))
-      {
-        MFATAL("Invalid RPC SSL support: " << ssl);
-        return false;
-      }
-    }
-
     auto rng = [](size_t len, uint8_t *ptr){ return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<core_rpc_server, connection_context>::init(
-      rng, std::move(port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login), std::move(ssl_options)
+      rng, std::move(port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login), std::move(rpc_config->ssl_options)
     );
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2436,40 +2393,6 @@ namespace cryptonote
   const command_line::arg_descriptor<bool> core_rpc_server::arg_restricted_rpc = {
       "restricted-rpc"
     , "Restrict RPC to view only commands and do not return privacy sensitive data in RPC calls"
-    , false
-    };
-
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_ssl = {
-      "rpc-ssl"
-    , "Enable SSL on RPC connections: enabled|disabled|autodetect"
-    , "autodetect"
-    };
-
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_ssl_private_key = {
-      "rpc-ssl-private-key"
-    , "Path to a PEM format private key"
-    , ""
-    };
-
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_ssl_certificate = {
-      "rpc-ssl-certificate"
-    , "Path to a PEM format certificate"
-    , ""
-    };
-
-  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_ssl_ca_certificates = {
-      "rpc-ssl-ca-certificates"
-    , "Path to file containing concatenated PEM format certificate(s) to replace system CA(s)."
-    };
-
-  const command_line::arg_descriptor<std::vector<std::string>> core_rpc_server::arg_rpc_ssl_allowed_fingerprints = {
-      "rpc-ssl-allowed-fingerprints"
-    , "List of certificate fingerprints to allow"
-  };
-
-  const command_line::arg_descriptor<bool> core_rpc_server::arg_rpc_ssl_allow_any_cert = {
-      "rpc-ssl-allow-any-cert"
-    , "Allow any peer certificate"
     , false
     };
 

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -35,6 +35,7 @@
 
 #include "common/command_line.h"
 #include "common/password.h"
+#include "net/net_ssl.h"
 
 namespace cryptonote
 {
@@ -54,16 +55,29 @@ namespace cryptonote
       const command_line::arg_descriptor<std::string> rpc_login;
       const command_line::arg_descriptor<bool> confirm_external_bind;
       const command_line::arg_descriptor<std::string> rpc_access_control_origins;
+      const command_line::arg_descriptor<std::string> rpc_ssl;
+      const command_line::arg_descriptor<std::string> rpc_ssl_private_key;
+      const command_line::arg_descriptor<std::string> rpc_ssl_certificate;
+      const command_line::arg_descriptor<std::string> rpc_ssl_ca_certificates;
+      const command_line::arg_descriptor<std::vector<std::string>> rpc_ssl_allowed_fingerprints;
+      const command_line::arg_descriptor<bool> rpc_ssl_allow_chained;
+      const command_line::arg_descriptor<bool> rpc_ssl_allow_any_cert;
     };
 
+    // `allow_any_cert` bool toggles `--rpc-ssl-allow-any-cert` configuration
+
     static const char* tr(const char* str);
-    static void init_options(boost::program_options::options_description& desc);
+    static void init_options(boost::program_options::options_description& desc, const bool any_cert_option = false);
 
     //! \return Arguments specified by user, or `boost::none` if error
-    static boost::optional<rpc_args> process(const boost::program_options::variables_map& vm);
+    static boost::optional<rpc_args> process(const boost::program_options::variables_map& vm, const bool any_cert_option = false);
+
+    //! \return SSL arguments specified by user, or `boost::none` if error
+    static boost::optional<epee::net_utils::ssl_options_t> process_ssl(const boost::program_options::variables_map& vm, const bool any_cert_option = false);
 
     std::string bind_ip;
     std::vector<std::string> access_control_origins;
     boost::optional<tools::login> login; // currently `boost::none` if unspecified by user
+    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
   };
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -400,8 +400,11 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   {
     const boost::string_ref real_daemon = boost::string_ref{daemon_address}.substr(0, daemon_address.rfind(':'));
 
+    /* If SSL or proxy is enabled, then a specific cert, CA or fingerprint must
+       be specified. This is specific to the wallet. */
     const bool verification_required =
-      ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled || use_proxy;
+      ssl_options.verification != epee::net_utils::ssl_verification_t::none &&
+      (ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled || use_proxy);
 
     THROW_WALLET_EXCEPTION_IF(
       verification_required && !ssl_options.has_strong_verification(real_daemon),

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -67,11 +67,6 @@ namespace
   const command_line::arg_descriptor<bool> arg_restricted = {"restricted-rpc", "Restricts to view-only commands", false};
   const command_line::arg_descriptor<std::string> arg_wallet_dir = {"wallet-dir", "Directory for newly created wallets"};
   const command_line::arg_descriptor<bool> arg_prompt_for_password = {"prompt-for-password", "Prompts for password when not provided", false};
-  const command_line::arg_descriptor<std::string> arg_rpc_ssl = {"rpc-ssl", tools::wallet2::tr("Enable SSL on wallet RPC connections: enabled|disabled|autodetect"), "autodetect"};
-  const command_line::arg_descriptor<std::string> arg_rpc_ssl_private_key = {"rpc-ssl-private-key", tools::wallet2::tr("Path to a PEM format private key"), ""};
-  const command_line::arg_descriptor<std::string> arg_rpc_ssl_certificate = {"rpc-ssl-certificate", tools::wallet2::tr("Path to a PEM format certificate"), ""};
-  const command_line::arg_descriptor<std::string> arg_rpc_ssl_ca_certificates = {"rpc-ssl-ca-certificates", tools::wallet2::tr("Path to file containing concatenated PEM format certificate(s) to replace system CA(s).")};
-  const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_fingerprints = {"rpc-ssl-allowed-fingerprints", tools::wallet2::tr("List of certificate fingerprints to allow")};
 
   constexpr const char default_rpc_username[] = "sumokoin";
 
@@ -245,45 +240,6 @@ namespace tools
       assert(bool(http_login));
     } // end auth enabled
 
-    auto rpc_ssl_private_key = command_line::get_arg(vm, arg_rpc_ssl_private_key);
-    auto rpc_ssl_certificate = command_line::get_arg(vm, arg_rpc_ssl_certificate);
-    auto rpc_ssl_ca_file = command_line::get_arg(vm, arg_rpc_ssl_ca_certificates);
-    auto rpc_ssl_allowed_fingerprints = command_line::get_arg(vm, arg_rpc_ssl_allowed_fingerprints);
-    auto rpc_ssl = command_line::get_arg(vm, arg_rpc_ssl);
-    epee::net_utils::ssl_options_t rpc_ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
-
-    if (!rpc_ssl_ca_file.empty() || !rpc_ssl_allowed_fingerprints.empty())
-    {
-      std::vector<std::vector<uint8_t>> allowed_fingerprints{ rpc_ssl_allowed_fingerprints.size() };
-      std::transform(rpc_ssl_allowed_fingerprints.begin(), rpc_ssl_allowed_fingerprints.end(), allowed_fingerprints.begin(), epee::from_hex::vector);
-      for (const auto &fpr: allowed_fingerprints)
-      {
-        if (fpr.size() != SSL_FINGERPRINT_SIZE)
-        {
-          MERROR("SHA-256 fingerprint should be " BOOST_PP_STRINGIZE(SSL_FINGERPRINT_SIZE) " bytes long.");
-          return false;
-        }
-      }
-
-      rpc_ssl_options = epee::net_utils::ssl_options_t{
-        std::move(allowed_fingerprints), std::move(rpc_ssl_ca_file)
-      };
-    }
-
-    // user specified CA file or fingeprints implies enabled SSL by default
-    if (rpc_ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_rpc_ssl))
-    {
-      if (!epee::net_utils::ssl_support_from_string(rpc_ssl_options.support, rpc_ssl))
-      {
-        MERROR("Invalid argument for " << std::string(arg_rpc_ssl.name));
-        return false;
-      }
-    }
-
-    rpc_ssl_options.auth = epee::net_utils::ssl_authentication_t{
-      std::move(rpc_ssl_private_key), std::move(rpc_ssl_certificate)
-    };
-
     m_auto_refresh_period = DEFAULT_AUTO_REFRESH_PERIOD;
     m_last_auto_refresh_time = boost::posix_time::min_date_time;
 
@@ -293,7 +249,7 @@ namespace tools
     auto rng = [](size_t len, uint8_t *ptr) { return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<wallet_rpc_server, connection_context>::init(
       rng, std::move(bind_port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login),
-      std::move(rpc_ssl_options)
+      std::move(rpc_config->ssl_options)
     );
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -4201,7 +4157,11 @@ namespace tools
       std::move(req.ssl_private_key_path), std::move(req.ssl_certificate_path)
     };
 
-    if (ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled && !ssl_options.has_strong_verification(boost::string_ref{}))
+    const bool verification_required =
+      ssl_options.verification != epee::net_utils::ssl_verification_t::none &&
+      ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+
+    if (verification_required && !ssl_options.has_strong_verification(boost::string_ref{}))
     {
       er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;
       er.message = "SSL is enabled but no user certificate or fingerprints were provided";
@@ -4446,11 +4406,6 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_from_json);
   command_line::add_arg(desc_params, arg_wallet_dir);
   command_line::add_arg(desc_params, arg_prompt_for_password);
-  command_line::add_arg(desc_params, arg_rpc_ssl);
-  command_line::add_arg(desc_params, arg_rpc_ssl_private_key);
-  command_line::add_arg(desc_params, arg_rpc_ssl_certificate);
-  command_line::add_arg(desc_params, arg_rpc_ssl_ca_certificates);
-  command_line::add_arg(desc_params, arg_rpc_ssl_allowed_fingerprints);
 
   daemonizer::init_options(hidden_options, desc_params);
   desc_params.add(hidden_options);

--- a/tests/functional_tests/bans.py
+++ b/tests/functional_tests/bans.py
@@ -28,6 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import time
 
 """Test peer baning RPC calls
@@ -42,7 +43,7 @@ from framework.daemon import Daemon
 
 class BanTest():
     def run_test(self):
-        print 'Testing bans'
+        print('Testing bans')
 
         daemon = Daemon()
         res = daemon.get_bans()

--- a/tests/functional_tests/blockchain.py
+++ b/tests/functional_tests/blockchain.py
@@ -28,6 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import time
 
 """Test daemon blockchain RPC calls
@@ -50,7 +51,7 @@ class BlockchainTest():
         self._test_alt_chains()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
@@ -58,7 +59,7 @@ class BlockchainTest():
     def _test_generateblocks(self, blocks):
         assert blocks >= 2
 
-        print "Test generating", blocks, 'blocks'
+        print("Test generating", blocks, 'blocks')
 
         daemon = Daemon()
 
@@ -182,14 +183,14 @@ class BlockchainTest():
                 for idx in tx.output_indices:
                     assert idx == running_output_index
                     running_output_index += 1
-                res_out = daemon.get_outs([{'amount': 0, 'index': i} for i in tx.output_indices], get_txid = True)
+                res_out = daemon.get_outs([{'amount': 0, 'index': idx} for idx in tx.output_indices], get_txid = True)
                 assert len(res_out.outs) == len(tx.output_indices)
                 for out in res_out.outs:
                     assert len(out.key) == 64
                     assert len(out.mask) == 64
                     assert not out.unlocked
-                    assert out.height == i + 1
-                    assert out.txid == txids[i + 1]
+                    assert out.height == i
+                    assert out.txid == txids[i]
 
         for i in range(height + nblocks - 1):
             res_sum = daemon.get_coinbase_tx_sum(i, 1)
@@ -255,7 +256,7 @@ class BlockchainTest():
             alt_blocks[i] = txid
             nonce += 1
 
-        print 'mining 3 on 1'
+        print('mining 3 on 1')
         # three more on [1]
         chain1 = []
         res = daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 3, prev_block = alt_blocks[1], starting_nonce = nonce)
@@ -275,7 +276,7 @@ class BlockchainTest():
         for txid in alt_blocks:
             assert txid in res.blks_hashes or txid == alt_blocks[1]
 
-        print 'mining 4 on 3'
+        print('mining 4 on 3')
         # 4 more on [3], the chain will reorg when we mine the 4th
         top_block_hash = blk_hash
         prev_block = alt_blocks[3]

--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -28,11 +28,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
-
 """Test cold tx signing
 """
 
+from __future__ import print_function
 from framework.daemon import Daemon
 from framework.wallet import Wallet
 
@@ -44,13 +43,13 @@ class ColdSigningTest():
         self.transfer()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
 
     def create(self, idx):
-        print 'Creating hot and cold wallet'
+        print('Creating hot and cold wallet')
 
         self.hot_wallet = Wallet(idx = 0)
         # close the wallet if any, will throw if none is loaded
@@ -116,7 +115,7 @@ class ColdSigningTest():
         assert len(res.unsigned_txset) > 0
         unsigned_txset = res.unsigned_txset
 
-        print 'Signing transaction with cold wallet'
+        print('Signing transaction with cold wallet')
         res = self.cold_wallet.describe_transfer(unsigned_txset = unsigned_txset)
         assert len(res.desc) == 1
         desc = res.desc[0]
@@ -140,7 +139,7 @@ class ColdSigningTest():
         txid = res.tx_hash_list[0]
         assert len(txid) == 64
 
-        print 'Submitting transaction with hot wallet'
+        print('Submitting transaction with hot wallet')
         res = self.hot_wallet.submit_transfer(signed_txset)
         assert len(res.tx_hash_list) > 0
         assert res.tx_hash_list[0] == txid

--- a/tests/functional_tests/daemon_info.py
+++ b/tests/functional_tests/daemon_info.py
@@ -36,6 +36,7 @@ Test the following RPCs:
 
 """
 
+from __future__ import print_function
 from framework.daemon import Daemon
 
 class DaemonGetInfoTest():

--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -10,7 +10,7 @@ import string
 import os
 
 USAGE = 'usage: functional_tests_rpc.py <python> <srcdir> <builddir> [<tests-to-run> | all]'
-DEFAULT_TESTS = ['daemon_info', 'blockchain', 'wallet_address', 'integrated_address', 'mining', 'transfer', 'txpool', 'multisig', 'cold_signing', 'sign_message', 'proofs', 'get_output_distribution']
+DEFAULT_TESTS = ['bans', 'daemon_info', 'blockchain', 'wallet_address', 'integrated_address', 'mining', 'transfer', 'txpool', 'multisig', 'cold_signing', 'sign_message', 'proofs', 'get_output_distribution']
 try:
   python = sys.argv[1]
   srcdir = sys.argv[2]

--- a/tests/functional_tests/get_output_distribution.py
+++ b/tests/functional_tests/get_output_distribution.py
@@ -28,11 +28,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
-
 """Test get_output_distribution RPC
 """
 
+from __future__ import print_function
 from framework.daemon import Daemon
 from framework.wallet import Wallet
 
@@ -43,7 +42,7 @@ class GetOutputDistributionTest():
         self.test_get_output_distribution()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
@@ -56,7 +55,7 @@ class GetOutputDistributionTest():
         res = self.wallet.restore_deterministic_wallet(seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted')
 
     def test_get_output_distribution(self):
-        print "Test get_output_distribution"
+        print("Test get_output_distribution")
 
         daemon = Daemon()
 
@@ -213,5 +212,14 @@ class GetOutputDistributionTest():
             assert d.distribution[h] == 0
 
 
+class Guard:
+    def __enter__(self):
+        for i in range(4):
+            Wallet(idx = i).auto_refresh(False)
+    def __exit__(self, exc_type, exc_value, traceback):
+        for i in range(4):
+            Wallet(idx = i).auto_refresh(True)
+
 if __name__ == '__main__':
-    GetOutputDistributionTest().run_test()
+    with Guard() as guard:
+        GetOutputDistributionTest().run_test()

--- a/tests/functional_tests/integrated_address.py
+++ b/tests/functional_tests/integrated_address.py
@@ -28,8 +28,6 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
-
 """Test integrated address RPC calls
 
 Test the following RPCs:
@@ -38,6 +36,7 @@ Test the following RPCs:
 
 """
 
+from __future__ import print_function
 from framework.wallet import Wallet
 
 class IntegratedAddressTest():
@@ -46,7 +45,7 @@ class IntegratedAddressTest():
       self.check()
 
     def create(self):
-        print 'Creating wallet'
+        print('Creating wallet')
         wallet = Wallet()
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
@@ -59,7 +58,7 @@ class IntegratedAddressTest():
     def check(self):
         wallet = Wallet()
 
-        print 'Checking local address'
+        print('Checking local address')
         res = wallet.make_integrated_address(payment_id = '0123456789abcdef')
         assert res.integrated_address == '4CMe2PUhs4J4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfSbLRB61BQVATzerHGj'
         assert res.payment_id == '0123456789abcdef'
@@ -67,7 +66,7 @@ class IntegratedAddressTest():
         assert res.standard_address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
         assert res.payment_id == '0123456789abcdef'
 
-        print 'Checking different address'
+        print('Checking different address')
         res = wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '1122334455667788')
         assert res.integrated_address == '4GYjoMG9Y2BBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCVSs1ZojwrDCGS5rUuo'
         assert res.payment_id == '1122334455667788'
@@ -75,7 +74,7 @@ class IntegratedAddressTest():
         assert res.standard_address == '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK'
         assert res.payment_id == '1122334455667788'
 
-        print 'Checking bad payment id'
+        print('Checking bad payment id')
         fails = 0
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '11223344556677880')
         except: fails += 1
@@ -89,7 +88,7 @@ class IntegratedAddressTest():
         except: fails += 1
         assert fails == 5
 
-        print 'Checking bad standard address'
+        print('Checking bad standard address')
         fails = 0
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerr', payment_id = '1122334455667788')
         except: fails += 1

--- a/tests/functional_tests/mining.py
+++ b/tests/functional_tests/mining.py
@@ -28,6 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import time
 
 """Test daemon mining RPC calls
@@ -48,13 +49,13 @@ class MiningTest():
         self.mine()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
 
     def create(self):
-        print 'Creating wallet'
+        print('Creating wallet')
         wallet = Wallet()
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
@@ -62,7 +63,7 @@ class MiningTest():
         res = wallet.restore_deterministic_wallet(seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted')
 
     def mine(self):
-        print "Test mining"
+        print("Test mining")
 
         daemon = Daemon()
         wallet = Wallet()

--- a/tests/functional_tests/multisig.py
+++ b/tests/functional_tests/multisig.py
@@ -28,7 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
+from __future__ import print_function
 
 """Test multisig transfers
 """
@@ -70,7 +70,7 @@ class MultisigTest():
         self.check_transaction(txid)
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()

--- a/tests/functional_tests/proofs.py
+++ b/tests/functional_tests/proofs.py
@@ -28,7 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
+from __future__ import print_function
 
 """Test misc proofs (tx key, send, receive, reserve)
 """
@@ -47,7 +47,7 @@ class ProofsTest():
         self.check_reserve_proof()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()

--- a/tests/functional_tests/sign_message.py
+++ b/tests/functional_tests/sign_message.py
@@ -28,7 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
+from __future__ import print_function
 
 """Test message signing/verification RPC calls
 
@@ -46,7 +46,7 @@ class MessageSigningTest():
       self.check_signing()
 
     def create(self):
-        print 'Creating wallets'
+        print('Creating wallets')
         seeds = [
             'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted',
             'peeled mixture ionic radar utopia puddle buying illness nuns gadget river spout cavernous bounced paradise drunk looking cottage jump tequila melting went winter adjust spout',
@@ -66,7 +66,7 @@ class MessageSigningTest():
             assert res.seed == seeds[i]
 
     def check_signing(self):
-        print 'Signing/verifing messages'
+        print('Signing/verifing messages')
         messages = ['foo', '']
         for message in messages:
             res = self.wallet[0].sign(message)

--- a/tests/functional_tests/speed.py
+++ b/tests/functional_tests/speed.py
@@ -40,7 +40,7 @@ Test the following RPCs:
 
 import time
 from time import sleep
-from decimal import Decimal
+from __future__ import print_function
 
 from framework.daemon import Daemon
 from framework.wallet import Wallet

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -28,7 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
+from __future__ import print_function
 import json
 
 """Test simple transfers
@@ -48,13 +48,13 @@ class TransferTest():
         self.sweep_single()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
 
     def create(self):
-        print 'Creating wallets'
+        print('Creating wallets')
         seeds = [
           'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted',
           'peeled mixture ionic radar utopia puddle buying illness nuns gadget river spout cavernous bounced paradise drunk looking cottage jump tequila melting went winter adjust spout',
@@ -297,7 +297,7 @@ class TransferTest():
         assert res.unlocked_balance <= res.balance
         assert res.blocks_to_unlock == 9
 
-        print 'Creating multi out transfer'
+        print('Creating multi out transfer')
 
         self.wallet[0].refresh()
 

--- a/tests/functional_tests/txpool.py
+++ b/tests/functional_tests/txpool.py
@@ -28,7 +28,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
+from __future__ import print_function
 
 """Test txpool
 """
@@ -44,13 +44,13 @@ class TransferTest():
         self.check_txpool()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
 
     def create(self):
-        print 'Creating wallet'
+        print('Creating wallet')
         wallet = Wallet()
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
@@ -114,15 +114,16 @@ class TransferTest():
         assert sorted(res.tx_hashes) == sorted(txes.keys())
 
         print('Flushing 2 transactions')
-        daemon.flush_txpool([txes.keys()[1], txes.keys()[3]])
+        txes_keys = list(txes.keys())
+        daemon.flush_txpool([txes_keys[1], txes_keys[3]])
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size - 2
-        assert len([x for x in res.transactions if x.id_hash == txes.keys()[1]]) == 0
-        assert len([x for x in res.transactions if x.id_hash == txes.keys()[3]]) == 0
+        assert len([x for x in res.transactions if x.id_hash == txes_keys[1]]) == 0
+        assert len([x for x in res.transactions if x.id_hash == txes_keys[3]]) == 0
 
-        new_keys = txes.keys()
-        new_keys.remove(txes.keys()[1])
-        new_keys.remove(txes.keys()[3])
+        new_keys = list(txes.keys())
+        new_keys.remove(txes_keys[1])
+        new_keys.remove(txes_keys[3])
         res = daemon.get_transaction_pool_hashes()
         assert sorted(res.tx_hashes) == sorted(new_keys)
 

--- a/tests/functional_tests/wallet_address.py
+++ b/tests/functional_tests/wallet_address.py
@@ -29,8 +29,6 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
-
 """Test transaction creation RPC calls
 
 Test the following RPCs:
@@ -38,6 +36,7 @@ Test the following RPCs:
 
 """
 
+from __future__ import print_function
 from framework.wallet import Wallet
 from framework.daemon import Daemon
 
@@ -52,13 +51,13 @@ class WalletAddressTest():
       self.languages()
 
     def reset(self):
-        print 'Resetting blockchain'
+        print('Resetting blockchain')
         daemon = Daemon()
         daemon.pop_blocks(1000)
         daemon.flush_txpool()
 
     def create(self):
-        print 'Creating wallet'
+        print('Creating wallet')
         wallet = Wallet()
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
@@ -69,7 +68,7 @@ class WalletAddressTest():
         assert res.seed == seed
 
     def check_main_address(self):
-        print 'Getting address'
+        print('Getting address')
         wallet = Wallet()
         res = wallet.get_address()
         assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', res
@@ -79,7 +78,7 @@ class WalletAddressTest():
         assert res.addresses[0].used == False
 
     def check_keys(self):
-        print 'Checking keys'
+        print('Checking keys')
         wallet = Wallet()
         res = wallet.query_key('view_key')
         assert res.key == '49774391fa5e8d249fc2c5b45dadef13534bf2483dede880dac88f061e809100'
@@ -89,7 +88,7 @@ class WalletAddressTest():
         assert res.key == 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
 
     def create_subaddresses(self):
-        print 'Creating subaddresses'
+        print('Creating subaddresses')
         wallet = Wallet()
         res = wallet.create_account("idx1")
         assert res.account_index == 1, res
@@ -160,7 +159,7 @@ class WalletAddressTest():
         assert res.index == {'major': 1, 'minor': 0}
 
     def open_close(self):
-        print 'Testing open/close'
+        print('Testing open/close')
         wallet = Wallet()
 
         res = wallet.get_address()
@@ -200,7 +199,7 @@ class WalletAddressTest():
         except: pass
         languages = res.languages
         for language in languages:
-            print 'Creating ' + str(language) + ' wallet'
+            print('Creating ' + str(language) + ' wallet')
             wallet.create_wallet(filename = '', language = language)
             res = wallet.query_key('mnemonic')
             wallet.close_wallet()

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -172,7 +172,7 @@ TEST(select_outputs, density)
     float chain_ratio = count_chain / (float)n_outs;
     MDEBUG(count_selected << "/" << NPICKS << " outputs selected in blocks of density " << d << ", " << 100.0f * selected_ratio << "%");
     MDEBUG(count_chain << "/" << offsets.size() << " outputs in blocks of density " << d << ", " << 100.0f * chain_ratio << "%");
-    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.02f);
+    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.025f);
   }
 }
 

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -609,137 +609,131 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6432"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5946"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5949"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6220"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6284"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6605"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6628"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6682"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6687"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6692"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6774"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6928"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6937"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6959"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
@@ -795,16 +789,16 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
         <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -855,7 +849,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -988,8 +982,8 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1005,9 +999,9 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9149"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1057,7 +1051,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1080,28 +1074,28 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9356"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7097"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1117,8 +1111,8 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5466"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,7 +1335,7 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5986"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1879,9 +1873,9 @@ Key Image, &quot;absolute&quot;, list of rings</source>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2003,15 +1997,15 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7222"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8924"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2156,7 +2150,7 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7258"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2340,8 +2334,8 @@ your wallet again (your wallet keys are NOT at risk in any case).
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5434"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8992"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2402,494 +2396,494 @@ your wallet again (your wallet keys are NOT at risk in any case).
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4978"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4977"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5002"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5091"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5110"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5448"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5452"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5461"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5139"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5144"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5187"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5196"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5197"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5211"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5314"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5334"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5338"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5342"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5378"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5400"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6306"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5456"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5561"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5569"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5573"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6563"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6568"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5668"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5798"/>
         <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5692"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6299"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5739"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5766"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5784"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5802"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6660"/>
         <source>No payment id is included with this transaction. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6439"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6181"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6643"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6651"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3165,7 +3159,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5988"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3190,43 +3184,43 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5017"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5027"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5034"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3294,822 +3288,833 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4960"/>
+        <source>NOTE: This transaction is locked, see details with: show_transfer </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5063"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5265"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5755"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5825"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6710"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6411"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6427"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6434"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
+        <source>.
+This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6008"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6170"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6736"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6481"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6820"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6836"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6984"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8186"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8197"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8198"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8217"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8679"/>
         <source>Short payment IDs are to be used within an integrated address only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8855"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9647"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8858"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9482"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9518"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9526"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9537"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9546"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9583"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9604"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9645"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9646"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9652"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9659"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9691"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9701"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9721"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9730"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9736"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9751"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9791"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9796"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9834"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9872"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9882"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9888"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10038"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9927"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9940"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9950"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9960"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9971"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9983"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10011"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10031"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10055"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10062"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10088"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10105"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10122"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10134"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10138"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10169"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10191"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10210"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10227"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10237"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10245"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10261"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10282"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10287"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10293"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10317"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10333"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10340"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10346"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10364"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10388"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10465"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10474"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8877"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8882"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8931"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8935"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8979"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9029"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9041"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9047"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9050"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9062"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9084"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9278"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9313"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4139,323 +4144,323 @@ Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6834"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7013"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7018"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7036"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7042"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7063"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7084"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8736"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7136"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7141"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7186"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7534"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7447"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7536"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7405"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7281"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7379"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7389"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7395"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7570"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7483"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7585"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7424"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7508"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7563"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7869"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7670"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7682"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7792"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8044"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8070"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8081"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8086"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8087"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8089"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8130"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8131"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8133"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8184"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8185"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4506,224 +4511,224 @@ Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8265"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8269"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8320"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8333"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8568"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8550"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8464"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8470"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8473"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8482"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8492"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8493"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8537"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8577"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8620"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8613"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8632"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8642"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
         <source>failed to parse payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8702"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8710"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8716"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8718"/>
         <source>Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8719"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8847"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8804"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8806"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8846"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8851"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8853"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6978"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5186,44 +5191,44 @@ Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7605"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9432"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -5289,7 +5294,7 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9426"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5297,288 +5302,288 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="234"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="235"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="241"/>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="361"/>
+        <location filename="../src/wallet/wallet2.cpp" line="372"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="491"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="493"/>
+        <location filename="../src/wallet/wallet2.cpp" line="504"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="519"/>
+        <location filename="../src/wallet/wallet2.cpp" line="530"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="239"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="237"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="238"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="242"/>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
+        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
+        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
+        <location filename="../src/wallet/wallet2.cpp" line="271"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
+        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <location filename="../src/wallet/wallet2.cpp" line="275"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <location filename="../src/wallet/wallet2.cpp" line="364"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="432"/>
+        <location filename="../src/wallet/wallet2.cpp" line="443"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="442"/>
+        <location filename="../src/wallet/wallet2.cpp" line="453"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="500"/>
+        <location filename="../src/wallet/wallet2.cpp" line="511"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="525"/>
+        <location filename="../src/wallet/wallet2.cpp" line="536"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="532"/>
+        <location filename="../src/wallet/wallet2.cpp" line="543"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="548"/>
+        <location filename="../src/wallet/wallet2.cpp" line="559"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="553"/>
-        <location filename="../src/wallet/wallet2.cpp" line="621"/>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="632"/>
+        <location filename="../src/wallet/wallet2.cpp" line="677"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="575"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="569"/>
-        <location filename="../src/wallet/wallet2.cpp" line="631"/>
-        <location filename="../src/wallet/wallet2.cpp" line="692"/>
+        <location filename="../src/wallet/wallet2.cpp" line="580"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="703"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="581"/>
+        <location filename="../src/wallet/wallet2.cpp" line="592"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="601"/>
+        <location filename="../src/wallet/wallet2.cpp" line="612"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="605"/>
+        <location filename="../src/wallet/wallet2.cpp" line="616"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="615"/>
+        <location filename="../src/wallet/wallet2.cpp" line="626"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="624"/>
+        <location filename="../src/wallet/wallet2.cpp" line="635"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="634"/>
+        <location filename="../src/wallet/wallet2.cpp" line="645"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="653"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="678"/>
+        <location filename="../src/wallet/wallet2.cpp" line="689"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
+        <location filename="../src/wallet/wallet2.cpp" line="695"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="701"/>
+        <location filename="../src/wallet/wallet2.cpp" line="712"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1674"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1675"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4171"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4761"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5357"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10893"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11653"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
@@ -5588,30 +5593,30 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
         <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
-        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
-        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
-        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <location filename="../src/wallet/wallet2.cpp" line="252"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="73"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5619,125 +5624,125 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="191"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="236"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="628"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3260"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4429"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4250"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4265"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4277"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4281"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4315"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4347"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4317"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4349"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4330"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4334"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4341"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4344"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4353"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -5746,8 +5751,8 @@ daemon to work correctly.</source>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9373"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4405"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -29,7 +29,7 @@
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
-        <translation>Tentative d&apos;enregistrement d&apos;une transaction dans un fichier, mais le fichier spécifié existe déjà. Sortie pour ne pas risquer de l&apos;écraser. Fichier :</translation>
+        <translation>Tentative d&apos;enregistrement d&apos;une transaction dans un fichier, mais le fichier spécifié existe déjà. Sortie pour ne pas risquer de l&apos;écraser. Fichier&#xa0;:</translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
@@ -49,17 +49,17 @@
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
-        <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
+        <translation>la transaction %s a été rejetée par le démon avec le statut&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
-        <translation>. Raison : </translation>
+        <translation>. Raison&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
-        <translation>Exception inconnue : </translation>
+        <translation>Exception inconnue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
@@ -136,12 +136,12 @@
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
-        <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
+        <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1468"/>
         <source>Failed to add short payment id: </source>
-        <translation>Échec de l&apos;ajout de l&apos;ID de paiement court : </translation>
+        <translation>Échec de l&apos;ajout de l&apos;ID de paiement court&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1510"/>
@@ -159,7 +159,7 @@
         <location filename="../src/wallet/api/wallet.cpp" line="1514"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1596"/>
         <source>RPC error: </source>
-        <translation>Erreur RPC : </translation>
+        <translation>Erreur RPC&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1542"/>
@@ -223,7 +223,7 @@
         <location filename="../src/wallet/api/wallet.cpp" line="669"/>
         <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
-        <translation>échec de la génération du nouveau portefeuille : </translation>
+        <translation>échec de la génération du nouveau portefeuille&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="955"/>
@@ -258,17 +258,17 @@
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1197"/>
         <source>Failed to import key images: </source>
-        <translation>Échec de l&apos;importation des images de clé : </translation>
+        <translation>Échec de l&apos;importation des images de clé&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1229"/>
         <source>Failed to get subaddress label: </source>
-        <translation>Échec de la récupération de l&apos;étiquette de sous-adresse : </translation>
+        <translation>Échec de la récupération de l&apos;étiquette de sous-adresse&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1242"/>
         <source>Failed to set subaddress label: </source>
-        <translation>Échec de l&apos;affectation de l&apos;étiquette de sous-adresse : </translation>
+        <translation>Échec de l&apos;affectation de l&apos;étiquette de sous-adresse&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="615"/>
@@ -369,7 +369,7 @@
         <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1636"/>
         <source>transaction %s was rejected by daemon with status: </source>
-        <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
+        <translation>la transaction %s a été rejetée par le démon avec le statut&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1557"/>
@@ -387,19 +387,19 @@
         <location filename="../src/wallet/api/wallet.cpp" line="1561"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1645"/>
         <source>unknown transfer error: </source>
-        <translation>erreur de transfert inconnue : </translation>
+        <translation>erreur de transfert inconnue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1563"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1647"/>
         <source>internal error: </source>
-        <translation>erreur interne : </translation>
+        <translation>erreur interne&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1565"/>
         <location filename="../src/wallet/api/wallet.cpp" line="1649"/>
         <source>unexpected error: </source>
-        <translation>erreur inattendue : </translation>
+        <translation>erreur inattendue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/api/wallet.cpp" line="1567"/>
@@ -606,7 +606,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="666"/>
         <source>Commands: </source>
-        <translation>Commandes : </translation>
+        <translation>Commandes&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4636"/>
@@ -621,17 +621,17 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3283"/>
         <source>set seed: needs an argument. available options: language</source>
-        <translation>set seed : requiert un argument. options disponibles : language</translation>
+        <translation>set seed&#xa0;: requiert un argument. options disponibles&#xa0;: language</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>set: unrecognized argument(s)</source>
-        <translation>set : argument(s) non reconnu(s)</translation>
+        <translation>set&#xa0;: argument(s) non reconnu(s)</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4476"/>
         <source>wallet file path not valid: </source>
-        <translation>chemin du fichier portefeuille non valide : </translation>
+        <translation>chemin du fichier portefeuille non valide&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3389"/>
@@ -685,17 +685,17 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4164"/>
         <source>wallet failed to connect to daemon: </source>
-        <translation>échec de la connexion du portefeuille au démon : </translation>
+        <translation>échec de la connexion du portefeuille au démon&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4172"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
-        <translation>Le démon utilise une version majeure de RPC (%u) différente de celle du portefeuille (%u) : %s. Mettez l&apos;un des deux à jour, ou utilisez --allow-mismatched-daemon-version.</translation>
+        <translation>Le démon utilise une version majeure de RPC (%u) différente de celle du portefeuille (%u)&#xa0;: %s. Mettez l&apos;un des deux à jour, ou utilisez --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4193"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
-        <translation>Liste des langues disponibles pour la phrase mnémonique de votre portefeuille :</translation>
+        <translation>Liste des langues disponibles pour la phrase mnémonique de votre portefeuille&#xa0;:</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4277"/>
@@ -708,7 +708,7 @@
         <location filename="../src/simplewallet/simplewallet.cpp" line="4293"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4365"/>
         <source>Generated new wallet: </source>
-        <translation>Nouveau portefeuille généré : </translation>
+        <translation>Nouveau portefeuille généré&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4302"/>
@@ -716,7 +716,7 @@
         <location filename="../src/simplewallet/simplewallet.cpp" line="4412"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4465"/>
         <source>failed to generate new wallet: </source>
-        <translation>échec de la génération du nouveau portefeuille : </translation>
+        <translation>échec de la génération du nouveau portefeuille&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4507"/>
@@ -745,7 +745,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4552"/>
         <source>failed to load wallet: </source>
-        <translation>échec du chargement du portefeuille : </translation>
+        <translation>échec du chargement du portefeuille&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4569"/>
@@ -767,7 +767,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4821"/>
         <source>mining has NOT been started: </source>
-        <translation>la mine n&apos;a PAS démarré : </translation>
+        <translation>la mine n&apos;a PAS démarré&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4841"/>
@@ -777,7 +777,7 @@
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4843"/>
         <source>mining has NOT been stopped: </source>
-        <translation>la mine n&apos;a PAS été stoppée : </translation>
+        <translation>la mine n&apos;a PAS été stoppée&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4925"/>
@@ -786,46 +786,46 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>Height </source>
         <translation>Hauteur </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4977"/>
         <source>spent </source>
         <translation>dépensé </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5091"/>
         <source>Starting refresh...</source>
         <translation>Démarrage du rafraîchissement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
         <source>Refresh done, blocks received: </source>
-        <translation>Rafraîchissement effectué, blocs reçus : </translation>
+        <translation>Rafraîchissement effectué, blocs reçus&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
-        <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
+        <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>bad locked_blocks parameter:</source>
-        <translation>mauvais paramètre locked_blocks :</translation>
+        <translation>mauvais paramètre locked_blocks&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6643"/>
         <source>a single transaction cannot use more than one payment id: </source>
-        <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement : </translation>
+        <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6651"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>échec de la définition de l&apos;ID de paiement, bien qu&apos;il ait été décodé correctement</translation>
     </message>
@@ -1096,7 +1096,7 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5988"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1121,763 +1121,756 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5017"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5027"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5034"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5063"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5265"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5825"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6710"/>
         <source>transaction cancelled.</source>
         <translation>transaction annulée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Failed to check for backlog: </source>
-        <translation>Échec de la vérification du backlog : </translation>
+        <translation>Échec de la vérification du backlog&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6427"/>
         <source>
 Transaction </source>
         <translation>
 Transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6432"/>
         <source>Spending from address index %d
 </source>
         <translation>Dépense depuis l&apos;adresse d&apos;index %d
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6434"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
-        <translation>ATTENTION : Des sorties de multiples adresses sont utilisées ensemble, ce qui pourrait potentiellement compromettre votre confidentialité.
+        <translation>ATTENTION&#xa0;: Des sorties de multiples adresses sont utilisées ensemble, ce qui pourrait potentiellement compromettre votre confidentialité.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5946"/>
         <source>Sending %s.  </source>
         <translation>Envoi de %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5949"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Votre transaction doit être scindée en %llu transactions. Il en résulte que des frais de transaction doivent être appliqués à chaque transaction, pour un total de %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>The transaction fee is %s</source>
         <translation>Les frais de transaction sont de %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
         <source>, of which %s is dust from change</source>
         <translation>, dont %s est de la poussière de monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un total de %s de poussière de monnaie rendue sera envoyé à une adresse de poussière</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation>.
-Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s jours (en supposant 2 minutes par bloc)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6008"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
-        <source>Unsigned transaction(s) successfully written to file: </source>
-        <translation>Transaction(s) non signée(s) écrite(s) dans le fichier avec succès : </translation>
+        <source>Failed to write transaction(s) to file</source>
+        <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6170"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6736"/>
+        <source>Unsigned transaction(s) successfully written to file: </source>
+        <translation>Transaction(s) non signée(s) écrite(s) dans le fichier avec succès&#xa0;: </translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6481"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>No unmixable outputs found</source>
         <translation>Aucune sortie non mélangeable trouvée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6439"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6181"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6220"/>
         <source>No address given</source>
         <translation>Aucune adresse fournie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6605"/>
         <source>failed to parse Payment ID</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6628"/>
         <source>failed to parse key image</source>
         <translation>échec de l&apos;analyse de l&apos;image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6682"/>
         <source>No outputs found</source>
         <translation>Pas de sorties trouvées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6687"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation>De multiples transactions sont crées, ce qui n&apos;est pas supposé arriver</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6692"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation>La transaction utilise aucune ou de multiples entrées, ce qui n&apos;est pas supposé arriver</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>missing threshold amount</source>
         <translation>montant seuil manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6774"/>
         <source>invalid amount threshold</source>
         <translation>montant seuil invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6984"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8186"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8679"/>
         <source>Short payment IDs are to be used within an integrated address only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9482"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9518"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9526"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9537"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9546"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9583"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9604"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9645"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9646"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9652"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9659"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9691"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9701"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9721"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9730"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9736"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9751"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9791"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9796"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9834"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9872"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9882"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9888"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10038"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9927"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9940"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9950"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9960"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9971"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9983"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10011"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10031"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10055"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10062"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10088"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10105"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10122"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10134"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10138"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10169"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10191"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10210"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10227"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10237"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10245"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10261"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10282"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10287"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10293"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10317"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10333"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10340"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10346"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10364"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10388"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10465"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10474"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6928"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6959"/>
         <source>sending %s to %s</source>
         <translation>envoi de %s à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
         <source> dummy output(s)</source>
         <translation> sortie(s) factice(s)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
         <source>with no destinations</source>
         <translation>sans destination</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7013"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Ceci est un portefeuille multisig, il ne peut signer qu&apos;avec sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7036"/>
         <source>Failed to sign transaction</source>
         <translation>Échec de signature de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7042"/>
         <source>Failed to sign transaction: </source>
-        <translation>Échec de signature de transaction : </translation>
+        <translation>Échec de signature de transaction&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7063"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Données brutes hex de la transaction exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7084"/>
         <source>Failed to load transaction from file</source>
         <translation>Échec du chargement de la transaction du fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5461"/>
         <source>RPC error: </source>
-        <translation>Erreur RPC : </translation>
+        <translation>Erreur RPC&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="716"/>
@@ -1895,7 +1888,7 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="875"/>
         <source>Error with wallet rewrite: </source>
-        <translation>Erreur avec la réécriture du portefeuille : </translation>
+        <translation>Erreur avec la réécriture du portefeuille&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2435"/>
@@ -1906,7 +1899,7 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
         <location filename="../src/simplewallet/simplewallet.cpp" line="2453"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2515"/>
         <source>invalid count: must be an unsigned integer</source>
-        <translation>nombre invalide : un entier non signé est attendu</translation>
+        <translation>nombre invalide&#xa0;: un entier non signé est attendu</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2471"/>
@@ -1917,13 +1910,13 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
         <location filename="../src/simplewallet/simplewallet.cpp" line="4021"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
         <source>bad m_restore_height parameter: </source>
-        <translation>mauvais paramètre m_restore_height : </translation>
+        <translation>mauvais paramètre m_restore_height&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3985"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4032"/>
         <source>Restore height is: </source>
-        <translation>La hauteur de restauration est : </translation>
+        <translation>La hauteur de restauration est&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4897"/>
@@ -1936,52 +1929,52 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
         <translation>Mot de passe pour le nouveau portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5144"/>
         <source>internal error: </source>
-        <translation>erreur interne : </translation>
+        <translation>erreur interne&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5466"/>
         <source>unexpected error: </source>
-        <translation>erreur inattendue : </translation>
+        <translation>erreur inattendue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7097"/>
         <source>unknown error</source>
         <translation>erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>refresh failed: </source>
-        <translation>échec du rafraîchissement : </translation>
+        <translation>échec du rafraîchissement&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>Blocks received: </source>
-        <translation>Blocs reçus : </translation>
+        <translation>Blocs reçus&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5197"/>
         <source>unlocked balance: </source>
-        <translation>solde débloqué : </translation>
+        <translation>solde débloqué&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>amount</source>
         <translation>montant</translation>
     </message>
@@ -1993,17 +1986,17 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="680"/>
         <source>Unknown command: </source>
-        <translation>Commande inconnue : </translation>
+        <translation>Commande inconnue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="687"/>
         <source>Command usage: </source>
-        <translation>Usage de la commande : </translation>
+        <translation>Usage de la commande&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Command description: </source>
-        <translation>Description de la commande : </translation>
+        <translation>Description de la commande&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="756"/>
@@ -2023,12 +2016,12 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="922"/>
         <source>Error: failed to estimate backlog array size: </source>
-        <translation>Erreur : échec de l&apos;estimation de la taille du tableau d&apos;arriéré : </translation>
+        <translation>Erreur&#xa0;: échec de l&apos;estimation de la taille du tableau d&apos;arriéré&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="927"/>
         <source>Error: bad estimated backlog array size</source>
-        <translation>Erreur : mauvaise estimation de la taille du tableau d&apos;arriéré</translation>
+        <translation>Erreur&#xa0;: mauvaise estimation de la taille du tableau d&apos;arriéré</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="939"/>
@@ -2092,17 +2085,17 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1069"/>
         <source>Error creating multisig: </source>
-        <translation>Erreur de création multisig : </translation>
+        <translation>Erreur de création multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1076"/>
         <source>Error creating multisig: new wallet is not multisig</source>
-        <translation>Erreur de création multisig : le nouveau portefeuille n&apos;est pas multisig</translation>
+        <translation>Erreur de création multisig&#xa0;: le nouveau portefeuille n&apos;est pas multisig</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
         <source> multisig address: </source>
-        <translation> adresse multisig : </translation>
+        <translation> adresse multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1103"/>
@@ -2126,7 +2119,7 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1130"/>
         <source>Failed to finalize multisig: </source>
-        <translation>Échec de finalisation multisig : </translation>
+        <translation>Échec de finalisation multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1191"/>
@@ -2145,7 +2138,7 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1260"/>
         <source>Error exporting multisig info: </source>
-        <translation>Erreur d&apos;importation des infos multisig : </translation>
+        <translation>Erreur d&apos;importation des infos multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1264"/>
@@ -2160,12 +2153,12 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1334"/>
         <source>Failed to import multisig info: </source>
-        <translation>Échec de l&apos;importation des infos multisig : </translation>
+        <translation>Échec de l&apos;importation des infos multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1345"/>
         <source>Failed to update spent status after importing multisig info: </source>
-        <translation>Échec de la mise à jour de l&apos;état des dépenses après l&apos;importation des infos multisig : </translation>
+        <translation>Échec de la mise à jour de l&apos;état des dépenses après l&apos;importation des infos multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1351"/>
@@ -2188,12 +2181,12 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1445"/>
         <source>Multisig error: </source>
-        <translation>Erreur multisig : </translation>
+        <translation>Erreur multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1450"/>
         <source>Failed to sign multisig transaction: </source>
-        <translation>Échec de la signature de la transaction multisig : </translation>
+        <translation>Échec de la signature de la transaction multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1473"/>
@@ -2214,13 +2207,13 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transaction transmise avec succès, transaction </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9356"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>Vous pouvez vérifier son statut en utilisant la commane &apos;show_transfers&apos;.</translation>
     </message>
@@ -2232,7 +2225,7 @@ Cette transaction sera déverrouillée au bloc %llu, dans approximativement %s j
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Saved exported multisig transaction file(s): </source>
-        <translation>Transaction multisig enregistrée dans le(s) fichier(s) : </translation>
+        <translation>Transaction multisig enregistrée dans le(s) fichier(s)&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1892"/>
@@ -2755,7 +2748,7 @@ Sinon, vous prouvez le plus petit solde supérieur à &lt;montant&gt; dans votre
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3414"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
-        <translation>Aucun portefeuille avec ce nom trouvé. Confirmer la création d&apos;un nouveau portefeuille nommé : </translation>
+        <translation>Aucun portefeuille avec ce nom trouvé. Confirmer la création d&apos;un nouveau portefeuille nommé&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3540"/>
@@ -2786,17 +2779,17 @@ Sinon, vous prouvez le plus petit solde supérieur à &lt;montant&gt; dans votre
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3796"/>
         <source>Error: expected M/N, but got: </source>
-        <translation>Erreur : M/N attendu, mais lu : </translation>
+        <translation>Erreur&#xa0;: M/N attendu, mais lu&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3801"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation>Erreur : N &gt; 1 et N &lt;= M attendu, mais lu : </translation>
+        <translation>Erreur&#xa0;: N &gt; 1 et N &lt;= M attendu, mais lu&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Error: M/N is currently unsupported. </source>
-        <translation>Erreur : M/N n&apos;est actuellement pas supporté. </translation>
+        <translation>Erreur&#xa0;: M/N n&apos;est actuellement pas supporté. </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3809"/>
@@ -2816,7 +2809,7 @@ Sinon, vous prouvez le plus petit solde supérieur à &lt;montant&gt; dans votre
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3889"/>
         <source>Error: M/N is currently unsupported</source>
-        <translation>Erreur : M/N n&apos;est actuellement pas supporté</translation>
+        <translation>Erreur&#xa0;: M/N n&apos;est actuellement pas supporté</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4055"/>
@@ -2826,7 +2819,7 @@ Sinon, vous prouvez le plus petit solde supérieur à &lt;montant&gt; dans votre
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4083"/>
         <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
-        <translation>Attention : en n&apos;utilisant %s qui n&apos;est pas un démon de confiance, la confidentialité sera réduite</translation>
+        <translation>Attention&#xa0;: en n&apos;utilisant %s qui n&apos;est pas un démon de confiance, la confidentialité sera réduite</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4093"/>
@@ -2875,7 +2868,7 @@ votre portefeuille à nouveau (mais les clés de votre portefeuille ne risquent 
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4460"/>
         <source>Generated new %u/%u multisig wallet: </source>
-        <translation>Nouveau portefeuille multisig %u/%u généré : </translation>
+        <translation>Nouveau portefeuille multisig %u/%u généré&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4509"/>
@@ -2954,410 +2947,421 @@ votre portefeuille à nouveau (mais les clés de votre portefeuille ne risquent 
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <source>txid </source>
         <translation>ID transaction </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4978"/>
         <source>idx </source>
         <translation>index </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4960"/>
+        <source>NOTE: This transaction is locked, see details with: show_transfer </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5110"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Certaines sorties ont des images de clé partielles - import_multisig_info requis)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Currently selected account: [</source>
-        <translation>Compte actuellement sélectionné : [</translation>
+        <translation>Compte actuellement sélectionné&#xa0;: [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>Tag: </source>
-        <translation>Mot clé : </translation>
+        <translation>Mot clé&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>(No tag assigned)</source>
         <translation>(Pas de mot clé assigné)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
         <source>Balance per address:</source>
-        <translation>Solde par adresse :</translation>
+        <translation>Solde par adresse&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Unlocked balance</source>
         <translation>Solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Outputs</source>
         <translation>Sorties</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5211"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>spent</source>
         <translation>dépensé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>global index</source>
         <translation>index global</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>tx id</source>
         <translation>ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>addr index</source>
         <translation>index adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5314"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5334"/>
         <source>No incoming transfers</source>
         <translation>Aucun transfert entrant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5338"/>
         <source>No incoming available transfers</source>
         <translation>Aucun transfert entrant disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5342"/>
         <source>No incoming unavailable transfers</source>
         <translation>Aucun transfert entrant non disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>payment</source>
         <translation>paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>transaction</source>
         <translation>transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>height</source>
         <translation>hauteur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>unlock time</source>
         <translation>durée de déverrouillage</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5378"/>
         <source>No payments with id </source>
         <translation>Aucun paiement avec l&apos;ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6306"/>
         <source>failed to get blockchain height: </source>
-        <translation>échec de la récupération de la hauteur de la chaîne de blocs : </translation>
+        <translation>échec de la récupération de la hauteur de la chaîne de blocs&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
-Transaction %llu/%llu : ID=%s</translation>
+Transaction %llu/%llu&#xa0;: ID=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5561"/>
         <source>failed to get output: </source>
-        <translation>échec de la récupération de la sortie : </translation>
+        <translation>échec de la récupération de la sortie&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5569"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>la hauteur du bloc d&apos;origine de la clé de la sortie ne devrait pas être supérieure à celle de la chaîne de blocs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5573"/>
         <source>
 Originating block heights: </source>
         <translation>
-Hauteurs des blocs d&apos;origine : </translation>
+Hauteurs des blocs d&apos;origine&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
-Attention : Certaines clés d&apos;entrées étant dépensées sont issues de </translation>
+Attention&#xa0;: Certaines clés d&apos;entrées étant dépensées sont issues de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, ce qui peut casser l&apos;anonymat du cercle de signature. Assurez-vous que c&apos;est intentionnel !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>Ring size must not be 0</source>
         <translation>La taille de cercle ne doit pas être 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6563"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>la taille de cercle %u est trop petite, le minimum est %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5668"/>
         <source>wrong number of arguments</source>
         <translation>mauvais nombre d&apos;arguments</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5798"/>
         <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6411"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Aucune sortie trouvée, ou le démon n&apos;est pas prêt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
+        <source>.
+This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6820"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6836"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8197"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8198"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8217"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
         <source>command only supported by HW wallet</source>
         <translation>commande supportée uniquement par un portefeuille matériel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9029"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9041"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9047"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9050"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9062"/>
         <source>Failed to import key images: </source>
-        <translation type="unfinished">Échec de l&apos;importation des images de clé : </translation>
+        <translation type="unfinished">Échec de l&apos;importation des images de clé&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
         <source>Failed to reconnect device</source>
         <translation>Échec de la reconnexion à l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9084"/>
         <source>Failed to reconnect device: </source>
         <translation>Échec de la reconnexion à l&apos;appareil : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Transaction successfully saved to </source>
         <translation>Transaction sauvegardée avec succès dans </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>, txid </source>
         <translation>, ID transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>Failed to save transaction to </source>
         <translation>Échec de la sauvegarde de la transaction dans </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7018"/>
         <source>This is a watch only wallet</source>
         <translation>Ceci est un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9278"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
-        <translation>Double dépense détectée sur le réseau : cette transaction sera peut-être invalidée</translation>
+        <translation>Double dépense détectée sur le réseau&#xa0;: cette transaction sera peut-être invalidée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9313"/>
         <source>Transaction ID not found</source>
         <translation>ID de transaction non trouvé</translation>
     </message>
@@ -3383,16 +3387,16 @@ Attention : Certaines clés d&apos;entrées étant dépensées sont issues de <
         <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
         <source>command not supported by HW wallet</source>
         <translation>commande non supportée par le portefeuille matériel</translation>
     </message>
@@ -3570,7 +3574,7 @@ Attention : Certaines clés d&apos;entrées étant dépensées sont issues de <
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5986"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation>ATTENTION : ceci c&apos;est pas la taille de cercle par défaut, ce qui peut nuire à votre confidentialité. La valeur par défaut est recommandée.</translation>
     </message>
@@ -3599,12 +3603,12 @@ Attention : Certaines clés d&apos;entrées étant dépensées sont issues de <
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2771"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
+        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont&#xa0;: unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2775"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
+        <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont&#xa0;: unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2779"/>
@@ -3705,7 +3709,7 @@ Image de clé, &quot;absolue&quot;, liste de cercles</translation>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
         <source>Key file not found. Failed to open wallet: </source>
-        <translation>Fichier de clés non trouvé. Échec de l&apos;ouverture du portefeuille : </translation>
+        <translation>Fichier de clés non trouvé. Échec de l&apos;ouverture du portefeuille&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
@@ -3750,15 +3754,15 @@ Image de clé, &quot;absolue&quot;, liste de cercles</translation>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7222"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8924"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
@@ -3840,7 +3844,7 @@ Image de clé, &quot;absolue&quot;, liste de cercles</translation>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7258"/>
         <source>wallet is null</source>
         <translation>portefeuille est nul</translation>
     </message>
@@ -3865,7 +3869,7 @@ Image de clé, &quot;absolue&quot;, liste de cercles</translation>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>View key: </source>
-        <translation>Clé d&apos;audit : </translation>
+        <translation>Clé d&apos;audit&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4407"/>
@@ -3895,12 +3899,12 @@ Image de clé, &quot;absolue&quot;, liste de cercles</translation>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4648"/>
         <source>Failed to save watch only wallet: </source>
-        <translation>Échec de la sauvegarde du portefeuille d&apos;audit : </translation>
+        <translation>Échec de la sauvegarde du portefeuille d&apos;audit&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5434"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8992"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>cette commande requiert un démon de confiance. Activer avec --trusted-daemon</translation>
     </message>
@@ -3922,801 +3926,801 @@ Image de clé, &quot;absolue&quot;, liste de cercles</translation>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4927"/>
         <source>blockchain can&apos;t be saved: </source>
-        <translation>la chaîne de blocs ne peut pas être sauvegardée : </translation>
+        <translation>la chaîne de blocs ne peut pas être sauvegardée&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation>Mot de passe requis (%s) - utilisez la commande refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5002"/>
         <source>Enter password</source>
         <translation>Entrez le mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5448"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5452"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5139"/>
         <source>refresh error: </source>
-        <translation>erreur du rafraîchissement : </translation>
+        <translation>erreur du rafraîchissement&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5187"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation> (Il manque les images de clé de certaines sorties - import_key_images requis)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5196"/>
         <source>Balance: </source>
-        <translation>Solde : </translation>
+        <translation>Solde&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>pubkey</source>
         <translation>clé publique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>key image</source>
         <translation>image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>unlocked</source>
         <translation>déverrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>T</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>locked</source>
         <translation>vérrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5400"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
-        <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
+        <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5456"/>
         <source>failed to get spent status</source>
         <translation>échec de la récupération du statut de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>failed to find construction data for tx input</source>
         <translation>échec de la recherche des données pour contruire l&apos;entrée de la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>the same transaction</source>
         <translation>la même transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>blocks that are temporally very close</source>
         <translation>blocs très proches dans le temps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6568"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation>la taille de cercle %u est trop grande, le maximum est %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5692"/>
         <source>payment id failed to encode</source>
         <translation>échec de l&apos;encodage de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5739"/>
         <source>failed to parse short payment ID from URI</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement court à partir de l&apos;URI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5766"/>
         <source>Invalid last argument: </source>
         <translation>Dernier argument invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5784"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5802"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement, bien qu&apos;il ait été détecté</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Pas assez de fonds dans le solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6284"/>
         <source>missing lockedblocks parameter</source>
         <translation>paramètre blocs_verrou manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
         <source>bad locked_blocks parameter</source>
         <translation>mauvais paramètre blocs_verrou</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
         <source>Failed to parse number of outputs</source>
         <translation>Échec de l&apos;analyse du nombre de sorties</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation>Le nombre de sorties doit être supérieur à 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6834"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation>Don de %s %s à The Monero Project (donate.getmonero.org ou %s).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7186"/>
         <source>failed to parse tx_key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Tx key successfully stored.</source>
         <translation>Clé de transaction sauvegardée avec succès.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
         <source>Failed to store tx key: </source>
         <translation>Échec de la sauvegarde de la clé de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7483"/>
         <source>Good signature</source>
         <translation>Bonne signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7585"/>
         <source>Bad signature</source>
         <translation>Mauvaise signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7869"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation>usage : show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;hauteur_min&gt; [&lt;hauteur_max&gt;]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>block</source>
         <translation>bloc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8184"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation>Attention : ceci pedra toute information qui ne peut pas être retrouvée à partir de la chaîne de blocs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8185"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation>Ceci inclut les adresses de destination, les clé secrètes de transaction, les notes de transaction, etc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Standard address: </source>
-        <translation>Adresse standard : </translation>
+        <translation>Adresse standard&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8642"/>
         <source>failed to parse payment ID or address</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement ou de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
         <source>failed to parse payment ID</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8702"/>
         <source>failed to parse index</source>
         <translation>échec de l&apos;analyse de l&apos;index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8710"/>
         <source>Address book is empty.</source>
         <translation>Le carnet d&apos;adresses est vide.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8716"/>
         <source>Index: </source>
-        <translation>Index : </translation>
+        <translation>Index&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
         <source>Address: </source>
-        <translation>Adresse : </translation>
+        <translation>Adresse&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8718"/>
         <source>Payment ID: </source>
-        <translation>ID de paiement : </translation>
+        <translation>ID de paiement&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8719"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8847"/>
         <source>Description: </source>
-        <translation>Description : </translation>
+        <translation>Description&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>Network type: </source>
         <translation>Type de réseau : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8858"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Stagenet</source>
         <translation>Stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Mainnet</source>
         <translation>Mainnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8877"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas signer</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9149"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6299"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6660"/>
         <source>No payment id is included with this transaction. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7570"/>
         <source>failed to load signature file</source>
         <translation>échec du chargement du fichier signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7424"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut générer de preuve</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7508"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation>La preuve de réserve ne peut être généré que par un portefeuille complet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7563"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;adresse ne doit pas être une sous-adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
-        <translation>Bonne signature -- total : %s, dépensé : %s, non dépensé : %s</translation>
+        <translation>Bonne signature -- total&#xa0;: %s, dépensé&#xa0;: %s, non dépensé&#xa0;: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7792"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
-        <translation>[Double dépense détectée sur le réseau : cette transaction sera peut-être invalidée] </translation>
+        <translation>[Double dépense détectée sur le réseau&#xa0;: cette transaction sera peut-être invalidée] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8070"/>
         <source>There is no unspent output in the specified address</source>
         <translation>Il n&apos;y a pas de sortie non dépensée pour l&apos;adresse spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
         <source> (no daemon)</source>
         <translation> (pas de démon)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8269"/>
         <source> (out of sync)</source>
         <translation> (désynchronisé)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8320"/>
         <source>(Untitled account)</source>
         <translation>(compte sans nom)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8333"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8568"/>
         <source>failed to parse index: </source>
-        <translation>échec de l&apos;analyse de l&apos;index : </translation>
+        <translation>échec de l&apos;analyse de l&apos;index&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8550"/>
         <source>specify an index between 0 and </source>
         <translation>specifiez un index entre 0 et </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>
 Grand total:
   Balance: </source>
         <translation>
-Somme finale :
-  Solde : </translation>
+Somme finale&#xa0;:
+  Solde&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>, unlocked balance: </source>
-        <translation>, solde débloqué : </translation>
+        <translation>, solde débloqué&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8464"/>
         <source>Untagged accounts:</source>
-        <translation>Comptes sans mot clé :</translation>
+        <translation>Comptes sans mot clé&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8470"/>
         <source>Tag %s is unregistered.</source>
         <translation>Le mot clé %s n&apos;est pas enregistré.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8473"/>
         <source>Accounts with tag: </source>
-        <translation>Comptes avec mot clé : </translation>
+        <translation>Comptes avec mot clé&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
         <source>Tag&apos;s description: </source>
-        <translation>Description du mot clé : </translation>
+        <translation>Description du mot clé&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Account</source>
         <translation>Compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8482"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8492"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8493"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>Primary address</source>
         <translation>Adresse primaire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>(used)</source>
         <translation>(utilisé)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8537"/>
         <source>(Untitled address)</source>
         <translation>(adresse sans nom)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8577"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation>&lt;index_min&gt; est déjà hors limite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation>&lt;index_max&gt; excède la limite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8620"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation>Les adresses intégrées ne peuvent être créées que pour le compte 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8632"/>
         <source>Integrated address: %s, payment ID: %s</source>
-        <translation>Adresse intégrée : %s, ID de paiement : %s</translation>
+        <translation>Adresse intégrée&#xa0;: %s, ID de paiement&#xa0;: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Subaddress: </source>
-        <translation>Sous-adresse : </translation>
+        <translation>Sous-adresse&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8804"/>
         <source>no description found</source>
         <translation>pas de description trouvée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8806"/>
         <source>description found: </source>
-        <translation>description trouvée : </translation>
+        <translation>description trouvée&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8846"/>
         <source>Filename: </source>
-        <translation>Fichier : </translation>
+        <translation>Fichier&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8851"/>
         <source>Watch only</source>
         <translation>Audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8853"/>
         <source>%u/%u multisig%s</source>
         <translation>Multisig %u/%u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8855"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9647"/>
         <source>Type: </source>
-        <translation>Type : </translation>
+        <translation>Type&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8882"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation>C&apos;est un portefeuille multisig et il ne peut pas signer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8931"/>
         <source>Bad signature from </source>
         <translation>Mauvaise signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8935"/>
         <source>Good signature from </source>
         <translation>Bonne signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas exporter les images de clé</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8979"/>
         <source>Signed key images exported to </source>
         <translation>Images de clé signées exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
         <source>Outputs exported to </source>
         <translation>Sorties exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>amount is wrong: </source>
-        <translation>montant erroné : </translation>
+        <translation>montant erroné&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5755"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
         <source>expected number from 0 to </source>
         <translation>attend un nombre de 0 à </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
         <source>Sweeping </source>
         <translation>Balayage de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
         <source>Money successfully sent, transaction: </source>
-        <translation>Fonds envoyés avec succès, transaction : </translation>
+        <translation>Fonds envoyés avec succès, transaction&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6937"/>
         <source>Change goes to more than one address</source>
         <translation>La monnaie rendue va à plus d&apos;une adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6978"/>
         <source>%s change to %s</source>
         <translation>%s de monnaie rendue à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
         <source>no change</source>
         <translation>sans monnaie rendue</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaction signée avec succès dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8736"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
         <source>failed to parse txid</source>
         <translation>échec de l&apos;analyse de l&apos;ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7136"/>
         <source>Tx key: </source>
-        <translation>Clé de transaction : </translation>
+        <translation>Clé de transaction&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7141"/>
         <source>no tx keys found for this txid</source>
         <translation>aucune clé de transaction trouvée pour cet ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7534"/>
         <source>signature file saved to: </source>
-        <translation>fichier signature sauvegardé dans : </translation>
+        <translation>fichier signature sauvegardé dans&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7447"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7536"/>
         <source>failed to save signature file</source>
         <translation>échec de la sauvegarde du fichier signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7281"/>
         <source>failed to parse tx key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7405"/>
         <source>error: </source>
-        <translation>erreur : </translation>
+        <translation>erreur&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>received</source>
         <translation>a reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>in txid</source>
         <translation>dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7395"/>
         <source>received nothing in txid</source>
         <translation>n&apos;a rien reçu dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7379"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
-        <translation>ATTENTION : cette transaction n&apos;est pas encore inclue dans la chaîne de blocs !</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
-        <source>This transaction has %u confirmations</source>
-        <translation>Cette transaction a %u confirmations</translation>
+        <translation>ATTENTION&#xa0;: cette transaction n&apos;est pas encore inclue dans la chaîne de blocs !</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
+        <source>This transaction has %u confirmations</source>
+        <translation>Cette transaction a %u confirmations</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7389"/>
         <source>WARNING: failed to determine number of confirmations!</source>
-        <translation>ATTENTION : échec de la détermination du nombre de confirmations !</translation>
+        <translation>ATTENTION&#xa0;: échec de la détermination du nombre de confirmations !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7670"/>
         <source>bad min_height parameter:</source>
-        <translation>mauvais paramètre hauteur_minimum :</translation>
+        <translation>mauvais paramètre hauteur_minimum&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7682"/>
         <source>bad max_height parameter:</source>
-        <translation>mauvais paramètre hauteur_maximum :</translation>
+        <translation>mauvais paramètre hauteur_maximum&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
         <source>in</source>
         <translation>reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8044"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;montant_minimum&gt; doit être inférieur à &lt;montant_maximum&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>
 Amount: </source>
         <translation>
-Montant : </translation>
+Montant&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>, number of keys: </source>
-        <translation>, nombre de clés : </translation>
+        <translation>, nombre de clés&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8081"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8086"/>
         <source>
 Min block height: </source>
         <translation>
-Hauteur de bloc minimum : </translation>
+Hauteur de bloc minimum&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8087"/>
         <source>
 Max block height: </source>
         <translation>
-Hauteur de bloc maximum : </translation>
+Hauteur de bloc maximum&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>
 Min amount found: </source>
         <translation>
-Montant minimum trouvé : </translation>
+Montant minimum trouvé&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8089"/>
         <source>
 Max amount found: </source>
         <translation>
-Montant maximum trouvé : </translation>
+Montant maximum trouvé&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>
 Total count: </source>
         <translation>
-Compte total : </translation>
+Compte total&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8130"/>
         <source>
 Bin size: </source>
         <translation>
-Taille de classe : </translation>
+Taille de classe&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8131"/>
         <source>
 Outputs per *: </source>
         <translation>
-Sorties par * : </translation>
+Sorties par *&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8133"/>
         <source>count
   ^
 </source>
@@ -4725,54 +4729,54 @@ Sorties par * : </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; hauteur de bloc
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8265"/>
         <source>wallet</source>
         <translation>portefeuille</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Random payment ID: </source>
-        <translation>ID de paiement aléatoire : </translation>
+        <translation>ID de paiement aléatoire&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8613"/>
         <source>Matching integrated address: </source>
-        <translation>Adresse intégrée correspondante : </translation>
+        <translation>Adresse intégrée correspondante&#xa0;: </translation>
     </message>
 </context>
 <context>
@@ -4835,7 +4839,7 @@ Sorties par * : </translation>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
-        <translation>Erreur de création des portefeuilles multisig : </translation>
+        <translation>Erreur de création des portefeuilles multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
@@ -4850,23 +4854,23 @@ Sorties par * : </translation>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
-        <translation>Erreur : N/M attendu, mais lu : </translation>
+        <translation>Erreur&#xa0;: N/M attendu, mais lu&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
-        <translation>Erreur : soit --scheme soit --threshold et --participants doivent être indiqués</translation>
+        <translation>Erreur&#xa0;: soit --scheme soit --threshold et --participants doivent être indiqués</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
-        <translation>Erreur : N &gt; 1 et N &lt;= M attendu, mais lu N==%u et M==%d</translation>
+        <translation>Erreur&#xa0;: N &gt; 1 et N &lt;= M attendu, mais lu N==%u et M==%d</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
-        <translation>Erreur : --filename-base est requis</translation>
+        <translation>Erreur&#xa0;: --filename-base est requis</translation>
     </message>
 </context>
 <context>
@@ -5114,7 +5118,7 @@ Use &quot;mms note&quot; to display the waiting notes</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="480"/>
         <source>failed to parse index: </source>
-        <translation>échec de l&apos;analyse de l&apos;index : </translation>
+        <translation>échec de l&apos;analyse de l&apos;index&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="493"/>
@@ -5129,12 +5133,12 @@ Use &quot;mms note&quot; to display the waiting notes</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="515"/>
         <source>RPC error: </source>
-        <translation>Erreur RPC : </translation>
+        <translation>Erreur RPC&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="519"/>
         <source>failed to get random outputs to mix: </source>
-        <translation>échec de la récupération de sorties aléatoires à mélanger : </translation>
+        <translation>échec de la récupération de sorties aléatoires à mélanger&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="526"/>
@@ -5190,22 +5194,22 @@ Use &quot;mms note&quot; to display the waiting notes</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="587"/>
         <source>unknown transfer error: </source>
-        <translation>erreur de transfert inconnue : </translation>
+        <translation>erreur de transfert inconnue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="592"/>
         <source>Multisig error: </source>
-        <translation>Erreur multisig : </translation>
+        <translation>Erreur multisig&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>internal error: </source>
-        <translation>erreur interne : </translation>
+        <translation>erreur interne&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>unexpected error: </source>
-        <translation>erreur inattendue : </translation>
+        <translation>erreur inattendue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="607"/>
@@ -5218,37 +5222,37 @@ Use &quot;mms note&quot; to display the waiting notes</source>
         <translation>Le fichier %s contient probablement des clés privées de portefeuille ! Utilisez un nom de fichier différent.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> seconds</source>
         <translation> secondes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> minutes</source>
         <translation> minutes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> hours</source>
         <translation> heures</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7605"/>
         <source> days</source>
         <translation> jours</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source> months</source>
         <translation> mois</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
         <source>a long time</source>
         <translation>longtemps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
@@ -5257,9 +5261,9 @@ Il a besoin de se connecter à un démon monero pour fonctionner correctement.
 ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE ce fork inclue des mitigations contre la réutilisation des clés. Faire ceci nuira à votre confidentialité.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9432"/>
         <source>Unknown command: </source>
-        <translation>Commande inconnue : </translation>
+        <translation>Commande inconnue&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="147"/>
@@ -5320,7 +5324,7 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="340"/>
         <source>Error: </source>
-        <translation>Erreur : </translation>
+        <translation>Erreur&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="449"/>
@@ -5338,7 +5342,7 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9426"/>
         <source>Failed to initialize wallet</source>
         <translation>Échec de l&apos;initialisation du portefeuille</translation>
     </message>
@@ -5346,288 +5350,288 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="234"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Utiliser l&apos;instance de démon située à &lt;hôte&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="235"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Utiliser l&apos;instance de démon située à l&apos;hôte &lt;arg&gt; au lieu de localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Wallet password file</source>
         <translation>Fichier mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="241"/>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Utiliser l&apos;instance de démon située au port &lt;arg&gt; au lieu de 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Pour testnet, le démon doit aussi être lancé avec l&apos;option --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="361"/>
+        <location filename="../src/wallet/wallet2.cpp" line="372"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>impossible de spécifier l&apos;hôte ou le port du démon plus d&apos;une fois</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="491"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>impossible de spécifier plus d&apos;une option parmis --password et --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="493"/>
+        <location filename="../src/wallet/wallet2.cpp" line="504"/>
         <source>the password file specified could not be read</source>
         <translation>le fichier mot de passe spécifié n&apos;a pas pu être lu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="519"/>
+        <location filename="../src/wallet/wallet2.cpp" line="530"/>
         <source>Failed to load file </source>
         <translation>Échec du chargement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="239"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Mot de passe du portefeuille (échapper/citer si nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="237"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Activer les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="238"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation>Désactiver les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="242"/>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Spécifier le nom_utilisateur:[mot_de_passe] pour le client RPC du démon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation>Pour stagenet, le démon doit aussi être lancé avec l&apos;option --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
+        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Set shared ring database path</source>
         <translation>Définir le chemin de la base de donnée de cercles partagés</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
+        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>Number of rounds for the key derivation function</source>
         <translation>Nombre de rondes de la fonction de dérivation de clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
+        <location filename="../src/wallet/wallet2.cpp" line="271"/>
         <source>HW device to use</source>
         <translation>Portefeuille matériel à utiliser</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
+        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <location filename="../src/wallet/wallet2.cpp" line="275"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <location filename="../src/wallet/wallet2.cpp" line="364"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="432"/>
+        <location filename="../src/wallet/wallet2.cpp" line="443"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation>--trusted-daemon et --untrusted-daemon présents simultanément, --untrusted-daemon choisi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="442"/>
+        <location filename="../src/wallet/wallet2.cpp" line="453"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="500"/>
+        <location filename="../src/wallet/wallet2.cpp" line="511"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>pas de mot de passe spécifié; utilisez --prompt-for-password pour demander un mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Enter a new password for the wallet</source>
         <translation>Entrer un nouveau mot de passe pour le portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Wallet password</source>
         <translation>Mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="525"/>
+        <location filename="../src/wallet/wallet2.cpp" line="536"/>
         <source>Failed to parse JSON</source>
         <translation>Échec de l&apos;analyse JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="532"/>
+        <location filename="../src/wallet/wallet2.cpp" line="543"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u trop récente, on comprend au mieux %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="548"/>
+        <location filename="../src/wallet/wallet2.cpp" line="559"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="553"/>
-        <location filename="../src/wallet/wallet2.cpp" line="621"/>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="632"/>
+        <location filename="../src/wallet/wallet2.cpp" line="677"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="575"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="569"/>
-        <location filename="../src/wallet/wallet2.cpp" line="631"/>
-        <location filename="../src/wallet/wallet2.cpp" line="692"/>
+        <location filename="../src/wallet/wallet2.cpp" line="580"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="703"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="581"/>
+        <location filename="../src/wallet/wallet2.cpp" line="592"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="601"/>
+        <location filename="../src/wallet/wallet2.cpp" line="612"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation>Il faut spécifier au moins une des options parmis la liste de mots de style Electrum, la clé privée d&apos;audit et la clé privée de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="605"/>
+        <location filename="../src/wallet/wallet2.cpp" line="616"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Liste de mots de style Electrum et clé privée spécifiées en même temps</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="615"/>
+        <location filename="../src/wallet/wallet2.cpp" line="626"/>
         <source>invalid address</source>
         <translation>adresse invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="624"/>
+        <location filename="../src/wallet/wallet2.cpp" line="635"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="634"/>
+        <location filename="../src/wallet/wallet2.cpp" line="645"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="653"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossible de générer un portefeuille obsolète à partir de JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="678"/>
+        <location filename="../src/wallet/wallet2.cpp" line="689"/>
         <source>failed to parse address: </source>
-        <translation>échec de l&apos;analyse de l&apos;adresse : </translation>
+        <translation>échec de l&apos;analyse de l&apos;adresse&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
+        <location filename="../src/wallet/wallet2.cpp" line="695"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>L&apos;adresse doit être spécifiée afin de créer un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="701"/>
+        <location filename="../src/wallet/wallet2.cpp" line="712"/>
         <source>failed to generate new wallet: </source>
-        <translation>échec de la génération du nouveau portefeuille : </translation>
+        <translation>échec de la génération du nouveau portefeuille&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1674"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation>Le mot de passe est requis pour calculer l&apos;image de clé pour les moneros entrants</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1675"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation>Mot de passe invalide : le mot de passe est requis pour calculer l&apos;image de clé pour les moneros entrants</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4171"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4761"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5357"/>
         <source>Primary account</source>
         <translation>Compte primaire</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10893"/>
         <source>No funds received in this tx.</source>
         <translation>Aucun fonds n&apos;a été reçu dans cette transaction.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11653"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
@@ -5637,30 +5641,30 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
         <translation>Définir les tailles d&apos;anticipation des sous-addresses à &lt;majeur&gt;:&lt;mineur&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
         <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
-        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
-        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
-        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <location filename="../src/wallet/wallet2.cpp" line="252"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="73"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5668,136 +5672,136 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="191"/>
         <source>Failed to create directory </source>
         <translation>Échec de la création du répertoire </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
         <source>Failed to create directory %s: %s</source>
-        <translation>Échec de la création du répertoire %s : %s</translation>
+        <translation>Échec de la création du répertoire %s&#xa0;: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source>Cannot specify --</source>
         <translation>Impossible de spécifier --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source> and --</source>
         <translation> et --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>Failed to create file </source>
         <translation>Échec de la création du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>. Check permissions or remove file</source>
         <translation>. Vérifiez les permissions ou supprimez le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>Error writing to file </source>
         <translation>Erreur d&apos;écriture dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="236"/>
         <source>RPC username/password is stored in file </source>
         <translation>nom_utilisateur/mot_de_passe RPC sauvegardé dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="628"/>
         <source>Tag %s is unregistered.</source>
         <translation>Le mot clé %s n&apos;est pas enregistré.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3260"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
-        <translation>Transaction impossible. Solde disponible : %s, montant de la transaction %s = %s + %s (frais)</translation>
+        <translation>Transaction impossible. Solde disponible&#xa0;: %s, montant de la transaction %s = %s + %s (frais)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4429"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Ceci est le portefeuille monero par RPC. Il a besoin de se
 connecter à un démon monero pour fonctionner correctement.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4265"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --wallet-file et --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4250"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --testnet et --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4277"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file, --generate-from-json ou --wallet-dir doit être spécifié</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4281"/>
         <source>Loading wallet...</source>
         <translation>Chargement du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4315"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4347"/>
         <source>Saving wallet...</source>
         <translation>Sauvegarde du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4317"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4349"/>
         <source>Successfully saved</source>
         <translation>Sauvegardé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Successfully loaded</source>
         <translation>Chargé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Wallet initialization failed: </source>
-        <translation>Échec de l&apos;initialisation du portefeuille : </translation>
+        <translation>Échec de l&apos;initialisation du portefeuille&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4330"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Échec de l&apos;initialisation du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4334"/>
         <source>Starting wallet RPC server</source>
         <translation>Démarrage du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4341"/>
         <source>Failed to run wallet: </source>
-        <translation>Échec du lancement du portefeuille : </translation>
+        <translation>Échec du lancement du portefeuille&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4344"/>
         <source>Stopped wallet RPC server</source>
         <translation>Arrêt du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4353"/>
         <source>Failed to save wallet: </source>
-        <translation>Échec de la sauvegarde du portefeuille : </translation>
+        <translation>Échec de la sauvegarde du portefeuille&#xa0;: </translation>
     </message>
 </context>
 <context>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9373"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4405"/>
         <source>Wallet options</source>
         <translation>Options du portefeuille</translation>
     </message>
@@ -5846,7 +5850,7 @@ connecter à un démon monero pour fonctionner correctement.</translation>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="210"/>
         <source>Logging to: </source>
-        <translation>Journalisation dans : </translation>
+        <translation>Journalisation dans&#xa0;: </translation>
     </message>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="212"/>
@@ -5866,7 +5870,7 @@ connecter à un démon monero pour fonctionner correctement.</translation>
     <message>
         <location filename="../src/wallet/wallet_args.cpp" line="146"/>
         <source>Usage:</source>
-        <translation>Usage :</translation>
+        <translation>Usage&#xa0;:</translation>
     </message>
 </context>
 </TS>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -776,271 +776,264 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>Height </source>
         <translation>Blocco </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4977"/>
         <source>spent </source>
         <translation>speso/i </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5091"/>
         <source>Starting refresh...</source>
         <translation>Sto iniziando il refresh...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
         <source>Refresh done, blocks received: </source>
         <translation>Refresh finito, blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento ha un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>bad locked_blocks parameter:</source>
         <translation>parametro locked_blocks non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6643"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>una singola transazione non può usare più di un id pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6651"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>impossibile impostare id pagamento, anche se è stato decodificado correttamente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6568"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation>la dimensione dell&apos;anello %u è troppo grande, il massimo è %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5692"/>
         <source>payment id failed to encode</source>
         <translation>codifica dell&apos;ID di pagamento non riuscita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5739"/>
         <source>failed to parse short payment ID from URI</source>
         <translation>impossibile analizzare l&apos;ID di pagamento breve dall&apos;URI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5766"/>
         <source>Invalid last argument: </source>
         <translation>Ultimo argomento non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5784"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>una singola transazione non può utilizzare più di un ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5802"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation>errore nell&apos;analisi dell&apos;ID di pagamento, anche se è stato rilevato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5825"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6710"/>
         <source>transaction cancelled.</source>
         <translation>transazione cancellata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5946"/>
         <source>Sending %s.  </source>
         <translation>Sto inviando %s. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5949"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>La tua transazione deve essere divisa in %llu transazioni. Una commissione verrà applicata per ogni transazione, per un totale di %s commissioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>The transaction fee is %s</source>
         <translation>La commissione per la transazione è %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
         <source>, of which %s is dust from change</source>
         <translation>, della quale %s è polvere dovuta allo scambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un totale di %s in polvere verrà inviato all&apos;indirizzo della polvere</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation>.
-Questa transazione verrà sbloccata al blocco %llu, in approssimativamente %s giorni (supponendo 2 minuti per blocco)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6008"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation>Transazione(i) senza firma scritta(e) con successo su MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation>Impossibile scrivere transazione/i su file</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation>Impossibile scrivere transazione/i su file</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6170"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6736"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Transazioni/e non firmata/e scritte/a con successo su file: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6481"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation>Impossibile firmare transazioni a freddo con il portafoglio hardware</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>No unmixable outputs found</source>
         <translation>Nessun output non-mixabile trovato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Fondi insufficienti in saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6220"/>
         <source>No address given</source>
         <translation>Non è stato fornito nessun indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6284"/>
         <source>missing lockedblocks parameter</source>
         <translation>parametro lockedblocks mancante</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
         <source>bad locked_blocks parameter</source>
         <translation>parametro locked_blocks errato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
         <source>Failed to parse number of outputs</source>
         <translation>Impossibile analizzare il numero di outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation>La quantità di outputs deve essere maggiore di 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6820"/>
         <source>Failed to parse donation address: </source>
         <translation>Impossibile analizzare l&apos;indirizzo di donazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6834"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation>Donare %s %s a The Monero Project (donate.getmonero.org o %s).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6836"/>
         <source>Donating %s %s to %s.</source>
         <translation>Donare %s %s a %s.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Il cambiamento richiesto non porta a un indirizzo pagato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6928"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Il cambiamento richiesto è più largo del pagamento all&apos;indirizzo di cambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6959"/>
         <source>sending %s to %s</source>
         <translation>sto mandando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
         <source> dummy output(s)</source>
         <translation> output dummy</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
         <source>with no destinations</source>
         <translation>senza destinazioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7013"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Questo è un portafoglio multisig, può firmare solo con sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7036"/>
         <source>Failed to sign transaction</source>
         <translation>Impossibile firmare la transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7042"/>
         <source>Failed to sign transaction: </source>
         <translation>Impossibile firmare la transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7063"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Dati esadecimali grezzi della transazione esportati su </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7084"/>
         <source>Failed to load transaction from file</source>
         <translation>Impossibile caricare la transazione da file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5461"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
@@ -1101,52 +1094,52 @@ Questa transazione verrà sbloccata al blocco %llu, in approssimativamente %s gi
         <translation>Password per il nuovo portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5144"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5466"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7097"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>refresh failed: </source>
         <translation>refresh fallito: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>Blocks received: </source>
         <translation>Blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5197"/>
         <source>unlocked balance: </source>
         <translation>bilancio sbloccato: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>amount</source>
         <translation>ammontare</translation>
     </message>
@@ -1379,13 +1372,13 @@ Questa transazione verrà sbloccata al blocco %llu, in approssimativamente %s gi
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transazione inviata con successo, transazione </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9356"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>E&apos; possibile controllare il suo stato mediante il comando `show_transfers`.</translation>
     </message>
@@ -2122,13 +2115,13 @@ di nuovo il tuo portafoglio (le chiavi del tuo portafoglio NON sono in nessun ca
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <source>txid </source>
         <translation>txid </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4978"/>
         <source>idx </source>
         <translation>idx </translation>
     </message>
@@ -2143,447 +2136,458 @@ di nuovo il tuo portafoglio (le chiavi del tuo portafoglio NON sono in nessun ca
         <translation>ATTENZIONE: questa transazione utilizza un ID di pagamento non criptato: questi sono obsoleti. Il supporto ad essi verrà sospeso in futuro. Utilizzare sottoindirizzi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4960"/>
+        <source>NOTE: This transaction is locked, see details with: show_transfer </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5110"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Alcuni output contengono immagini chiave parziali - import_multisig_info necessario)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Currently selected account: [</source>
         <translation>Account attualmente selezionato: [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>Tag: </source>
         <translation>Etichetta: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>(No tag assigned)</source>
         <translation>(Nessuna etichetta assegnata)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
         <source>Balance per address:</source>
         <translation>Saldo per indirizzo:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Unlocked balance</source>
         <translation>Saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Outputs</source>
         <translation>Outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5211"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>spent</source>
         <translation>spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>global index</source>
         <translation>indice globale</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>tx id</source>
         <translation>tx id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>addr index</source>
         <translation>indice indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5314"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5334"/>
         <source>No incoming transfers</source>
         <translation>Nessun trasferimento in entrata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5338"/>
         <source>No incoming available transfers</source>
         <translation>Nessun trasferimento in entrata disponibile</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5342"/>
         <source>No incoming unavailable transfers</source>
         <translation>Nessun trasferimento indisponibile in entrata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>payment</source>
         <translation>pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>transaction</source>
         <translation>transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>height</source>
         <translation>altezza</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>unlock time</source>
         <translation>tempo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5378"/>
         <source>No payments with id </source>
         <translation>Nessun pagamento con id </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6306"/>
         <source>failed to get blockchain height: </source>
         <translation>impossibile recuperare altezza blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transazione %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5561"/>
         <source>failed to get output: </source>
         <translation>impossibile recuperare output: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5569"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>l&apos;altezza del blocco di origine della chiave di output non dovrebbe essere più alta dell&apos;altezza della blockchain</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5573"/>
         <source>
 Originating block heights: </source>
         <translation>
 Originando blocchi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Avviso: alcune chiavi di input spese vengono da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, che potrebbe compromettere l&apos;anonimità della ring signature. Assicurati di farlo intenzionalmente!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>Ring size must not be 0</source>
         <translation>Il ring size non può essere 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6563"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>il ring size %u è troppo piccolo, il minimo è %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5668"/>
         <source>wrong number of arguments</source>
         <translation>numero di argomenti errato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5798"/>
         <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6411"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Nessun output trovato, o il daemon non è pronto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
+        <source>.
+This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7186"/>
         <source>failed to parse tx_key</source>
         <translation>impossibile analizzare tx_key</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Tx key successfully stored.</source>
         <translation>Tx key memorizzata con successo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
         <source>Failed to store tx key: </source>
         <translation>Impossibile memorizzare la chiave tx: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>block</source>
         <translation>blocco</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7869"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation>utilizzo: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation>utilizzo: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>direction</source>
         <translation>direzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>timestamp</source>
         <translation>timestamp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>running balance</source>
         <translation>bilancio corrente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>hash</source>
         <translation>hash</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>payment ID</source>
         <translation>ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>fee</source>
         <translation>tassa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>destination</source>
         <translation>destinazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>index</source>
         <translation>indice</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>note</source>
         <translation>nota</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
         <source>CSV exported to </source>
         <translation>CSV esportato in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8184"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation>Attenzione: questo farà perdere ogni informazione che non può essere recuperata dalla blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8185"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation>Questo include gli indirizzi di destinazione, le chiavi segrete di tx, le note di tx, ecc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8197"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8198"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8217"/>
         <source>MMS received new message</source>
         <translation>ricevuto un nuovo messaggio MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>Network type: </source>
         <translation>Tipo di rete: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8858"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Stagenet</source>
         <translation>Stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Mainnet</source>
         <translation>Mainnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
         <source>command only supported by HW wallet</source>
         <translation>comando supportato solo dal portafoglio HW</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9029"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation>Il portafoglio hardware non supporta la sincronizzazione cold KI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9041"/>
         <source>Please confirm the key image sync on the device</source>
         <translation>Si prega di confermare la sincronizzazione della chiave immagine sul dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9047"/>
         <source>Key images synchronized to height </source>
         <translation>Immagini della chiave sincronizzate all&apos;altezza </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9050"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation>L&apos;esecuzione di un daemon non fidato non può determinare quale output di transazione viene speso. Utilizzare un daemon fidato con --trusted-daemon ed eseguire rescan_spent</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> spent, </source>
         <translation> speso, </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> unspent</source>
         <translation> non speso</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
         <source>Failed to import key images</source>
         <translation>Impossibile importare le immagini della chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9062"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">Impossibile importare le key images: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
         <source>Failed to reconnect device</source>
         <translation>Impossibile ricollegare il dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9084"/>
         <source>Failed to reconnect device: </source>
         <translation>Impossibile ricollegare il dispositivo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Transaction successfully saved to </source>
         <translation>Transazione salvata correttamente in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>, txid </source>
         <translation>, txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>Failed to save transaction to </source>
         <translation>Impossibile salvare la transazione in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7018"/>
         <source>This is a watch only wallet</source>
         <translation>Questo è un portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9278"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9313"/>
         <source>Transaction ID not found</source>
         <translation>ID transazione non trovato</translation>
     </message>
@@ -2609,16 +2613,16 @@ Avviso: alcune chiavi di input spese vengono da </translation>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
         <source>command not supported by HW wallet</source>
         <translation>comando non supportato dal portafoglio HW</translation>
     </message>
@@ -2847,7 +2851,7 @@ Avviso: alcune chiavi di input spese vengono da </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5986"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation>ATTENZIONE: impostazione dell&apos;anello non default, la tua privacy potrebbe essere compromessa. Si consiglia di utilizzare l&apos;impostazione predefinita</translation>
     </message>
@@ -3234,15 +3238,15 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7222"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8924"/>
         <source>failed to parse address</source>
         <translation>impossibile fare il parsing dell&apos;indirizzo</translation>
     </message>
@@ -3334,7 +3338,7 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7258"/>
         <source>wallet is null</source>
         <translation>il portafoglio è nullo</translation>
     </message>
@@ -3393,8 +3397,8 @@ Key Image, &quot;absolute&quot;, list of rings</source>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5434"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8992"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>questo comando richiede un daemon fidato. Abilita questa opzione con --trusted-daemon</translation>
     </message>
@@ -3419,825 +3423,825 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation>impossibile salvare la blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation>Password necessaria (%s) - usa il comando refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5002"/>
         <source>Enter password</source>
         <translation>Inserisci la password</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5017"/>
         <source>Device requires attention</source>
         <translation>Il dispositivo richiede attenzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Enter device PIN</source>
         <translation>Inserisci il PIN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5027"/>
         <source>Failed to read device PIN</source>
         <translation>Impossibile leggere il PIN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5034"/>
         <source>Please enter the device passphrase on the device</source>
         <translation>Inserisci la passphrase del dispositivo sul dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Enter device passphrase</source>
         <translation>Immettere la passphrase del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Failed to read device passphrase</source>
         <translation>Impossibile leggere la passphrase del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation>Vuoi procedere adesso? (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5063"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5448"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5452"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Assicurati che sia in funzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5139"/>
         <source>refresh error: </source>
         <translation>errore refresh: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5187"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5196"/>
         <source>Balance: </source>
         <translation>Bilancio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5265"/>
         <source>Invalid keyword: </source>
         <translation>Parola chiave non valida: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>pubkey</source>
         <translation>pubkey</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>key image</source>
         <translation>immagine chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>unlocked</source>
         <translation>sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>locked</source>
         <translation>bloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5400"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento è in un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5456"/>
         <source>failed to get spent status</source>
         <translation>impossibile recuperare status spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>failed to find construction data for tx input</source>
         <translation>impossibile trovare i dati di costruzione per l&apos;input tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>the same transaction</source>
         <translation>la stessa transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>blocks that are temporally very close</source>
         <translation>i blocchi che sono temporalmente molto vicini</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6299"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6660"/>
         <source>No payment id is included with this transaction. Is this okay?</source>
         <translation>Nessun ID di pagamento è incluso in questa transazione. Vuoi procedere comunque?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Is this okay anyway?</source>
         <translation>Vuoi procedere comunque?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6439"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6181"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6984"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8186"/>
         <source>Rescan anyway?</source>
         <translation>Ripetere comunque la scansione?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8679"/>
         <source>Short payment IDs are to be used within an integrated address only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9482"/>
         <source> (Y/Yes/N/No): </source>
         <translation> (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>Choose processing:</source>
         <translation>Scegli l&apos;elaborazione:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9518"/>
         <source>Sign tx</source>
         <translation>Firma tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9526"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9537"/>
         <source>Submit tx</source>
         <translation>Invia tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>unknown</source>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9546"/>
         <source>Choice: </source>
         <translation>Scelta: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>Wrong choice</source>
         <translation>Scelta errata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>I/O</source>
         <translation>I/O</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Authorized Signer</source>
         <translation>Firmatario autorizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message Type</source>
         <translation>Tipo di messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Height</source>
         <translation>Altezza</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message State</source>
         <translation>Stato del messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Since</source>
         <translation>Da</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9583"/>
         <source> ago</source>
         <translation> fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Transport Address</source>
         <translation>Indirizzo di trasporto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Auto-Config Token</source>
         <translation>Auto-Config Token</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Monero Address</source>
         <translation>Indirizzo Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9604"/>
         <source>&lt;not set&gt;</source>
         <translation>&lt;not set&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9645"/>
         <source>Message </source>
         <translation>Messaggio </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9646"/>
         <source>In/out: </source>
         <translation>In/out: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>State: </source>
         <translation>Stato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>%s since %s, %s ago</source>
         <translation>%s da %s, %s fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9652"/>
         <source>Sent: Never</source>
         <translation>Inviati: mai</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>Sent: %s, %s ago</source>
         <translation>inviato/i: %s, %s fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9659"/>
         <source>Authorized signer: </source>
         <translation>Firmatario autorizzato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source>Content size: </source>
         <translation>Dimensione del contenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source> bytes</source>
         <translation> bytes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>Content: </source>
         <translation>Contenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>(binary data)</source>
         <translation>(dati binari)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9691"/>
         <source>Send these messages now?</source>
         <translation>Vuoi inviare questi messaggi adesso?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9701"/>
         <source>Queued for sending.</source>
         <translation>In coda per l&apos;invio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9721"/>
         <source>Invalid message id</source>
         <translation>ID messaggio non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9730"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation>utilizzo: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9736"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation>L&apos;MMS è già inizializzato. Reinizializzare eliminando tutte le informazioni e i messaggi del firmatario?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9751"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation>Errore nel numero di firmatari richiesti e/o firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source>The MMS is not active.</source>
         <translation>L&apos;MMS non è attivo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9791"/>
         <source>Invalid signer number </source>
         <translation>Numero del firmatario non valido </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9796"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
         <source>Invalid Monero address</source>
         <translation>Indirizzo Monero non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation>Lo stato del portafoglio non consente più di modificare gli indirizzi Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9834"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>Usage: mms next [sync]</source>
         <translation>Utilizzo: mms next [sync]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9872"/>
         <source>No next step: </source>
         <translation>Nessun passo successivo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9882"/>
         <source>prepare_multisig</source>
         <translation>prepare_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9888"/>
         <source>make_multisig</source>
         <translation>make_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>exchange_multisig_keys</source>
         <translation>exchange_multisig_keys</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10038"/>
         <source>export_multisig_info</source>
         <translation>export_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9927"/>
         <source>import_multisig_info</source>
         <translation>import_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9940"/>
         <source>sign_multisig</source>
         <translation>sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9950"/>
         <source>submit_multisig</source>
         <translation>submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9960"/>
         <source>Send tx</source>
         <translation>Invia tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9971"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9983"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation>Sostituire la configurazione attuale del firmatario con quella visualizzata sopra?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
         <source>Process auto config data</source>
         <translation>Elabora dati di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10011"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10031"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10055"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10062"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10088"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10105"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10122"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10134"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10138"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10169"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10191"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10210"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10227"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10237"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10245"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10261"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10282"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10287"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10293"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10317"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10333"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10340"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10346"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10364"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10388"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10465"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10474"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6427"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6432"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6434"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6605"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6628"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6682"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6687"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6692"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>missing threshold amount</source>
         <translation>manca la soglia massima dell&apos;ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6774"/>
         <source>invalid amount threshold</source>
         <translation>ammontare soglia invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6937"/>
         <source>Change goes to more than one address</source>
         <translation>Il cambiamento va a più di un indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7483"/>
         <source>Good signature</source>
         <translation>Firma valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7585"/>
         <source>Bad signature</source>
         <translation>Firma invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Standard address: </source>
         <translation>Indirizzo standard: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8642"/>
         <source>failed to parse payment ID or address</source>
         <translation>impossibile fare il parsing di ID pagamento o indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
         <source>failed to parse payment ID</source>
         <translation>impossibile fare il parsing di ID pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8702"/>
         <source>failed to parse index</source>
         <translation>impossibile fare il parsing dell&apos;indice</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8710"/>
         <source>Address book is empty.</source>
         <translation>La rubrica è vuota.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8716"/>
         <source>Index: </source>
         <translation>Indice: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
         <source>Address: </source>
         <translation>Indirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8718"/>
         <source>Payment ID: </source>
         <translation>ID Pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8719"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8847"/>
         <source>Description: </source>
         <translation>Descrizione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8877"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>il portafoglio è di tipo solo-visualizzazione e non può firmare</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9149"/>
         <source>failed to read file </source>
         <translation>impossibile leggere il file </translation>
     </message>
@@ -4249,7 +4253,7 @@ Transaction </source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5988"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4259,506 +4263,506 @@ Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7570"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7424"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7508"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7563"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished">L&apos;indirizzo non può essere un sottoindirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7792"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8070"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8269"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8320"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8333"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8568"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8550"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8464"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8470"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8473"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8482"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8492"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8493"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8537"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8577"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8620"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8632"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8804"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8806"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8846"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8851"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8853"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8855"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9647"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8882"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8931"/>
         <source>Bad signature from </source>
         <translation>Firma non valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8935"/>
         <source>Good signature from </source>
         <translation>Firma valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>il portafoglio è solo-vista e non può esportare immagini chiave</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
         <source>failed to save file </source>
         <translation>impossibile salvare file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8979"/>
         <source>Signed key images exported to </source>
         <translation>Chiave immagine firmata esportata in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
         <source>Outputs exported to </source>
         <translation>Outputs esportati in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>amount is wrong: </source>
         <translation>l&apos;ammontare non è corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5755"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
         <source>expected number from 0 to </source>
         <translation>deve essere un numero da 0 a </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
         <source>Sweeping </source>
         <translation>Eseguendo lo sweeping </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fondi inviati con successo, transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6978"/>
         <source>%s change to %s</source>
         <translation>%s cambia in %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
         <source>no change</source>
         <translation>nessun cambiamento</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transazione firmata con successo nel file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8736"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
         <source>failed to parse txid</source>
         <translation>parsing txid fallito</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7136"/>
         <source>Tx key: </source>
         <translation>Chiave Tx: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7141"/>
         <source>no tx keys found for this txid</source>
         <translation>nessuna chiave tx trovata per questo txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7534"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7447"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7536"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7281"/>
         <source>failed to parse tx key</source>
         <translation>impossibile fare il parsing della chiave tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7405"/>
         <source>error: </source>
         <translation>errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>received</source>
         <translation>ricevuto/i</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>in txid</source>
         <translation>in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7395"/>
         <source>received nothing in txid</source>
         <translation>nulla ricevuto in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7379"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>AVVISO: questa transazione non è ancora inclusa nella blockchain!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>This transaction has %u confirmations</source>
         <translation>Questa transazione ha %u conferme</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7389"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>AVVISO: impossibile determinare il numero di conferme!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7670"/>
         <source>bad min_height parameter:</source>
         <translation>parametro min_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7682"/>
         <source>bad max_height parameter:</source>
         <translation>parametro max_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8044"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_amount&gt; dovrebbe essere più piccolo di &lt;max_amount&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>
 Amount: </source>
         <translation>
 Ammontare: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>, number of keys: </source>
         <translation>, numero di chiavi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8081"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8086"/>
         <source>
 Min block height: </source>
         <translation>
 Altezza minima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8087"/>
         <source>
 Max block height: </source>
         <translation>
 Altezza massima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>
 Min amount found: </source>
         <translation>
 Ammontare minimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8089"/>
         <source>
 Max amount found: </source>
         <translation>
 Ammontare massimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>
 Total count: </source>
         <translation>
 Conto totale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8130"/>
         <source>
 Bin size: </source>
         <translation>
 Dimensione Bin: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8131"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8133"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8265"/>
         <source>wallet</source>
         <translation>portafoglio</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Random payment ID: </source>
         <translation>ID pagamento casuale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8613"/>
         <source>Matching integrated address: </source>
         <translation>Indirizzo integrato corrispondente: </translation>
     </message>
@@ -5206,44 +5210,44 @@ Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7605"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9432"/>
         <source>Unknown command: </source>
         <translation type="unfinished">Comando sconosciuto: </translation>
     </message>
@@ -5324,7 +5328,7 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9426"/>
         <source>Failed to initialize wallet</source>
         <translation>Inizializzazione wallet fallita</translation>
     </message>
@@ -5332,288 +5336,288 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="234"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Usa instanza daemon in &lt;host&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="235"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Usa istanza daemon all&apos;host &lt;arg&gt; invece che localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Wallet password file</source>
         <translation>File password portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="241"/>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Usa istanza daemon alla porta &lt;arg&gt; invece che alla 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Per testnet. Il daemon può anche essere lanciato con la flag --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="361"/>
+        <location filename="../src/wallet/wallet2.cpp" line="372"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>non puoi specificare la porta o l&apos;host del daemon più di una volta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="491"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>non puoi specificare più di un --password e --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="493"/>
+        <location filename="../src/wallet/wallet2.cpp" line="504"/>
         <source>the password file specified could not be read</source>
         <translation>il file password specificato non può essere letto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="519"/>
+        <location filename="../src/wallet/wallet2.cpp" line="530"/>
         <source>Failed to load file </source>
         <translation>Impossibile caricare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="239"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Wallet password (escape/quote se necessario)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="237"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">Abilita comandi dipendenti da un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="238"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="242"/>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Specificare username[:password] per client del daemon RPC</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
+        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
+        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
+        <location filename="../src/wallet/wallet2.cpp" line="271"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
+        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <location filename="../src/wallet/wallet2.cpp" line="275"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <location filename="../src/wallet/wallet2.cpp" line="364"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="432"/>
+        <location filename="../src/wallet/wallet2.cpp" line="443"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="442"/>
+        <location filename="../src/wallet/wallet2.cpp" line="453"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="500"/>
+        <location filename="../src/wallet/wallet2.cpp" line="511"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="525"/>
+        <location filename="../src/wallet/wallet2.cpp" line="536"/>
         <source>Failed to parse JSON</source>
         <translation>Impossibile fare il parsing di JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="532"/>
+        <location filename="../src/wallet/wallet2.cpp" line="543"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>La versione %u è troppo recente, possiamo comprendere solo fino alla versione %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="548"/>
+        <location filename="../src/wallet/wallet2.cpp" line="559"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing di chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="553"/>
-        <location filename="../src/wallet/wallet2.cpp" line="621"/>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="632"/>
+        <location filename="../src/wallet/wallet2.cpp" line="677"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="575"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="569"/>
-        <location filename="../src/wallet/wallet2.cpp" line="631"/>
-        <location filename="../src/wallet/wallet2.cpp" line="692"/>
+        <location filename="../src/wallet/wallet2.cpp" line="580"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="703"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="581"/>
+        <location filename="../src/wallet/wallet2.cpp" line="592"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Verifica lista di parole stile-Electrum fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="601"/>
+        <location filename="../src/wallet/wallet2.cpp" line="612"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="605"/>
+        <location filename="../src/wallet/wallet2.cpp" line="616"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Specificate entrambe lista parole stile-Electrum e chiave/i privata/e </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="615"/>
+        <location filename="../src/wallet/wallet2.cpp" line="626"/>
         <source>invalid address</source>
         <translation>indirizzo invalido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="624"/>
+        <location filename="../src/wallet/wallet2.cpp" line="635"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="634"/>
+        <location filename="../src/wallet/wallet2.cpp" line="645"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="653"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossibile creare portafogli disapprovati da JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="678"/>
+        <location filename="../src/wallet/wallet2.cpp" line="689"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
+        <location filename="../src/wallet/wallet2.cpp" line="695"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="701"/>
+        <location filename="../src/wallet/wallet2.cpp" line="712"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1674"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1675"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4171"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4761"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5357"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10893"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11653"/>
         <source>failed to read file </source>
         <translation>lettura file fallita</translation>
     </message>
@@ -5623,30 +5627,30 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
         <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
-        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
-        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
-        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <location filename="../src/wallet/wallet2.cpp" line="252"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="73"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5654,125 +5658,125 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="191"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source>Cannot specify --</source>
         <translation>Impossibile specificare --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source> and --</source>
         <translation> e --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>Failed to create file </source>
         <translation>Impossibile creare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>. Check permissions or remove file</source>
         <translation>. Controlla permessi o rimuovi il file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>Error writing to file </source>
         <translation>Errore durante scrittura su file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="236"/>
         <source>RPC username/password is stored in file </source>
         <translation>Username/password RPC conservato nel file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="628"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3260"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4429"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4265"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Non puoi specificare più di un --wallet-file e --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4250"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished">Non è possibile specificare più di un --testnet e --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4277"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Devi specificare --wallet-file o --generate-from-json o --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4281"/>
         <source>Loading wallet...</source>
         <translation>Sto caricando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4315"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4347"/>
         <source>Saving wallet...</source>
         <translation>Sto salvando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4317"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4349"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Wallet initialization failed: </source>
         <translation>Inizializzazione portafoglio fallita: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4330"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Inizializzazione server RPC portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4334"/>
         <source>Starting wallet RPC server</source>
         <translation>Server RPC portafoglio in avvio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4341"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4344"/>
         <source>Stopped wallet RPC server</source>
         <translation>Server RPC portafoglio arrestato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4353"/>
         <source>Failed to save wallet: </source>
         <translation>Impossibile salvare portafoglio: </translation>
     </message>
@@ -5781,8 +5785,8 @@ daemon to work correctly.</source>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9373"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4405"/>
         <source>Wallet options</source>
         <translation>Opzioni portafoglio</translation>
     </message>

--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -782,319 +782,313 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4977"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5091"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished">ペイメントIDのフォーマットは不正です。16文字または64文字の16進数の文字列が必要で： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6643"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6651"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6568"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5692"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5739"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5766"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5784"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5802"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5825"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6710"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6427"/>
         <source>
 Transaction </source>
         <translation>
 取引 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6432"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6434"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5946"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5949"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>.</source>
         <translation>。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6008"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation type="unfinished">取引をファイルに書き込めませんでした</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation type="unfinished">取引をファイルに書き込めませんでした</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6170"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6736"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6481"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6220"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6284"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6605"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6628"/>
         <source>failed to parse key image</source>
         <translation>キーイメージの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6682"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6687"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6692"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6774"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished">請求したお釣りはもうお金に送ったアドレス送りません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6928"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished">請求したお釣りはお釣りのアドレスに送ったペイメントより大きいです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6959"/>
         <source>sending %s to %s</source>
         <translation>%s を %s に送ってます</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
         <source>with no destinations</source>
         <translation>目的地なし</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7013"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7036"/>
         <source>Failed to sign transaction</source>
         <translation>取引を署名できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7042"/>
         <source>Failed to sign transaction: </source>
         <translation>取引を署名できませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7063"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7084"/>
         <source>Failed to load transaction from file</source>
         <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5461"/>
         <source>RPC error: </source>
         <translation>RPCエラー： </translation>
     </message>
@@ -1155,52 +1149,52 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5144"/>
         <source>internal error: </source>
         <translation>内部エラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5466"/>
         <source>unexpected error: </source>
         <translation>予期せぬエラー： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7097"/>
         <source>unknown error</source>
         <translation>不明なエラー</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5197"/>
         <source>unlocked balance: </source>
         <translation>ロック解除された残高： </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>amount</source>
         <translation>金額</translation>
     </message>
@@ -1433,13 +1427,13 @@ This transaction will unlock on block %llu, in approximately %s days (assuming 2
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9356"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2167,13 +2161,13 @@ your wallet again (your wallet keys are NOT at risk in any case).
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <source>txid </source>
         <translation>txid </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4978"/>
         <source>idx </source>
         <translation>idx </translation>
     </message>
@@ -2188,459 +2182,470 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4960"/>
+        <source>NOTE: This transaction is locked, see details with: show_transfer </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5110"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>Tag: </source>
         <translation>タグ： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Balance</source>
         <translation>残高</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Unlocked balance</source>
         <translation>ロック解除された残高</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Outputs</source>
         <translation>アウトプット</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5211"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>tx id</source>
         <translation>tx id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5314"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5334"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5338"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5342"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>payment</source>
         <translation>ペイメント</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>transaction</source>
         <translation>取引</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5378"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6306"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5561"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5569"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5573"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6563"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5668"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5798"/>
         <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6411"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
+        <source>.
+This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6820"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6834"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6836"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7186"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7869"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8184"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8185"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8197"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8198"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8217"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8858"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9029"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9041"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9047"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9050"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9062"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">キーイメージをインポートできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9084"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>, txid </source>
         <translation>、txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7018"/>
         <source>This is a watch only wallet</source>
         <translation>これは閲覧専用ウォレットです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9278"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9313"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2666,16 +2671,16 @@ Warning: Some input keys being spent are from </source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2904,7 +2909,7 @@ Warning: Some input keys being spent are from </source>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5986"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3279,15 +3284,15 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7222"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8924"/>
         <source>failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
@@ -3374,7 +3379,7 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7258"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3432,8 +3437,8 @@ Key Image, &quot;absolute&quot;, list of rings</source>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5434"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8992"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3458,757 +3463,757 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5002"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5017"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5027"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5034"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5063"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5448"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5452"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5139"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5187"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5196"/>
         <source>Balance: </source>
         <translation>残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5265"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>key image</source>
         <translation>キーイメージ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>unlocked</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5400"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5456"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>the same transaction</source>
         <translation>同じ取引</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6299"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6660"/>
         <source>No payment id is included with this transaction. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6439"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6181"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6984"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8186"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8679"/>
         <source>Short payment IDs are to be used within an integrated address only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9482"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9518"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9526"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9537"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9546"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9583"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9604"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9645"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9646"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9652"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9659"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9691"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9701"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9721"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9730"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9736"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9751"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9791"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9796"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9834"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9872"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9882"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9888"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10038"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9927"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9940"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9950"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9960"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9971"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9983"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10011"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10031"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10055"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10062"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10088"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10105"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10122"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10134"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10138"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10169"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10191"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10210"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10227"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10237"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10245"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10261"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10282"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10287"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10293"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10317"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10333"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10340"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10346"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10364"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10388"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10465"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10474"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7483"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7585"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8642"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
         <source>failed to parse payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8702"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8710"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8716"/>
         <source>Index: </source>
         <translation>インデックス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
         <source>Address: </source>
         <translation>アドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8718"/>
         <source>Payment ID: </source>
         <translation>ペイメントID： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8719"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8847"/>
         <source>Description: </source>
         <translation>記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8877"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9149"/>
         <source>failed to read file </source>
         <translation>ファイルの読み込みに失敗しました </translation>
     </message>
@@ -4220,7 +4225,7 @@ Input %llu/%llu (%s): amount=%s</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5988"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4230,506 +4235,506 @@ Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7570"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7424"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7508"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7563"/>
         <source>Address must not be a subaddress</source>
         <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7792"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8070"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
         <source> (no daemon)</source>
         <translation> (デーモンありません）</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8269"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8320"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8333"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8568"/>
         <source>failed to parse index: </source>
         <translation>インデックスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8550"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>, unlocked balance: </source>
         <translation>、ロック解除された残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8464"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8470"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished">タグ %s を登録してません。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8473"/>
         <source>Accounts with tag: </source>
         <translation>タグを持ってるアカウント： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
         <source>Tag&apos;s description: </source>
         <translation>タグの記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8482"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8492"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8493"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>Primary address</source>
         <translation>プライマリアドレス</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8537"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8577"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8620"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8632"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Subaddress: </source>
         <translation>サブアドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8804"/>
         <source>no description found</source>
         <translation>記述を見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8806"/>
         <source>description found: </source>
         <translation>記述を見つかれました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8846"/>
         <source>Filename: </source>
         <translation>ファイル名： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8851"/>
         <source>Watch only</source>
         <translation>閲覧専用</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8853"/>
         <source>%u/%u multisig%s</source>
         <translation>%u/%u マルチサイン%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8855"/>
         <source>Normal</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9647"/>
         <source>Type: </source>
         <translation>タイプ： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8882"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8931"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8935"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
         <source>failed to save file </source>
         <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8979"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5755"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6937"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished">お釣りは複数のアドレスに送ります</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6978"/>
         <source>%s change to %s</source>
         <translation>%s のお釣り %s に</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
         <source>no change</source>
         <translation>お釣りありません</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8736"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
         <source>failed to parse txid</source>
         <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7136"/>
         <source>Tx key: </source>
         <translation>txキー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7141"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished">このtxidのためにtxキーを見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7534"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7447"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7536"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7281"/>
         <source>failed to parse tx key</source>
         <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7405"/>
         <source>error: </source>
         <translation>エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>received</source>
         <translation>貰いました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>in txid</source>
         <translation>txidに</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7395"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7379"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
-        <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
+        <source>This transaction has %u confirmations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7389"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7670"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7682"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8044"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>
 Amount: </source>
         <translation>
 金額： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>, number of keys: </source>
         <translation>、キーの数： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8081"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8086"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8087"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8089"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8130"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8131"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8133"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; ブロック高
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8265"/>
         <source>wallet</source>
         <translation>ウォレット</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Random payment ID: </source>
         <translation>ランダムなペイメントID： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8613"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4799,7 +4804,7 @@ Outputs per *: </source>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
-        <translation>このプログラムはマルチサインウォレットのセットを生じます　－　みんながみんなを信用する場合にだけこの単純なスキームを使ってください</translation>
+        <translation>このプログラムはマルチサインウォレットのセットを生じます&#x3000;－&#x3000;みんながみんなを信用する場合にだけこの単純なスキームを使ってください</translation>
     </message>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
@@ -5177,44 +5182,44 @@ Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7605"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9432"/>
         <source>Unknown command: </source>
         <translation type="unfinished">未知のコマンド： </translation>
     </message>
@@ -5295,7 +5300,7 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9426"/>
         <source>Failed to initialize wallet</source>
         <translation>ウォレットを初期化できませんでした</translation>
     </message>
@@ -5303,288 +5308,288 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="234"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>&lt;host&gt;:&lt;port&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="235"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>localhostの代わりにホスト &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Wallet password file</source>
         <translation>ウォレットのパスワードファイル</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="241"/>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>１８０８１の代わりにポート &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>テストネットのためにデーモンは --testnet のフラグで開始する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="361"/>
+        <location filename="../src/wallet/wallet2.cpp" line="372"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>デーモンのホストやポートを複数回指定することはできません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="491"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>--password と --passwordfile を1つしか指定しません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="493"/>
+        <location filename="../src/wallet/wallet2.cpp" line="504"/>
         <source>the password file specified could not be read</source>
         <translation>指定されたパスワードファイルを読み取れません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="519"/>
+        <location filename="../src/wallet/wallet2.cpp" line="530"/>
         <source>Failed to load file </source>
         <translation>ファイルのロードに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="239"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>ウォレットのパスワード(随時にエスケープ文字を使ってください)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="237"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">必要な信用できるデーモンのコマンドをエネーブルしてください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="238"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="242"/>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>デーモンのRPCクライアントを使うためにユーザー名[：パスワード]を指定してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
+        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
+        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
+        <location filename="../src/wallet/wallet2.cpp" line="271"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
+        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <location filename="../src/wallet/wallet2.cpp" line="275"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <location filename="../src/wallet/wallet2.cpp" line="364"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="432"/>
+        <location filename="../src/wallet/wallet2.cpp" line="443"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="442"/>
+        <location filename="../src/wallet/wallet2.cpp" line="453"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="500"/>
+        <location filename="../src/wallet/wallet2.cpp" line="511"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>パスワードを指定しませんでした。パスワードプロンプトを見るために--prompt-for-password を使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="525"/>
+        <location filename="../src/wallet/wallet2.cpp" line="536"/>
         <source>Failed to parse JSON</source>
         <translation>JSONを解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="532"/>
+        <location filename="../src/wallet/wallet2.cpp" line="543"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>バージョン %u 新しすぎるです。%u までグロークできます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="548"/>
+        <location filename="../src/wallet/wallet2.cpp" line="559"/>
         <source>failed to parse view key secret key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="553"/>
-        <location filename="../src/wallet/wallet2.cpp" line="621"/>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="632"/>
+        <location filename="../src/wallet/wallet2.cpp" line="677"/>
         <source>failed to verify view key secret key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="575"/>
         <source>failed to parse spend key secret key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="569"/>
-        <location filename="../src/wallet/wallet2.cpp" line="631"/>
-        <location filename="../src/wallet/wallet2.cpp" line="692"/>
+        <location filename="../src/wallet/wallet2.cpp" line="580"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="703"/>
         <source>failed to verify spend key secret key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="581"/>
+        <location filename="../src/wallet/wallet2.cpp" line="592"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="601"/>
+        <location filename="../src/wallet/wallet2.cpp" line="612"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="605"/>
+        <location filename="../src/wallet/wallet2.cpp" line="616"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Electrumな単語表と秘密なキーを指定しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="615"/>
+        <location filename="../src/wallet/wallet2.cpp" line="626"/>
         <source>invalid address</source>
         <translation>不正なアドレス</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="624"/>
+        <location filename="../src/wallet/wallet2.cpp" line="635"/>
         <source>view key does not match standard address</source>
         <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="634"/>
+        <location filename="../src/wallet/wallet2.cpp" line="645"/>
         <source>spend key does not match standard address</source>
         <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="653"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>JSONで非推奨のウォレットを生成することはできません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="678"/>
+        <location filename="../src/wallet/wallet2.cpp" line="689"/>
         <source>failed to parse address: </source>
         <translation>アドレスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
+        <location filename="../src/wallet/wallet2.cpp" line="695"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>閲覧専用ウォレットを作るためにアドレスを指定する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="701"/>
+        <location filename="../src/wallet/wallet2.cpp" line="712"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1674"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1675"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4171"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4761"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5357"/>
         <source>Primary account</source>
         <translation>プライマリア カウント</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10893"/>
         <source>No funds received in this tx.</source>
         <translation>この取引から資金貰いませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11653"/>
         <source>failed to read file </source>
         <translation>ファイルの読み込みに失敗しました </translation>
     </message>
@@ -5594,30 +5599,30 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
         <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
-        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
-        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
-        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <location filename="../src/wallet/wallet2.cpp" line="252"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="73"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5625,126 +5630,126 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="191"/>
         <source>Failed to create directory </source>
         <translation>ディレクトリの作成に失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
         <source>Failed to create directory %s: %s</source>
         <translation>%s %s ディレクトリの作成に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source>Cannot specify --</source>
         <translation>これを指定しません： --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source> and --</source>
         <translation> と --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>Failed to create file </source>
         <translation>ファイルの作成に失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>. Check permissions or remove file</source>
         <translation>。 パーミッションを確認するか、ファイルを削除してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>Error writing to file </source>
         <translation>ファイルへの書き込みエラー </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="236"/>
         <source>RPC username/password is stored in file </source>
         <translation>RPCユーザー名/パスワードはファイルに保存しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="628"/>
         <source>Tag %s is unregistered.</source>
         <translation>タグ %s を登録してません。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3260"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4429"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>これはMoneroのRPCウォレットです。正しく動作させるには
 Moneroデーモンに接続する必要があります。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4265"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>--wallet-file と --generate-from-json を1つしか指定しません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4250"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4277"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file や --generate-from-json や --wallet-dir を指定する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4281"/>
         <source>Loading wallet...</source>
         <translation>ウォレットをロードしてます...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4315"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4347"/>
         <source>Saving wallet...</source>
         <translation>ウォレットを保存してます...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4317"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4349"/>
         <source>Successfully saved</source>
         <translation>保存しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Successfully loaded</source>
         <translation>ロードしました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Wallet initialization failed: </source>
         <translation>ウォレットを初期化できませんでした: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4330"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>ウォレットのRPCサーバを初期化できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4334"/>
         <source>Starting wallet RPC server</source>
         <translation>ウォレットのRPCサーバを開始してます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4341"/>
         <source>Failed to run wallet: </source>
         <translation>ウォレットを起動することできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4344"/>
         <source>Stopped wallet RPC server</source>
         <translation>ウォレットのRPCサーバを停止しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4353"/>
         <source>Failed to save wallet: </source>
         <translation>ウォレットを保存することできませんでした： </translation>
     </message>
@@ -5753,8 +5758,8 @@ Moneroデーモンに接続する必要があります。</translation>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9373"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4405"/>
         <source>Wallet options</source>
         <translation>ウォレットのオプション</translation>
     </message>

--- a/translations/monero_sv.ts
+++ b/translations/monero_sv.ts
@@ -786,322 +786,315 @@
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4973"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
         <source>Height </source>
         <translation>Höjd </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4975"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4977"/>
         <source>spent </source>
         <translation>spenderat </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5089"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5091"/>
         <source>Starting refresh...</source>
-        <translation>Startar uppdatering …</translation>
+        <translation>Startar uppdatering&#xa0;…</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5115"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5117"/>
         <source>Refresh done, blocks received: </source>
         <translation>Uppdatering färdig, mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6349"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6353"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5704"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>bad locked_blocks parameter:</source>
         <translation>felaktig parameter för locked_blocks:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6639"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6643"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>en enda transaktion kan inte använda fler än ett betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6378"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6607"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6647"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5808"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6611"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6651"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>det gick inte att upprätta betalnings-ID, trots att det avkodades korrekt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6271"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6275"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6568"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5692"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5737"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5739"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5762"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="5764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5766"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5782"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5784"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5800"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5802"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5991"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6139"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6392"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6706"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5825"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5905"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5995"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6143"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6396"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6665"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6710"/>
         <source>transaction cancelled.</source>
         <translation>transaktion avbruten.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Failed to check for backlog: </source>
         <translation>Det gick inte att kontrollera eftersläpning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5933"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6423"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6427"/>
         <source>
 Transaction </source>
         <translation>
 Transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5938"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6428"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6432"/>
         <source>Spending from address index %d
 </source>
         <translation>Spendera från adressindex %d
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5940"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6430"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6434"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation>VARNING: Utgångar från flera adresser används tillsammans, vilket möjligen kan kompromettera din sekretess.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5942"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5946"/>
         <source>Sending %s.  </source>
         <translation>Skickar %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5945"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5949"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Transaktionen behöver delas upp i %llu transaktioner.  Detta gör att en transaktionsavgift läggs till varje transaktion, med ett totalbelopp på %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>The transaction fee is %s</source>
         <translation>Transaktionsavgiften är %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5958"/>
         <source>, of which %s is dust from change</source>
         <translation>, varav %s är damm från växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Ett totalt belopp på %s från växeldamm skickas till damm-adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5960"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation>.
-Denna transaktion låses upp vid block %llu, om ungefär %s dagar (förutsatt en blocktid på 2 minuter)</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6008"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6012"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6049"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6150"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6162"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6461"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6498"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6728"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation>Det gick inte att skriva transaktioner till fil</translation>
-    </message>
-    <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6154"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6166"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6502"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6720"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="6732"/>
+        <source>Failed to write transaction(s) to file</source>
+        <translation>Det gick inte att skriva transaktioner till fil</translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6021"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6058"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6170"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6469"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6506"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6724"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6736"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Osignerade transaktioner skrevs till fil: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6477"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6481"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>No unmixable outputs found</source>
         <translation>Inga omixbara utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6176"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6180"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6216"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6220"/>
         <source>No address given</source>
         <translation>Ingen adress har angivits</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6280"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6284"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6294"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6315"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6577"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6320"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6578"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6324"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6605"/>
         <source>failed to parse Payment ID</source>
         <translation>det gick inte att parsa betalnings-ID</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2078"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2125"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6624"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6628"/>
         <source>failed to parse key image</source>
         <translation>det gick inte att parsa nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6682"/>
         <source>No outputs found</source>
         <translation>Inga utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6683"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6687"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation>Flera transaktioner skapas, vilket inte ska kunna inträffa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6692"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation>Transaktionen använder flera eller inga ingångar, vilket inte ska kunna inträffa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6765"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>missing threshold amount</source>
         <translation>tröskelbelopp saknas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6770"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6774"/>
         <source>invalid amount threshold</source>
         <translation>ogiltigt tröskelbelopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6919"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6923"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Begärd växel går inte till en betald adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6924"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6928"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Begärd växel är större än betalning till växeladressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6955"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6959"/>
         <source>sending %s to %s</source>
         <translation>skickar %s till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6965"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6969"/>
         <source> dummy output(s)</source>
         <translation> dummy-utgångar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6972"/>
         <source>with no destinations</source>
         <translation>utan några mål</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7009"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7013"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Detta är en multisig-plånbok, som endast kan signera med sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7036"/>
         <source>Failed to sign transaction</source>
         <translation>Det gick inte att signera transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7038"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7042"/>
         <source>Failed to sign transaction: </source>
         <translation>Det gick inte att signera transaktionen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7063"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Hexadecimala rådata för transaktionen exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7084"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5132"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5459"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5461"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
@@ -1162,52 +1155,52 @@ Denna transaktion låses upp vid block %llu, om ungefär %s dagar (förutsatt en
         <translation>Lösenord för ny granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5142"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5144"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5147"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5464"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5149"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5466"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1637"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5152"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6040"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6195"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6490"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6517"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6749"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5471"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6044"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6074"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6199"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6494"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6753"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7097"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>refresh failed: </source>
         <translation>det gick inte att uppdatera: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5157"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5159"/>
         <source>Blocks received: </source>
         <translation>Mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5197"/>
         <source>unlocked balance: </source>
         <translation>upplåst saldo: </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3303"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>amount</source>
         <translation>belopp</translation>
     </message>
@@ -1440,13 +1433,13 @@ Denna transaktion låses upp vid block %llu, om ungefär %s dagar (förutsatt en
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1547"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9330"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transaktionen skickades, transaktion </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9331"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9356"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>Du kan kontrollera dess status genom att använda kommandot &apos;show_transfers&apos;.</translation>
     </message>
@@ -2184,13 +2177,13 @@ din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som 
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4941"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
         <source>txid </source>
         <translation>txid </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4978"/>
         <source>idx </source>
         <translation>idx </translation>
     </message>
@@ -2205,462 +2198,473 @@ din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4960"/>
+        <source>NOTE: This transaction is locked, see details with: show_transfer </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5110"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5183"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Några ägda utgångar har partiella nyckelavbildningar - import_multisig_info krävs)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>Currently selected account: [</source>
         <translation>Aktuellt valt konto: [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>Tag: </source>
         <translation>Tagg: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5188"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5190"/>
         <source>(No tag assigned)</source>
         <translation>(Ingen tagg tilldelad)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5200"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5202"/>
         <source>Balance per address:</source>
         <translation>Saldo per adress:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Unlocked balance</source>
         <translation>Upplåst saldo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
         <source>Outputs</source>
         <translation>Utgångar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5201"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5203"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5209"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5211"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>spent</source>
         <translation>spenderat</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>global index</source>
         <translation>globalt index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>tx id</source>
         <translation>tx-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>addr index</source>
         <translation>addr index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5314"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5332"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5334"/>
         <source>No incoming transfers</source>
         <translation>Inga inkommande överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5336"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5338"/>
         <source>No incoming available transfers</source>
         <translation>Inga inkommande tillgängliga överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5340"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5342"/>
         <source>No incoming unavailable transfers</source>
         <translation>Inga inkommande otillgängliga överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>payment</source>
         <translation>betalning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>transaction</source>
         <translation>transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>height</source>
         <translation>höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5366"/>
         <source>unlock time</source>
         <translation>upplåsningstid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5378"/>
         <source>No payments with id </source>
         <translation>Inga betalningar med ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5514"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5426"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5516"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6306"/>
         <source>failed to get blockchain height: </source>
         <translation>det gick inte att hämta blockkedjans höjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5522"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaktion %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5561"/>
         <source>failed to get output: </source>
         <translation>det gick inte att hämta utgång: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5567"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5569"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>utgångsnyckelns ursprungsblockhöjd får inte vara högre än blockkedjans höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5571"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5573"/>
         <source>
 Originating block heights: </source>
         <translation>
 Ursprungsblockhöjder: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5585"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5600"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Varning: Några ingångsnycklar som spenderas kommer från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5604"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, vilket kan bryta ringsignaturens anonymitet. Se till att detta är avsiktligt!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5642"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6254"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6547"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6258"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>Ring size must not be 0</source>
         <translation>Ringstorlek för inte vara 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6266"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6270"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6563"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>ringstorlek %uär för liten, minimum är %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5668"/>
         <source>wrong number of arguments</source>
         <translation>fel antal argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5796"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5798"/>
         <source>Warning: Unencrypted payment IDs will harm your privacy: ask the recipient to use subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5859"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5861"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6411"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Inga utgångar hittades, eller så är daemonen inte klar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6816"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
+        <source>.
+This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6820"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6834"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6836"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7164"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7175"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7182"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7168"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7186"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7191"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7195"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7199"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7869"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7897"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7976"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8184"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8160"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8185"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8172"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8197"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8173"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8198"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8192"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8217"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8832"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8833"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8858"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8834"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8859"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9024"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9004"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9029"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9016"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9041"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9022"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9047"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9050"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9028"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9053"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9062"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">Det gick inte att importera nyckelavbildningar: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9054"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9079"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9084"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
         <source>Transaction successfully saved to </source>
         <translation>Transaktionen sparades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>, txid </source>
         <translation>, txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9325"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9350"/>
         <source>Failed to save transaction to </source>
         <translation>Det gick inte att spara transaktion till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7014"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7018"/>
         <source>This is a watch only wallet</source>
         <translation>Detta är en granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9253"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9278"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation>En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9288"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9313"/>
         <source>Transaction ID not found</source>
         <translation>Transaktions-ID kunde inte hittas</translation>
     </message>
@@ -2686,16 +2690,16 @@ Varning: Några ingångsnycklar som spenderas kommer från </translation>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1374"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1490"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1571"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7068"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7105"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7410"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7494"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8842"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8919"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9070"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7008"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7072"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7414"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7498"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8867"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8987"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9095"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9135"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2924,7 +2928,7 @@ Varning: Några ingångsnycklar som spenderas kommer från </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2255"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5982"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5986"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3233,12 +3237,12 @@ Key Image, &quot;absolute&quot;, list of rings</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3394"/>
         <source>Wallet and key files found, loading...</source>
-        <translation>Plånbok och nyckelfil hittades, läser in …</translation>
+        <translation>Plånbok och nyckelfil hittades, läser in&#xa0;…</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Key file found but not wallet file. Regenerating...</source>
-        <translation>Nyckelfilen hittades men inte plånboksfilen. Återskapar …</translation>
+        <translation>Nyckelfilen hittades men inte plånboksfilen. Återskapar&#xa0;…</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3406"/>
@@ -3248,7 +3252,7 @@ Key Image, &quot;absolute&quot;, list of rings</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3425"/>
         <source>Generating new wallet...</source>
-        <translation>Skapar ny plånbok …</translation>
+        <translation>Skapar ny plånbok&#xa0;…</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3443"/>
@@ -3304,15 +3308,15 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3636"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3822"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6360"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7218"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7286"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7350"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7554"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8636"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8899"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5772"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6364"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7222"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7290"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7354"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8661"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8924"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
@@ -3399,7 +3403,7 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4779"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4832"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4917"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7258"/>
         <source>wallet is null</source>
         <translation>plånbok är null</translation>
     </message>
@@ -3458,8 +3462,8 @@ Key Image, &quot;absolute&quot;, list of rings</source>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4770"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5432"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8967"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5434"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8992"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>detta kommando kräver en betrodd daemon. Aktivera med --trusted-daemon</translation>
     </message>
@@ -3484,757 +3488,757 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation>blockkedjan kan inte sparas: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4992"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="4994"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5000"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5002"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5015"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5017"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5023"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5025"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5027"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5032"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5034"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5039"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5041"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5059"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5063"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5446"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5448"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5450"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5129"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5452"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5139"/>
         <source>refresh error: </source>
         <translation>fel vid uppdatering: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5187"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5194"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5196"/>
         <source>Balance: </source>
         <translation>Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5263"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5265"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>pubkey</source>
         <translation>publik nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5301"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>key image</source>
         <translation>nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7922"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7947"/>
         <source>unlocked</source>
         <translation>upplåst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5302"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5304"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>T</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5317"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5318"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5320"/>
         <source>locked</source>
         <translation>låst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5319"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5321"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5398"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5400"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5454"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5456"/>
         <source>failed to get spent status</source>
         <translation>det gick inte att hämta spenderstatus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5545"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>the same transaction</source>
         <translation>samma transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5603"/>
         <source>blocks that are temporally very close</source>
         <translation>block som ligger väldigt nära varandra i tiden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6299"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6387"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6656"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5820"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6660"/>
         <source>No payment id is included with this transaction. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5882"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5892"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5884"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5894"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5887"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5889"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6124"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6435"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6128"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6439"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6130"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6698"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6134"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6702"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6177"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6181"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6980"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6984"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8186"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8654"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8679"/>
         <source>Short payment IDs are to be used within an integrated address only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9482"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9484"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9493"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9518"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9501"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9526"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9505"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9530"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9537"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9515"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9521"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9546"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9533"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9540"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9541"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9566"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9583"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9589"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9565"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9590"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9569"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9577"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9579"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9594"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9602"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9604"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9620"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9645"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9621"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9646"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9623"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9648"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9627"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9652"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9631"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9634"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9659"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9635"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9660"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9661"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9691"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9676"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9701"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9721"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9705"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9730"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9711"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9736"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9726"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9751"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9743"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9766"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9791"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9771"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9796"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9790"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9815"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9797"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9834"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9847"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9872"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9882"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9863"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9888"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9878"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10013"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9918"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10038"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9902"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9927"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9915"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9940"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9925"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9950"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9935"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9960"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9946"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9971"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9958"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9983"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9972"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9997"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9986"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10011"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10031"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10030"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10055"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10037"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10062"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10088"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10080"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10105"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10097"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10122"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10109"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10134"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10138"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10144"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10169"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10166"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10191"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10185"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10210"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10202"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10227"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10207"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10232"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10237"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10220"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10245"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10236"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10261"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10257"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10282"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10262"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10287"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10268"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10293"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10292"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10317"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10308"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10333"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10315"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10340"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10321"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10346"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10339"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10364"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10363"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10388"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10440"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10465"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10445"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10470"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="10474"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7479"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7373"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7483"/>
         <source>Good signature</source>
         <translation>Godkänd signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7396"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7481"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7400"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7485"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7585"/>
         <source>Bad signature</source>
         <translation>Felaktig signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Standard address: </source>
         <translation>Standardadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8617"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8642"/>
         <source>failed to parse payment ID or address</source>
         <translation>det gick inte att parsa betalnings-ID eller adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8659"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8684"/>
         <source>failed to parse payment ID</source>
         <translation>det gick inte att parsa betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8677"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8702"/>
         <source>failed to parse index</source>
         <translation>det gick inte att parsa index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8685"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8710"/>
         <source>Address book is empty.</source>
         <translation>Adressboken är tom.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8716"/>
         <source>Index: </source>
         <translation>Index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8692"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8823"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8717"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8848"/>
         <source>Address: </source>
         <translation>Adress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8718"/>
         <source>Payment ID: </source>
         <translation>Betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8694"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8822"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8719"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8847"/>
         <source>Description: </source>
         <translation>Beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8852"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8877"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>plånboken är enbart för granskning och kan inte signera</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8892"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9124"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8891"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8917"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9149"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
@@ -4246,7 +4250,7 @@ Input %llu/%llu (%s): amount=%s</source>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="3945"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="4033"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5984"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5988"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4256,75 +4260,75 @@ Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7358"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7566"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7362"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7476"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7570"/>
         <source>failed to load signature file</source>
         <translation>det gick inte att läsa in signaturfil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7420"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7424"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation>plånboken är enbart för granskning och kan inte skapa beviset</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7504"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7508"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation>Beviset på reserv kan endast skapas av en standardplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7559"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7563"/>
         <source>Address must not be a subaddress</source>
         <translation>Adressen får inte vara en underadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7577"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7581"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation>Godkänd signatur -- summa: %s, spenderat: %s, ej spenderat: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7767"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7792"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation>[En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8045"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8070"/>
         <source>There is no unspent output in the specified address</source>
         <translation>Det finns ingen ej spenderad utgång i den angivna adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8242"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8267"/>
         <source> (no daemon)</source>
         <translation> (ingen daemon)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8244"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8269"/>
         <source> (out of sync)</source>
         <translation> (inte synkroniserad)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8295"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8320"/>
         <source>(Untitled account)</source>
         <translation>(Ej namngivet konto)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8326"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8333"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="8351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8374"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8543"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8376"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8399"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8545"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8568"/>
         <source>failed to parse index: </source>
         <translation>det gick inte att parsa index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8313"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8525"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8338"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8550"/>
         <source>specify an index between 0 and </source>
         <translation>ange ett index mellan 0 och </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>
 Grand total:
   Balance: </source>
@@ -4333,386 +4337,386 @@ Totalsumma:
   Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8456"/>
         <source>, unlocked balance: </source>
         <translation>, upplåst saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8439"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8464"/>
         <source>Untagged accounts:</source>
         <translation>Otaggade konton:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8470"/>
         <source>Tag %s is unregistered.</source>
         <translation>Taggen %s har inte registrerats.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8448"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8473"/>
         <source>Accounts with tag: </source>
         <translation>Konton med tagg: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8449"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8474"/>
         <source>Tag&apos;s description: </source>
         <translation>Taggens beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8451"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8476"/>
         <source>Account</source>
         <translation>Konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8457"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8482"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8467"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8492"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8468"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8493"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>Primary address</source>
         <translation>Primär adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8491"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8516"/>
         <source>(used)</source>
         <translation>(används)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8512"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8537"/>
         <source>(Untitled address)</source>
         <translation>(Ej namngiven adress)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8552"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8577"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation>&lt;index_min&gt; är redan utanför tillåtet intervall</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8557"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8582"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation>&lt;index_max&gt; är utanför tillåtet intervall</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8583"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8608"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8620"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation>Integrerade adresser kan bara skapas för konto 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8607"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8632"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation>Integrerad adress: %s, betalnings-ID: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8637"/>
         <source>Subaddress: </source>
         <translation>Underadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8779"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8804"/>
         <source>no description found</source>
         <translation>ingen beskrivning hittades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8781"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8806"/>
         <source>description found: </source>
         <translation>beskrivning hittades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8821"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8846"/>
         <source>Filename: </source>
         <translation>Filnamn: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8826"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8851"/>
         <source>Watch only</source>
         <translation>Endast granskning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8828"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8853"/>
         <source>%u/%u multisig%s</source>
         <translation>%u/%u multisig%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8830"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8855"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8831"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8856"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9647"/>
         <source>Type: </source>
         <translation>Typ: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8857"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8882"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation>Plånboken är multisig och kan inte signera</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8906"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8931"/>
         <source>Bad signature from </source>
         <translation>Felaktig signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8910"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8935"/>
         <source>Good signature from </source>
         <translation>Godkänd signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8929"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>plånboken är enbart för granskning och kan inte exportera nyckelavbildningar</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1252"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8943"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9091"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8968"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9116"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8954"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8979"/>
         <source>Signed key images exported to </source>
         <translation>Signerade nyckelavbildningar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9102"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9127"/>
         <source>Outputs exported to </source>
         <translation>Utgångar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5752"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8004"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8012"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5754"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7519"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8029"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>amount is wrong: </source>
         <translation>beloppet är fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5753"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6805"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="5755"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6809"/>
         <source>expected number from 0 to </source>
         <translation>förväntades: ett tal från 0 till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6122"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6126"/>
         <source>Sweeping </source>
         <translation>Sveper upp </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6738"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Pengar skickades, transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6937"/>
         <source>Change goes to more than one address</source>
         <translation>Växel går till fler än en adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6974"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6978"/>
         <source>%s change to %s</source>
         <translation>%s växel till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="6981"/>
         <source>no change</source>
         <translation>ingen växel</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1459"/>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7049"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaktionen signerades till fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7116"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7154"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7342"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7427"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8711"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7158"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7215"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7264"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7346"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7431"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7466"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8736"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8764"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9179"/>
         <source>failed to parse txid</source>
         <translation>det gick inte att parsa txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7136"/>
         <source>Tx key: </source>
         <translation>Tx-nyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7141"/>
         <source>no tx keys found for this txid</source>
         <translation>inga tx-nycklar kunde hittas för detta txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7229"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7530"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7233"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7445"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7534"/>
         <source>signature file saved to: </source>
         <translation>signaturfilen sparades till: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7231"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7443"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7447"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7536"/>
         <source>failed to save signature file</source>
         <translation>det gick inte att spara signaturfilen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7268"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7277"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7281"/>
         <source>failed to parse tx key</source>
         <translation>det gick inte att parsa txnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7235"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7323"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7405"/>
         <source>error: </source>
         <translation>fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>received</source>
         <translation>mottaget</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7299"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7372"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7303"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7376"/>
         <source>in txid</source>
         <translation>i txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7318"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7391"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7395"/>
         <source>received nothing in txid</source>
         <translation>tog emot ingenting i txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7302"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7375"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7306"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7379"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>VARNING: denna transaktion är ännu inte inkluderad i blockkedjan!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7381"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
         <source>This transaction has %u confirmations</source>
         <translation>Denna transaktion har %u bekräftelser</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7312"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7385"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7316"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7389"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>VARNING: det gick inte att bestämma antal bekräftelser!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7666"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7670"/>
         <source>bad min_height parameter:</source>
         <translation>felaktig parameter för min_höjd:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7678"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7682"/>
         <source>bad max_height parameter:</source>
         <translation>felaktig parameter för max_höjd:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7696"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7702"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8019"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8044"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_belopp&gt; måste vara mindre än &lt;max_belopp&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>
 Amount: </source>
         <translation>
 Belopp: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8051"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8076"/>
         <source>, number of keys: </source>
         <translation>, antal nycklar: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8056"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8081"/>
         <source> </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8061"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8086"/>
         <source>
 Min block height: </source>
         <translation>
 Minblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8087"/>
         <source>
 Max block height: </source>
         <translation>
 Maxblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8063"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>
 Min amount found: </source>
         <translation>
 Minbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8064"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8089"/>
         <source>
 Max amount found: </source>
         <translation>
 Maxbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8065"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>
 Total count: </source>
         <translation>
 Totalt antal: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8105"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8130"/>
         <source>
 Bin size: </source>
         <translation>
 Storlek för binge: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8106"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8131"/>
         <source>
 Outputs per *: </source>
         <translation>
 Utgångar per *: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8108"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8133"/>
         <source>count
   ^
 </source>
@@ -4721,52 +4725,52 @@ Utgångar per *: </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8110"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8137"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; blockhöjd
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8113"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8138"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8114"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8240"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8265"/>
         <source>wallet</source>
         <translation>plånbok</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="893"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8612"/>
         <source>Random payment ID: </source>
         <translation>Slumpmässigt betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8588"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="8613"/>
         <source>Matching integrated address: </source>
         <translation>Matchande integrerad adress: </translation>
     </message>
@@ -5214,44 +5218,44 @@ Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7595"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7597"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7599"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7601"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7605"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7603"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7604"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="7608"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9382"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9407"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9432"/>
         <source>Unknown command: </source>
         <translation type="unfinished">Okänt kommando: </translation>
     </message>
@@ -5332,7 +5336,7 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9401"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9426"/>
         <source>Failed to initialize wallet</source>
         <translation>Det gick inte att initiera plånbok</translation>
     </message>
@@ -5340,288 +5344,288 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="234"/>
+        <location filename="../src/wallet/wallet2.cpp" line="240"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Använd daemonen på &lt;värddator&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="235"/>
+        <location filename="../src/wallet/wallet2.cpp" line="241"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Använd daemonen på värddatorn &lt;arg&gt; istället för localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="240"/>
+        <location filename="../src/wallet/wallet2.cpp" line="246"/>
         <source>Wallet password file</source>
         <translation>Lösenordsfil för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="241"/>
+        <location filename="../src/wallet/wallet2.cpp" line="247"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Använd daemonen på port &lt;arg&gt; istället för 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>För testnet. Daemonen måste också startas med flaggan --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="361"/>
+        <location filename="../src/wallet/wallet2.cpp" line="372"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>det går inte ange värd eller port för daemonen mer än en gång</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="480"/>
+        <location filename="../src/wallet/wallet2.cpp" line="491"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>det går inte att ange fler än en av --password och --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="493"/>
+        <location filename="../src/wallet/wallet2.cpp" line="504"/>
         <source>the password file specified could not be read</source>
         <translation>det gick inte att läsa angiven lösenordsfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="519"/>
+        <location filename="../src/wallet/wallet2.cpp" line="530"/>
         <source>Failed to load file </source>
         <translation>Det gick inte att läsa in fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="239"/>
+        <location filename="../src/wallet/wallet2.cpp" line="245"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Lösenord för plånboken (använd escape-sekvenser eller citattecken efter behov)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="236"/>
+        <location filename="../src/wallet/wallet2.cpp" line="242"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="237"/>
+        <location filename="../src/wallet/wallet2.cpp" line="243"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">Aktivera kommandon som kräver en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="238"/>
+        <location filename="../src/wallet/wallet2.cpp" line="244"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="242"/>
+        <location filename="../src/wallet/wallet2.cpp" line="248"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Ange användarnamn[:lösenord] för RPC-klient till daemonen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="243"/>
+        <location filename="../src/wallet/wallet2.cpp" line="249"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="247"/>
+        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="248"/>
+        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="249"/>
+        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
+        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
+        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
+        <location filename="../src/wallet/wallet2.cpp" line="271"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
+        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
+        <location filename="../src/wallet/wallet2.cpp" line="274"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
+        <location filename="../src/wallet/wallet2.cpp" line="275"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="353"/>
+        <location filename="../src/wallet/wallet2.cpp" line="364"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="397"/>
+        <location filename="../src/wallet/wallet2.cpp" line="408"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="398"/>
+        <location filename="../src/wallet/wallet2.cpp" line="409"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="432"/>
+        <location filename="../src/wallet/wallet2.cpp" line="443"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="442"/>
+        <location filename="../src/wallet/wallet2.cpp" line="453"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="500"/>
+        <location filename="../src/wallet/wallet2.cpp" line="511"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>inget lösenord har angivits; använd --prompt-for-password för att fråga efter lösenord</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="502"/>
+        <location filename="../src/wallet/wallet2.cpp" line="513"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="525"/>
+        <location filename="../src/wallet/wallet2.cpp" line="536"/>
         <source>Failed to parse JSON</source>
         <translation>Det gick inte att parsa JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="532"/>
+        <location filename="../src/wallet/wallet2.cpp" line="543"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u är för ny, vi förstår bara upp till %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="548"/>
+        <location filename="../src/wallet/wallet2.cpp" line="559"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="553"/>
-        <location filename="../src/wallet/wallet2.cpp" line="621"/>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
+        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="632"/>
+        <location filename="../src/wallet/wallet2.cpp" line="677"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="564"/>
+        <location filename="../src/wallet/wallet2.cpp" line="575"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="569"/>
-        <location filename="../src/wallet/wallet2.cpp" line="631"/>
-        <location filename="../src/wallet/wallet2.cpp" line="692"/>
+        <location filename="../src/wallet/wallet2.cpp" line="580"/>
+        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="703"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="581"/>
+        <location filename="../src/wallet/wallet2.cpp" line="592"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="601"/>
+        <location filename="../src/wallet/wallet2.cpp" line="612"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="605"/>
+        <location filename="../src/wallet/wallet2.cpp" line="616"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Både ordlista av Electrum-typ och privat nyckel har angivits</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="615"/>
+        <location filename="../src/wallet/wallet2.cpp" line="626"/>
         <source>invalid address</source>
         <translation>ogiltig adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="624"/>
+        <location filename="../src/wallet/wallet2.cpp" line="635"/>
         <source>view key does not match standard address</source>
         <translation>granskningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="634"/>
+        <location filename="../src/wallet/wallet2.cpp" line="645"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="642"/>
+        <location filename="../src/wallet/wallet2.cpp" line="653"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Det går inte att skapa inaktuella plånböcker från JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="678"/>
+        <location filename="../src/wallet/wallet2.cpp" line="689"/>
         <source>failed to parse address: </source>
         <translation>det gick inte att parsa adressen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
+        <location filename="../src/wallet/wallet2.cpp" line="695"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>Adress måste anges för att kunna skapa granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="701"/>
+        <location filename="../src/wallet/wallet2.cpp" line="712"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1625"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1674"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1626"/>
+        <location filename="../src/wallet/wallet2.cpp" line="1675"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4122"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4712"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5308"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4171"/>
+        <location filename="../src/wallet/wallet2.cpp" line="4761"/>
+        <location filename="../src/wallet/wallet2.cpp" line="5357"/>
         <source>Primary account</source>
         <translation>Primärt konto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="10885"/>
+        <location filename="../src/wallet/wallet2.cpp" line="10893"/>
         <source>No funds received in this tx.</source>
         <translation>Inga pengar togs emot i denna tx.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11645"/>
+        <location filename="../src/wallet/wallet2.cpp" line="11653"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
@@ -5631,30 +5635,30 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="68"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
         <source>Enable SSL on wallet RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="69"/>
-        <location filename="../src/wallet/wallet2.cpp" line="244"/>
+        <location filename="../src/wallet/wallet2.cpp" line="250"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="70"/>
-        <location filename="../src/wallet/wallet2.cpp" line="245"/>
+        <location filename="../src/wallet/wallet2.cpp" line="251"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="71"/>
-        <location filename="../src/wallet/wallet2.cpp" line="246"/>
+        <location filename="../src/wallet/wallet2.cpp" line="252"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="72"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="73"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5662,126 +5666,126 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="192"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="191"/>
         <source>Failed to create directory </source>
         <translation>Det gick inte att skapa mapp </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="194"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="193"/>
         <source>Failed to create directory %s: %s</source>
         <translation>Det gick inte att skapa mapp %s: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source>Cannot specify --</source>
         <translation>Det går inte att ange --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="205"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="204"/>
         <source> and --</source>
         <translation> och --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>Failed to create file </source>
         <translation>Det gick inte att skapa fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="224"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="223"/>
         <source>. Check permissions or remove file</source>
         <translation>. Kontrollera behörigheter eller ta bort filen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="234"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>Error writing to file </source>
         <translation>Ett fel uppstod vid skrivning till fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="237"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="236"/>
         <source>RPC username/password is stored in file </source>
         <translation>Användarnamn/lösenord för RPC har sparats i fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="613"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="628"/>
         <source>Tag %s is unregistered.</source>
         <translation>Taggen %s har inte registrerats.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3242"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3260"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>Transaktion är inte möjlig. Endast tillgängligt %s, transaktionsbelopp %s = %s + %s (avgift)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4409"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4429"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Detta är RPC-plånboken för monero. Den måste ansluta till en Monero-
 daemon för att fungera korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4245"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4265"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Det går inte att ange fler än en av --wallet-file och --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4230"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4250"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4257"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4277"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Måste ange --wallet-file eller --generate-from-json eller --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4261"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4281"/>
         <source>Loading wallet...</source>
-        <translation>Läser in plånbok …</translation>
+        <translation>Läser in plånbok&#xa0;…</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4295"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4327"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4315"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4347"/>
         <source>Saving wallet...</source>
-        <translation>Sparar plånbok …</translation>
+        <translation>Sparar plånbok&#xa0;…</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4297"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4329"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4317"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4349"/>
         <source>Successfully saved</source>
         <translation>Plånboken sparades</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4300"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Successfully loaded</source>
         <translation>Plånboken lästes in</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
         <source>Wallet initialization failed: </source>
         <translation>Det gick inte att initiera plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4310"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4330"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Det gick inte att initiera RPC-servern för plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4314"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4334"/>
         <source>Starting wallet RPC server</source>
         <translation>Startar RPC-server för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4321"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4341"/>
         <source>Failed to run wallet: </source>
         <translation>Det gick inte att köra plånboken: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4324"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4344"/>
         <source>Stopped wallet RPC server</source>
         <translation>Stoppade RPC-server för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4333"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4353"/>
         <source>Failed to save wallet: </source>
         <translation>Det gick inte spara plånboken: </translation>
     </message>
@@ -5790,8 +5794,8 @@ daemon för att fungera korrekt.</translation>
     <name>wallet_args</name>
     <message>
         <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9348"/>
+        <location filename="../src/simplewallet/simplewallet.cpp" line="9373"/>
+        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4405"/>
         <source>Wallet options</source>
         <translation>Alternativ för plånbok</translation>
     </message>


### PR DESCRIPTION
- core: update pruning if using --prune-blockchain on a pruned blockchain
- core: do not commit half constructed batch db txn
- blockchain: do not try to pop blocks down to the genesis block
- ssl: fix allow any cert mode in wallet rpc when configured over rpc
- ssl: add ssl_options support to sumokoind's rpc mode
- wallet: fix configuration bug; wallet2 --daemon-ssl-allow-any-cert now works
- core: fix stale block template cache
- Update tests and translations

Up to upstream commit https://github.com/monero-project/monero/commit/256f8d8b66c161b928129e97a7b7b3b70bbebb2a
(branch release-v0.14)