### PR TITLE
[DEPENDS] Add ncurses package for linux and darwin readline

### DIFF
--- a/contrib/depends/packages/ncurses.mk
+++ b/contrib/depends/packages/ncurses.mk
@@ -1,0 +1,57 @@
+package=ncurses
+$(package)_version=6.1
+$(package)_download_path=https://ftp.gnu.org/gnu/ncurses
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17
+
+define $(package)_set_vars
+  $(package)_build_opts=CC="$($(package)_cc)"
+  $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
+  $(package)_config_env_darwin=RANLIB="$(host_prefix)/native/bin/x86_64-apple-darwin11-ranlib" AR="$(host_prefix)/native/bin/x86_64-apple-darwin11-ar" CC="$(host_prefix)/native/bin/$($(package)_cc)"
+  $(package)_config_opts=--prefix=$(host_prefix)
+  $(package)_config_opts+=--disable-shared
+  $(package)_config_opts+=--with-build-cc=gcc
+  $(package)_config_opts+=--without-debug
+  $(package)_config_opts+=--without-ada
+  $(package)_config_opts+=--without-cxx-binding
+  $(package)_config_opts+=--without-cxx
+  $(package)_config_opts+=--without-ticlib
+  $(package)_config_opts+=--without-tic
+  $(package)_config_opts+=--without-progs
+  $(package)_config_opts+=--without-tests
+  $(package)_config_opts+=--without-tack
+  $(package)_config_opts+=--without-manpages
+  $(package)_config_opts+=--disable-tic-depends
+  $(package)_config_opts+=--disable-big-strings
+  $(package)_config_opts+=--disable-ext-colors
+  $(package)_config_opts+=--enable-pc-files
+  $(package)_config_opts+=--host=$(HOST)
+  $(pacakge)_config_opts+=--without-shared
+  $(pacakge)_config_opts+=--without-pthread
+  $(pacakge)_config_opts+=--disable-rpath
+  $(pacakge)_config_opts+=--disable-colorfgbg
+  $(pacakge)_config_opts+=--disable-ext-colors
+  $(pacakge)_config_opts+=--disable-ext-mouse
+  $(pacakge)_config_opts+=--disable-symlinks
+  $(pacakge)_config_opts+=--enable-warnings
+  $(pacakge)_config_opts+=--enable-assertions
+  $(pacakge)_config_opts+=--disable-home-terminfo
+  $(pacakge)_config_opts+=--enable-database
+  $(pacakge)_config_opts+=--enable-sp-funcs
+  $(pacakge)_config_opts+=--enable-term-driver
+  $(pacakge)_config_opts+=--enable-interop
+  $(pacakge)_config_opts+=--enable-widec
+  $(package)_build_opts=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
+endef
+
+define $(package)_config_cmds
+  ./configure $($(package)_config_opts)
+endef
+
+define $(package)_build_cmds
+  $(MAKE) $($(package)_build_opts) V=1
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) install DESTDIR=$($(package)_staging_dir)
+endef

--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -1,20 +1,16 @@
-packages:=boost openssl zeromq cppzmq expat ldns readline libiconv hidapi protobuf libusb
+packages:=boost openssl zeromq cppzmq expat ldns libiconv hidapi protobuf libusb
 native_packages := native_ccache native_protobuf
 
 darwin_native_packages = native_biplist native_ds_store native_mac_alias
-darwin_packages = sodium-darwin
+darwin_packages = sodium-darwin ncurses readline
 
-linux_packages = eudev
+linux_packages = eudev ncurses readline unwind sodium
 qt_packages = qt
 
 ifeq ($(build_tests),ON)
 packages += gtest
 endif
 
-ifeq ($(host_os),linux)
-packages += unwind
-packages += sodium
-endif
 ifeq ($(host_os),mingw32)
 packages += icu4c
 packages += sodium

--- a/contrib/depends/packages/readline.mk
+++ b/contrib/depends/packages/readline.mk
@@ -3,19 +3,19 @@ $(package)_version=8.0
 $(package)_download_path=https://ftp.gnu.org/gnu/readline
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
+$(package)_dependencies=ncurses
 
 define $(package)_set_vars
-  $(package)_build_opts=CC="$($(package)_cc)"
-  $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
   $(package)_config_opts=--prefix=$(host_prefix)
-  $(package)_config_opts+=--disable-shared --enable-multibye --without-purify --without-curses
+  $(package)_config_opts+=--exec-prefix=$(host_prefix)
+  $(package)_config_opts+=--host=$(HOST)
+  $(package)_config_opts+=--disable-shared --with-curses
   $(package)_config_opts_release=--disable-debug-mode
+  $(package)_config_opts_darwin+=RANLIB="$(host_prefix)/native/bin/x86_64-apple-darwin11-ranlib" AR="$(host_prefix)/native/bin/x86_64-apple-darwin11-ar" CC="$(host_prefix)/native/bin/$($(package)_cc)"
   $(package)_build_opts=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
 endef
 
 define $(package)_config_cmds
-  export bash_cv_have_mbstate_t=yes &&\
-  export bash_cv_wcwidth_broken=yes &&\
   ./configure $($(package)_config_opts)
 endef
 
@@ -24,6 +24,6 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+  $(MAKE) install DESTDIR=$($(package)_staging_dir) prefix=$(host_prefix) exec-prefix=$(host_prefix)
 endef
 

--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -21,6 +21,8 @@ SET(ENV{PKG_CONFIG_PATH} @prefix@/lib/pkgconfig)
 SET(LRELEASE_PATH @prefix@/native/bin CACHE FILEPATH "path to lrelease" FORCE)
 
 SET(Readline_ROOT_DIR @prefix@)
+SET(Readline_INCLUDE_DIR @prefix@/include)
+SET(Termcap_LIBRARY @prefix@/lib/libncurses.a)
 
 SET(LIBUNWIND_INCLUDE_DIR @prefix@/include)
 SET(LIBUNWIND_LIBRARIES @prefix@/lib/libunwind.a)


### PR DESCRIPTION
Readline support is now compiled with the ncurses backend.

Ref: https://github.com/monero-project/monero/pull/5694/commits/48c26599e6da3528958c57ca849761b405f0dafd