### PR TITLE
[Wallet] Fix change subaddress mixup when sending pre rct outputs

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8124,6 +8124,7 @@ void wallet2::transfer_selected(const std::vector<cryptonote::tx_destination_ent
   if (needed_money < found_money)
   {
     change_dts.addr = get_subaddress({subaddr_account, 0});
+    change_dts.is_subaddress = subaddr_account != 0;
     change_dts.amount = found_money - needed_money;
   }
 


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/5672/commits/b2bfcab6182706cd55033ee539f88ce4dd07523b