### PR TITLE
[Crypto] Fix for biased signature nonce

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -275,8 +275,6 @@ namespace crypto {
     buf.key = pub;
   try_again:
     random_scalar(k);
-    if (((const uint32_t*)(&k))[7] == 0) // we don't want tiny numbers here
-      goto try_again;
     ge_scalarmult_base(&tmp3, &k);
     ge_p3_tobytes(&buf.comm, &tmp3);
     hash_to_scalar(&buf, sizeof(s_comm), sig.c);


### PR DESCRIPTION
Small nonces were not mentioned in the QuarksLab report. The nonce
should be unbiased, so small values must be equally considered.

Ref: https://github.com/monero-project/monero/pull/5807/commits/4b1df4e50ffac182cae53d049b2ef4e0a5083340