### PR TITLE
[MISC] Fixes for get_bulk_payment, p2p, keccak, and depends

### DIFF
--- a/contrib/depends/packages/ncurses.mk
+++ b/contrib/depends/packages/ncurses.mk
@@ -53,7 +53,6 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  echo $($(package)_staging_dir) &&\
   $(MAKE) install DESTDIR=$($(package)_staging_dir)
 endef
 

--- a/contrib/depends/packages/readline.mk
+++ b/contrib/depends/packages/readline.mk
@@ -16,10 +16,6 @@ define $(package)_set_vars
 endef
 
 define $(package)_config_cmds
-  echo $(HOST) &&\
-  echo $($(package)_staging_dir) &&\
-  export bash_cv_have_mbstate_t=yes &&\
-  export bash_cv_wcwidth_broken=yes &&\
   ./configure $($(package)_config_opts)
 endef
 
@@ -28,8 +24,6 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  echo $($(package)_staging_dir) &&\
-  echo $(host_prefix) &&\
   $(MAKE) install DESTDIR=$($(package)_staging_dir) prefix=$(host_prefix) exec-prefix=$(host_prefix)
 endef
 

--- a/src/crypto/keccak.c
+++ b/src/crypto/keccak.c
@@ -105,9 +105,12 @@ void keccak(const uint8_t *in, size_t inlen, uint8_t *md, int mdlen)
     memset(st, 0, sizeof(st));
 
     for ( ; inlen >= rsiz; inlen -= rsiz, in += rsiz) {
-        for (i = 0; i < rsizw; i++)
-            st[i] ^= swap64le(((uint64_t *) in)[i]);
-        keccakf(st, KECCAK_ROUNDS);
+      for (i = 0; i < rsizw; i++) {
+        uint64_t ina;
+        memcpy(&ina, in + i * 8, 8);
+        st[i] ^= swap64le(ina);
+      }
+      keccakf(st, KECCAK_ROUNDS);
     }
     
     // last block and padding

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1227,19 +1227,53 @@ namespace nodetool
       size_t random_index;
       const uint32_t next_needed_pruning_stripe = m_payload_handler.get_next_needed_pruning_stripe().second;
 
+      // build a set of all the /16 we're connected to, and prefer a peer that's not in that set
+      std::set<uint32_t> classB;
+      if (&zone == &m_network_zones.at(epee::net_utils::zone::public_)) // at returns reference, not copy
+      {
+        zone.m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
+        {
+          if (cntxt.m_remote_address.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id())
+          {
+
+            const epee::net_utils::network_address na = cntxt.m_remote_address;
+            const uint32_t actual_ip = na.as<const epee::net_utils::ipv4_network_address>().ip();
+            classB.insert(actual_ip & 0x0000ffff);
+          }
+          return true;
+        });
+      }
+
       std::deque<size_t> filtered;
       const size_t limit = use_white_list ? 20 : std::numeric_limits<size_t>::max();
-      size_t idx = 0;
-      zone.m_peerlist.foreach (use_white_list, [&filtered, &idx, limit, next_needed_pruning_stripe](const peerlist_entry &pe){
-        if (filtered.size() >= limit)
-          return false;
-        if (next_needed_pruning_stripe == 0 || pe.pruning_seed == 0)
-          filtered.push_back(idx);
-        else if (next_needed_pruning_stripe == tools::get_pruning_stripe(pe.pruning_seed))
-          filtered.push_front(idx);
-        ++idx;
-        return true;
-      });
+      size_t idx = 0, skipped = 0;
+      for (int step = 0; step < 2; ++step)
+      {
+        bool skip_duplicate_class_B = step == 0;
+        zone.m_peerlist.foreach (use_white_list, [&classB, &filtered, &idx, &skipped, skip_duplicate_class_B, limit, next_needed_pruning_stripe](const peerlist_entry &pe){
+          if (filtered.size() >= limit)
+            return false;
+          bool skip = false;
+          if (skip_duplicate_class_B && pe.adr.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id())
+          {
+            const epee::net_utils::network_address na = pe.adr;
+            uint32_t actual_ip = na.as<const epee::net_utils::ipv4_network_address>().ip();
+            skip = classB.find(actual_ip & 0x0000ffff) != classB.end();
+          }
+          if (skip)
+            ++skipped;
+          else if (next_needed_pruning_stripe == 0 || pe.pruning_seed == 0)
+            filtered.push_back(idx);
+          else if (next_needed_pruning_stripe == tools::get_pruning_stripe(pe.pruning_seed))
+            filtered.push_front(idx);
+          ++idx;
+          return true;
+        });
+        if (skipped == 0 || !filtered.empty())
+          break;
+        if (skipped)
+          MGINFO("Skipping " << skipped << " possible peers as they share a class B with existing peers");
+      }
       if (filtered.empty())
       {
         MDEBUG("No available peer in " << (use_white_list ? "white" : "gray") << " list filtered by " << next_needed_pruning_stripe);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -820,6 +820,7 @@ namespace cryptonote
       res.sanity_check_failed = true;
       return true;
     }
+    res.sanity_check_failed = false;
 
     cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
     tx_verification_context tvc = AUTO_VAL_INIT(tvc);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1746,6 +1746,11 @@ namespace tools
       else if (payment_id_str.size() == 2 * sizeof(payment_id8))
       {
         r = epee::string_tools::hex_to_pod(payment_id_str, payment_id8);
+        if (r)
+        {
+          memcpy(payment_id.data, payment_id8.data, 8);
+          memset(payment_id.data + 8, 0, 24);
+        }
       }
       else
       {

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -519,6 +519,9 @@ class TransferTest():
         res = self.wallet[2].get_bulk_payments(payment_ids = ['1'*64, '1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde', '2'*64])
         assert len(res.payments) >= 1 # one tx was sent
 
+        res = self.wallet[1].get_bulk_payments(["1111111122222222"])
+        assert len(res.payments) >= 1 # we have one of these
+
     def check_double_spend_detection(self):
         print('Checking double spend detection')
         txes = [[None, None], [None, None]]

--- a/tests/unit_tests/keccak.cpp
+++ b/tests/unit_tests/keccak.cpp
@@ -148,3 +148,20 @@ TEST(keccak, 137_and_1_136)
   TEST_KECCAK(137, chunks);
 }
 
+TEST(keccak, alignment)
+{
+  uint8_t data[6064];
+  __attribute__ ((aligned(16))) char adata[6000];
+
+  for (size_t i = 0; i < sizeof(data) / sizeof(data[0]); ++i)
+    data[i] = i & 1;
+
+  uint8_t md[32], amd[32];
+  for (int offset = 0; offset < 64; ++offset)
+  {
+    memcpy(adata, data + offset, 6000);
+    keccak((const uint8_t*)&data[offset], 6000, md, 32);
+    keccak((const uint8_t*)adata, 6000, amd, 32);
+    ASSERT_TRUE(!memcmp(md, amd, 32));
+  }
+}


### PR DESCRIPTION
- wallet_rpc_server: fix get_bulk_payments with short payment ids
- p2p: don't connect to more than one IP per class B if we can\
- keccak: guard against misaligned memory accesses on ARM
- depends: further fixes for readline and ncurses

Up to upstream commit https://github.com/monero-project/monero/commit/fd3ff741644152ed559fcf79550435d3df75b764