### PR TITLE
[CRYPTO] Make heavy hash work at cross-compiling for MINGW (2)

### DIFF
--- a/src/crypto/cn_heavy_hash.hpp
+++ b/src/crypto/cn_heavy_hash.hpp
@@ -76,7 +76,7 @@
 #if defined(_MSC_VER)
 #define cpuid(info,x)    __cpuidex(info,x,0)
 #else
-void cpuid(int CPUInfo[4], int InfoType)
+inline void cpuid(int CPUInfo[4], int InfoType)
 {
     ASM __volatile__
     (


### PR DESCRIPTION
Let cpuid() function inline