### PR TITLE
[Crypto] CryptonightR_JIT: fix return value on error

### DIFF
--- a/src/crypto/CryptonightR_JIT.c
+++ b/src/crypto/CryptonightR_JIT.c
@@ -63,7 +63,7 @@ int v4_generate_JIT_code(const struct V4_Instruction* code, v4_random_math_JIT_f
 
 #if !(defined(_MSC_VER) || defined(__MINGW32__))
 	if (mprotect((void*)buf, buf_size, PROT_READ | PROT_WRITE))
-		return 1;
+		return -1;
 #endif
 
 	APPEND_CODE(prologue, sizeof(prologue));
@@ -111,13 +111,13 @@ int v4_generate_JIT_code(const struct V4_Instruction* code, v4_random_math_JIT_f
 
 #if !(defined(_MSC_VER) || defined(__MINGW32__))
 	if (mprotect((void*)buf, buf_size, PROT_READ | PROT_EXEC))
-		return 1;
+		return -1;
 #endif
 
 	__builtin___clear_cache((char*)buf, (char*)JIT_code);
 
 	return 0;
 #else
-	return 1;
+	return -1;
 #endif
 }


### PR DESCRIPTION
The value was positive rather than zero, but the caller only
checks for negative errors

Ref: https://github.com/monero-project/monero/pull/5731/commits/c393e824d6a571f969088d9bd99c5a899fbee353