### PR TITLE
[ALL] Various fixes and updates on SSL, miner, p2p, upnp and GCC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(NOT MANUAL_SUBMODULES)
       if (upToDate)
         message(STATUS "Submodule '${relative_path}' is up-to-date")
       else()
-#        message(FATAL_ERROR "Submodule '${relative_path}' is not up-to-date. Please update with\ngit submodule update --init --force ${relative_path}\nor run cmake with -DMANUAL_SUBMODULES=1")
+        message(FATAL_ERROR "Submodule '${relative_path}' is not up-to-date. Please update with\ngit submodule update --init --force ${relative_path}\nor run cmake with -DMANUAL_SUBMODULES=1")
       endif()
     endfunction ()
     
@@ -672,8 +672,11 @@ else()
     add_cxx_flag_if_supported(-fstack-clash-protection CXX_SECURITY_FLAGS)
   endif()
 
-  add_c_flag_if_supported(-mmitigate-rop C_SECURITY_FLAGS)
-  add_cxx_flag_if_supported(-mmitigate-rop CXX_SECURITY_FLAGS)
+  # Removed in GCC 9.1 (or before ?), but still accepted, so spams the output
+  if (NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
+    add_c_flag_if_supported(-mmitigate-rop C_SECURITY_FLAGS)
+    add_cxx_flag_if_supported(-mmitigate-rop CXX_SECURITY_FLAGS)
+  endif()
 
   # linker
   if (NOT WIN32)

--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.0.2q
+$(package)_version=1.0.2r
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684
+$(package)_sha256_hash=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -193,7 +193,6 @@ namespace net_utils
 								return CONNECT_FAILURE;
 							}
 						}
-						m_ssl_options.support = ssl_support_t::e_ssl_support_enabled;
 					}
 					return CONNECT_SUCCESS;
 				}else
