### PR TITLE
[RPC] Bans for (bad) RPC connections

### DIFF
--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -577,6 +577,10 @@ namespace net_utils
 		if (query_info.m_http_method != http::http_method_options)
 		{
 			res = handle_request(query_info, response);
+			if (response.m_response_code == 500)
+			{
+				m_want_close = true;	// close on all "Internal server error"s
+			}
 		}
 		else
 		{

--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -71,7 +71,7 @@
       MINFO(m_conn_context << "calling " << s_pattern); \
       if(!callback_f(static_cast<command_type::request&>(req), static_cast<command_type::response&>(resp), &m_conn_context)) \
       { \
-        LOG_ERROR("Failed to " << #callback_f << "()"); \
+        MERROR(m_conn_context << "Failed to " << #callback_f << "()"); \
         response_info.m_response_code = 500; \
         response_info.m_response_comment = "Internal Server Error"; \
         return true; \
@@ -99,7 +99,7 @@
       MINFO(m_conn_context << "calling " << s_pattern); \
       if(!callback_f(static_cast<command_type::request&>(req), static_cast<command_type::response&>(resp), &m_conn_context)) \
       { \
-        LOG_ERROR("Failed to " << #callback_f << "()"); \
+        MERROR(m_conn_context << "Failed to " << #callback_f << "()"); \
         response_info.m_response_code = 500; \
         response_info.m_response_comment = "Internal Server Error"; \
         return true; \

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -138,6 +138,8 @@
 #define P2P_SUPPORT_FLAG_FLUFFY_BLOCKS                  0x01
 #define P2P_SUPPORT_FLAGS                               P2P_SUPPORT_FLAG_FLUFFY_BLOCKS
 
+#define RPC_IP_FAILS_BEFORE_BLOCK                       3
+
 #define ALLOW_DEBUG_COMMANDS
 
 #define CRYPTONOTE_NAME                         "sumokoin"

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -142,6 +142,7 @@ namespace cryptonote
   {
     m_restricted = restricted;
     m_net_server.set_threads_prefix("RPC");
+    m_net_server.set_connection_filter(&m_p2p);
 
     auto rpc_config = cryptonote::rpc_args::process(vm, true);
     if (!rpc_config)
@@ -170,6 +171,24 @@ namespace cryptonote
     if(!m_p2p.get_payload_object().is_synchronized())
     {
       return false;
+    }
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::add_host_fail(const connection_context *ctx)
+  {
+    if(!ctx || !ctx->m_remote_address.is_blockable())
+      return false;
+
+    CRITICAL_REGION_LOCAL(m_host_fails_score_lock);
+    uint64_t fails = ++m_host_fails_score[ctx->m_remote_address.host_str()];
+    MDEBUG("Host " << ctx->m_remote_address.host_str() << " fail score=" << fails);
+    if(fails > RPC_IP_FAILS_BEFORE_BLOCK)
+    {
+      auto it = m_host_fails_score.find(ctx->m_remote_address.host_str());
+      CHECK_AND_ASSERT_MES(it != m_host_fails_score.end(), false, "internal error");
+      it->second = RPC_IP_FAILS_BEFORE_BLOCK/2;
+      m_p2p.block_host(ctx->m_remote_address);
     }
     return true;
   }
@@ -300,6 +319,7 @@ namespace cryptonote
     if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.start_height, req.prune, !req.no_miner_tx, COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT))
     {
       res.status = "Failed";
+      add_host_fail(ctx);
       return false;
     }
 
@@ -423,6 +443,7 @@ namespace cryptonote
     if(!m_core.get_blockchain_storage().find_blockchain_supplement(req.block_ids, res.m_block_ids, res.start_height, res.current_height, false))
     {
       res.status = "Failed";
+      add_host_fail(ctx);
       return false;
     }
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -236,6 +236,7 @@ namespace cryptonote
 private:
     bool check_core_busy();
     bool check_core_ready();
+    bool add_host_fail(const connection_context *ctx);
     
     //utils
     uint64_t get_block_reward(const block& blk);
@@ -256,6 +257,8 @@ private:
     bool m_was_bootstrap_ever_used;
     network_type m_nettype;
     bool m_restricted;
+    epee::critical_section m_host_fails_score_lock;
+    std::map<std::string, uint64_t> m_host_fails_score;
   };
 }
 


### PR DESCRIPTION
- Make bans control RPC sessions too
- Auto-ban some bad requests. Drops HTTP connections whenever
response code is 500

Ref: https://github.com/monero-project/monero/pull/5649/commits/a182df21d0760e037219a6ae0a31b26b00489f22