### PR TITLE
On close() a connection delete it as well

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -927,7 +927,11 @@ bool async_protocol_handler_config<t_connection_context>::close(boost::uuids::uu
 {
   CRITICAL_REGION_LOCAL(m_connects_lock);
   async_protocol_handler<t_connection_context>* aph = find_connection(connection_id);
-  return 0 != aph ? aph->close() : false;
+  if (aph) {
+    del_connection(aph);
+    return aph->close();
+  }
+  return false;
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>


### PR DESCRIPTION
Without this change a connection that is explicitly close()d is not
properly deleted and so hangs around erroneously in the list of
connections (as a `before_handshake`) even though it is actually closed.
From:
https://github.com/loki-project/loki/commit/9a4c1262d49505812d1b8d2d0307c4f5d5a9474b