### PR TITLE
Don't count pingback connections as out conns

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -864,7 +864,10 @@ namespace nodetool
             }
             else
             {
-              ++number_of_out_peers;
+              // If this is a new (<10s) connection and we're still in before handshake mode then
+              // don't count it yet: it is probably a back ping connection that will be closed soon.
+              if (!(cntxt.m_state == p2p_connection_context::state_before_handshake && std::time(NULL) < cntxt.m_started + 10))
+                ++number_of_out_peers;
             }
             return true;
           }); // lambda


### PR DESCRIPTION
When an incoming peer connects, the daemon establishes an outbound peer
connection to ping the remote to see if its advertised p2p port works
before adding to the whitelist.
These aren't really outbound peers, though, and will never get beyond
the handshake stage, so don't count them as outs (unless they hang
around for at least 10 seconds), so that we don't kill *good* outbound
peers when we think we have too many outgoing p2p connections.
From:
https://github.com/loki-project/loki/commit/73577194863d55f48c2f4b6b7150ab17bc711812