### PR TITLE
[LMDB] Increase max_dbs from 20 to 32

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1329,7 +1329,7 @@ void BlockchainLMDB::open(const std::string& filename, const int db_flags)
   // set up lmdb environment
   if ((result = mdb_env_create(&m_env)))
     throw0(DB_ERROR(lmdb_error("Failed to create lmdb environment: ", result).c_str()));
-  if ((result = mdb_env_set_maxdbs(m_env, 20)))
+  if ((result = mdb_env_set_maxdbs(m_env, 32)))
     throw0(DB_ERROR(lmdb_error("Failed to set max number of dbs: ", result).c_str()));
 
   int threads = tools::get_max_concurrency();


### PR DESCRIPTION
A lot of new indices have been added recently, and 20 isn't enough
for them plus new DBs opened during format migrations.

Ref: https://github.com/monero-project/monero/pull/5817/commits/50ec40ea16f281690aeded37973dc582ddf38843