### PR TITLE
[MMS] Use chans instead of normal addresses for auto-config

### DIFF
--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -397,10 +397,9 @@ void message_store::stop_auto_config()
   for (uint32_t i = 0; i < m_num_authorized_signers; ++i)
   {
     authorized_signer &m = m_signers[i];
-    if (!m.me && !m.auto_config_transport_address.empty())
+    if (!m.auto_config_transport_address.empty())
     {
-      // Try to delete those "unused API" addresses in PyBitmessage, especially since
-      // it seems it's not possible to delete them interactively, only to "disable" them
+      // Try to delete the chan that was used for auto-config
       m_transporter.delete_transport_address(m.auto_config_transport_address);
     }
     m.auto_config_token.clear();
@@ -429,14 +428,7 @@ void message_store::setup_signer_for_auto_config(uint32_t index, const std::stri
   m.auto_config_token = token;
   crypto::hash_to_scalar(token.data(), token.size(), m.auto_config_secret_key);
   crypto::secret_key_to_public_key(m.auto_config_secret_key, m.auto_config_public_key);
-  if (receiving)
-  {
-    m.auto_config_transport_address = m_transporter.derive_and_receive_transport_address(m.auto_config_token);
-  }
-  else
-  {
-    m.auto_config_transport_address = m_transporter.derive_transport_address(m.auto_config_token);
-  }
+  m.auto_config_transport_address = m_transporter.derive_transport_address(m.auto_config_token);
 }
 
 bool message_store::get_signer_index_by_monero_address(const cryptonote::account_public_address &monero_address, uint32_t &index) const

--- a/src/wallet/message_transporter.h
+++ b/src/wallet/message_transporter.h
@@ -91,7 +91,6 @@ public:
   bool delete_message(const std::string &transport_id);
   void stop() { m_run.store(false, std::memory_order_relaxed); }
   std::string derive_transport_address(const std::string &seed);
-  std::string derive_and_receive_transport_address(const std::string &seed);
   bool delete_transport_address(const std::string &transport_address);
 
 private:


### PR DESCRIPTION
Using the Bitmessage mechanism of chans instead of normal
addresses as the basis for the auto-config mechanism of
the MMS has advantages:

They are faster because no initial key exchange is needed -
everybody who knows the chan name knows already the key
(or better said, can derive the key from the chan name).

Especially in connection with the PyBitmessage app that the MMS
uses chans have another advantage over normal addresses: It's
possible to delete them manually if anything goes wrong and the MMS
has no chance to delete them automatically.

Just for completeness' sake it should be noted that one should not
bring this change into service exactly in the middle of an
already-running auto-config process.

Ref: https://github.com/monero-project/monero/pull/5778/commits/8703aa59db18918d6d6687c25a5461be3521adcf