### PR TITLE
Glitch fix of syncing display in Linux

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -472,7 +472,7 @@ void lmdb_resized(MDB_env *env)
   mdb_env_info(env, &mei);
   uint64_t new_mapsize = mei.me_mapsize;
 
-  MGINFO("LMDB Mapsize increased." << "  Old: " << old / (1024 * 1024) << "MiB" << ", New: " << new_mapsize / (1024 * 1024) << "MiB");
+  MGINFO("LMDB Mapsize increased." << "  Old: " << old / (1024 * 1024) << "MiB" << ", New: " << new_mapsize / (1024 * 1024) << "MiB" << "\033[K");
 
   mdb_txn_safe::allow_new_txns();
 }
@@ -566,7 +566,7 @@ void BlockchainLMDB::do_resize(uint64_t increase_size)
   if (result)
     throw0(DB_ERROR(lmdb_error("Failed to set new mapsize: ", result).c_str()));
 
-  MGINFO("LMDB Mapsize increased." << "  Old: " << mei.me_mapsize / (1024 * 1024) << "MiB" << ", New: " << new_mapsize / (1024 * 1024) << "MiB");
+  MGINFO("LMDB Mapsize increased." << "  Old: " << mei.me_mapsize / (1024 * 1024) << "MiB" << ", New: " << new_mapsize / (1024 * 1024) << "MiB" << "\033[K");
 
   mdb_txn_safe::allow_new_txns();
 }
@@ -646,7 +646,7 @@ void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint6
   // size-based check
   if (need_resize(threshold_size))
   {
-    MGINFO("[batch] DB resize needed");
+    MGINFO("[batch] DB resize needed" << "\033[K");
     do_resize(increase_size);
   }
 }

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -564,7 +564,7 @@ bool load_txt_records_from_dns(std::vector<std::string> &good_records, const std
 
   if (num_valid_records < 2)
   {
-    LOG_PRINT_L0("WARNING: no two valid DNS TXT records were received");
+    LOG_PRINT_L0("WARNING: no two valid DNS TXT records were received" << "\033[K");
     return false;
   }
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2399,7 +2399,7 @@ skip:
       MINFO("Target height decreasing from " << previous_target << " to " << target);
       m_core.set_target_blockchain_height(target);
       if (target == 0 && context.m_state > cryptonote_connection_context::state_before_handshake && !m_stopping)
-        MCWARNING("global", "sumokoind is now disconnected from the network");
+        MCWARNING("global", "sumokoind is now disconnected from the network" << "\033[K");
     }
 
     m_block_queue.flush_spans(context.m_connection_id, false);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1425,7 +1425,7 @@ namespace nodetool
         if (skipped == 0 || !filtered.empty())
           break;
         if (skipped)
-          MGINFO("Skipping " << skipped << " possible peers as they share a class B with existing peers");
+          MGINFO("Skipping " << skipped << " possible peers as they share a class B with existing peers" << "\033[K");
       }
       if (filtered.empty())
       {


### PR DESCRIPTION
Use \033[K ANSI escape sequence (erase to the end of the line) instead of spaces to remove left over chars from the cursor return