@@ -223,7 +222,6 @@ namespace net_utils
 					return false;
 				if (m_ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
 				{
-					m_ssl_options.support = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
 					if (try_connect_result == CONNECT_NO_SSL)
 					{
 						MERROR("SSL handshake failed on an autodetect connection, reconnecting without SSL");
@@ -396,7 +394,7 @@ namespace net_utils
 			if (!m_connected || !m_ssl_socket->next_layer().is_open())
 				return false;
 			if (ssl)
-				*ssl = m_ssl_options.support == ssl_support_t::e_ssl_support_enabled;
+				*ssl = m_ssl_options.support != ssl_support_t::e_ssl_support_disabled;
 			return true;
 		}
 
@@ -651,7 +649,7 @@ namespace net_utils
 		bool write(const void* data, size_t sz, boost::system::error_code& ec)
 		{
 			bool success;
-			if(m_ssl_options.support == ssl_support_t::e_ssl_support_enabled)
+			if(m_ssl_options.support != ssl_support_t::e_ssl_support_disabled)
 				success = boost::asio::write(*m_ssl_socket, boost::asio::buffer(data, sz), ec);
 			else
 				success = boost::asio::write(m_ssl_socket->next_layer(), boost::asio::buffer(data, sz), ec);
@@ -660,7 +658,7 @@ namespace net_utils
 		
 		void async_write(const void* data, size_t sz, boost::system::error_code& ec) 
 		{
-			if(m_ssl_options.support == ssl_support_t::e_ssl_support_enabled)
+			if(m_ssl_options.support != ssl_support_t::e_ssl_support_disabled)
 				boost::asio::async_write(*m_ssl_socket, boost::asio::buffer(data, sz), boost::lambda::var(ec) = boost::lambda::_1);
 			else
 				boost::asio::async_write(m_ssl_socket->next_layer(), boost::asio::buffer(data, sz), boost::lambda::var(ec) = boost::lambda::_1);
@@ -668,7 +666,7 @@ namespace net_utils
 		
 		void async_read(char* buff, size_t sz, boost::asio::detail::transfer_at_least_t transfer_at_least, handler_obj& hndlr)
 		{
-			if(m_ssl_options.support != ssl_support_t::e_ssl_support_enabled)
+			if(m_ssl_options.support == ssl_support_t::e_ssl_support_disabled)
 				boost::asio::async_read(m_ssl_socket->next_layer(), boost::asio::buffer(buff, sz), transfer_at_least, hndlr);
 			else
 				boost::asio::async_read(*m_ssl_socket, boost::asio::buffer(buff, sz), transfer_at_least, hndlr);

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -294,6 +294,11 @@ namespace net_utils
                                m_max_speed_up(0)
     {}
 
+    connection_context_base(const connection_context_base& a): connection_context_base()
+    {
+      set_details(a.m_connection_id, a.m_remote_address, a.m_is_income, a.m_ssl);
+    }
+
     connection_context_base& operator=(const connection_context_base& a)
     {
       set_details(a.m_connection_id, a.m_remote_address, a.m_is_income, a.m_ssl);

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -64,7 +64,7 @@ namespace cryptonote
     static void init_options(boost::program_options::options_description& desc);
     bool set_block_template(const block& bl, const difficulty_type& diffic, uint64_t height, uint64_t block_reward);
     bool on_block_chain_update();
-    bool start(const account_public_address& adr, size_t threads_count, const boost::thread::attributes& attrs, bool do_background = false, bool ignore_battery = false);
+    bool start(const account_public_address& adr, size_t threads_count, bool do_background = false, bool ignore_battery = false);
     uint64_t get_speed() const;
     uint32_t get_threads_count() const;
     void send_stop_signal();

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -90,6 +90,20 @@ namespace hw {
       AKout = keys.AKout;
     }
 
+    ABPkeys &ABPkeys::operator=(const ABPkeys& keys) {
+      if (&keys == this)
+        return *this;
+      Aout = keys.Aout;
+      Bout = keys.Bout;
+      is_subaddress = keys.is_subaddress;
+      is_change_address = keys.is_change_address;
+      additional_key = keys.additional_key;
+      index = keys.index;
+      Pout = keys.Pout;
+      AKout = keys.AKout;
+      return *this;
+    }
+
     bool Keymap::find(const rct::key& P, ABPkeys& keys) const {
       size_t sz = ABP.size();
       for (size_t i=0; i<sz; i++) {

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -77,6 +77,7 @@ namespace hw {
         ABPkeys(const rct::key& A, const rct::key& B, const bool is_subaddr, bool is_subaddress, bool is_change_address, size_t index, const rct::key& P,const rct::key& AK);
         ABPkeys(const ABPkeys& keys) ;
         ABPkeys() {index=0;is_subaddress=false;is_subaddress=false;is_change_address=false;}
+        ABPkeys &operator=(const ABPkeys &keys);
     };
 
     class Keymap {

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -134,10 +134,11 @@ namespace boost
       a & port;
       a & length;
 
-      if (length > net::tor_address::buffer_size())
+      const size_t buffer_size = net::tor_address::buffer_size();
+      if (length > buffer_size)
         MONERO_THROW(net::error::invalid_tor_address, "Tor address too long");
 
-      char host[net::tor_address::buffer_size()] = {0};
+      char host[buffer_size] = {0};
       a.load_binary(host, length);
       host[sizeof(host) - 1] = 0;
 
@@ -155,10 +156,11 @@ namespace boost
       a & port;
       a & length;
 
-      if (length > net::i2p_address::buffer_size())
+      const size_t buffer_size = net::i2p_address::buffer_size();
+      if (length > buffer_size)
         MONERO_THROW(net::error::invalid_i2p_address, "i2p address too long");
 
-      char host[net::i2p_address::buffer_size()] = {0};
+      char host[buffer_size] = {0};
       a.load_binary(host, length);
       host[sizeof(host) - 1] = 0;
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -905,16 +905,13 @@ namespace cryptonote
       return true;
     }
 
-    boost::thread::attributes attrs;
-    attrs.set_stack_size(THREAD_STACK_SIZE);
-
     cryptonote::miner &miner= m_core.get_miner();
     if (miner.is_mining())
     {
       res.status = "Already mining";
       return true;
     }
-    if(!miner.start(info.address, static_cast<size_t>(req.threads_count), attrs, req.do_background_mining, req.ignore_battery))
+    if(!miner.start(info.address, static_cast<size_t>(req.threads_count), req.do_background_mining, req.ignore_battery))
     {
       res.status = "Failed, mining not started";
       LOG_PRINT_L0(res.status);

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -408,10 +408,7 @@ namespace rpc
       return;
     }
 
-    boost::thread::attributes attrs;
-    attrs.set_stack_size(THREAD_STACK_SIZE);
-
-    if(!m_core.get_miner().start(info.address, static_cast<size_t>(req.threads_count), attrs, req.do_background_mining, req.ignore_battery))
+    if(!m_core.get_miner().start(info.address, static_cast<size_t>(req.threads_count), req.do_background_mining, req.ignore_battery))
     {
       res.error_details = "Failed, mining not started";
       LOG_PRINT_L0(res.error_details);


### PR DESCRIPTION
- epee: fix SSL autodetect on reconnection
- miner: fix double free of thread attributes
- miniupnpc: update to build on BSD
- p2p: fix GCC 9.1 crash
- Fix GCC 9.1 build warnings
- cmake: do not use -mmitigate-rop on GCC >= 9.1

Up to upstream commit# https://github.com/monero-project/monero/commit/fd0cf689ddb62c07fa9d86ca6e070860c51669cc