### PR TITLE
[DAEMON] Automatic bootstrap daemon switching

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -30,6 +30,7 @@ set(rpc_base_sources
   rpc_args.cpp)
 
 set(rpc_sources
+  bootstrap_daemon.cpp
   core_rpc_server.cpp
   rpc_handler.cpp
   instanciations)
@@ -53,6 +54,7 @@ set(daemon_rpc_server_headers)
 
 
 set(rpc_daemon_private_headers
+  bootstrap_daemon.h
   core_rpc_server.h
   core_rpc_server_commands_defs.h
   core_rpc_server_error_codes.h)

--- a/src/rpc/bootstrap_daemon.cpp
+++ b/src/rpc/bootstrap_daemon.cpp
@@ -1,0 +1,95 @@
+#include "bootstrap_daemon.h"
+
+#include <stdexcept>
+
+#include "crypto/crypto.h"
+#include "cryptonote_core/cryptonote_core.h"
+#include "misc_log_ex.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "daemon.rpc.bootstrap_daemon"
+
+namespace cryptonote
+{
+
+  bootstrap_daemon::bootstrap_daemon(std::function<boost::optional<std::string>()> get_next_public_node) noexcept
+    : m_get_next_public_node(get_next_public_node)
+  {
+  }
+
+  bootstrap_daemon::bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials)
+    : bootstrap_daemon(nullptr)
+  {
+    if (!set_server(address, credentials))
+    {
+      throw std::runtime_error("invalid bootstrap daemon address or credentials");
+    }
+  }
+
+  std::string bootstrap_daemon::address() const noexcept
+  {
+    const auto& host = m_http_client.get_host();
+    if (host.empty())
+    {
+      return std::string();
+    }
+    return host + ":" + m_http_client.get_port();
+  }
+
+  boost::optional<uint64_t> bootstrap_daemon::get_height()
+  {
+    cryptonote::COMMAND_RPC_GET_HEIGHT::request req;
+    cryptonote::COMMAND_RPC_GET_HEIGHT::response res;
+
+    if (!invoke_http_json("/getheight", req, res))
+    {
+      return boost::none;
+    }
+
+    if (res.status != CORE_RPC_STATUS_OK)
+    {
+      return boost::none;
+    }
+
+    return res.height;
+  }
+
+  bool bootstrap_daemon::handle_result(bool success)
+  {
+    if (!success && m_get_next_public_node)
+    {
+      m_http_client.disconnect();
+    }
+
+    return success;
+  }
+
+  bool bootstrap_daemon::set_server(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials /* = boost::none */)
+  {
+    if (!m_http_client.set_server(address, credentials))
+    {
+      MERROR("Failed to set bootstrap daemon address " << address);
+      return false;
+    }
+
+    MINFO("Changed bootstrap daemon address to " << address);
+    return true;
+  }
+
+
+  bool bootstrap_daemon::switch_server_if_needed()
+  {
+    if (!m_get_next_public_node || m_http_client.is_connected())
+    {
+      return true;
+    }
+
+    const boost::optional<std::string> address = m_get_next_public_node();
+    if (address) {
+      return set_server(*address);
+    }
+
+    return false;
+  }
+
+}

--- a/src/rpc/bootstrap_daemon.h
+++ b/src/rpc/bootstrap_daemon.h
@@ -1,0 +1,67 @@
+#pragma  once
+
+#include <functional>
+#include <vector>
+
+#include <boost/optional/optional.hpp>
+#include <boost/utility/string_ref.hpp>
+
+#include "net/http_client.h"
+#include "storages/http_abstract_invoke.h"
+
+namespace cryptonote
+{
+
+  class bootstrap_daemon
+  {
+  public:
+    bootstrap_daemon(std::function<boost::optional<std::string>()> get_next_public_node) noexcept;
+    bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials);
+
+    std::string address() const noexcept;
+    boost::optional<uint64_t> get_height();
+    bool handle_result(bool success);
+
+    template <class t_request, class t_response>
+    bool invoke_http_json(const boost::string_ref uri, const t_request &out_struct, t_response &result_struct)
+    {
+      if (!switch_server_if_needed())
+      {
+        return false;
+      }
+
+      return handle_result(epee::net_utils::invoke_http_json(uri, out_struct, result_struct, m_http_client));
+    }
+
+    template <class t_request, class t_response>
+    bool invoke_http_bin(const boost::string_ref uri, const t_request &out_struct, t_response &result_struct)
+    {
+      if (!switch_server_if_needed())
+      {
+        return false;
+      }
+
+      return handle_result(epee::net_utils::invoke_http_bin(uri, out_struct, result_struct, m_http_client));
+    }
+
+    template <class t_request, class t_response>
+    bool invoke_http_json_rpc(const boost::string_ref command_name, const t_request &out_struct, t_response &result_struct)
+    {
+      if (!switch_server_if_needed())
+      {
+        return false;
+      }
+
+      return handle_result(epee::net_utils::invoke_http_json_rpc("/json_rpc", std::string(command_name.begin(), command_name.end()), out_struct, result_struct, m_http_client));
+    }
+
+  private:
+    bool set_server(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials = boost::none);
+    bool switch_server_if_needed();
+
+  private:
+    epee::net_utils::http::http_simple_client m_http_client;
+    std::function<boost::optional<std::string>()> m_get_next_public_node;
+  };
+
+}

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -116,20 +116,59 @@ namespace cryptonote
     return set_bootstrap_daemon(address, credentials);
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  boost::optional<std::string> core_rpc_server::get_random_public_node()
+  {
+    COMMAND_RPC_GET_PUBLIC_NODES::request request;
+    COMMAND_RPC_GET_PUBLIC_NODES::response response;
+
+    request.gray = true;
+    request.white = true;
+    if (!on_get_public_nodes(request, response) || response.status != CORE_RPC_STATUS_OK)
+    {
+      return boost::none;
+    }
+
+    const auto get_random_node_address = [](const std::vector<public_node>& public_nodes) -> std::string {
+      const auto& random_node = public_nodes[crypto::rand_idx(public_nodes.size())];
+      const auto address = random_node.host + ":" + std::to_string(random_node.rpc_port);
+      return address;
+    };
+
+    if (!response.white.empty())
+    {
+      return get_random_node_address(response.white);
+    }
+
+    MDEBUG("No white public node found, checking gray peers");
+
+    if (!response.gray.empty())
+    {
+      return get_random_node_address(response.gray);
+    }
+
+    MERROR("Failed to find any suitable public node");
+
+    return boost::none;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::set_bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials)
   {
     boost::unique_lock<boost::shared_mutex> lock(m_bootstrap_daemon_mutex);
 
-    if (!address.empty())
+    if (address.empty())
     {
-      if (!m_http_client.set_server(address, credentials, epee::net_utils::ssl_support_t::e_ssl_support_autodetect))
-      {
-        return false;
-      }
+      m_bootstrap_daemon.reset(nullptr);
+    }
+    else if (address == "auto")
+    {
+      m_bootstrap_daemon.reset(new bootstrap_daemon([this]{ return get_random_public_node(); }));
+    }
+    else
+    {
+      m_bootstrap_daemon.reset(new bootstrap_daemon(address, credentials));
     }
 
-    m_bootstrap_daemon_address = address;
-    m_should_use_bootstrap_daemon = !m_bootstrap_daemon_address.empty();
+    m_should_use_bootstrap_daemon = m_bootstrap_daemon.get() != nullptr;
 
     return true;
   }
@@ -220,7 +259,10 @@ namespace cryptonote
     {
       {
         boost::shared_lock<boost::shared_mutex> lock(m_bootstrap_daemon_mutex);
-        res.bootstrap_daemon_address = m_bootstrap_daemon_address;
+        if (m_bootstrap_daemon.get() != nullptr)
+        {
+          res.bootstrap_daemon_address = m_bootstrap_daemon->address();
+        }
       }
       crypto::hash top_hash;
       m_core.get_blockchain_top(res.height_without_bootstrap, top_hash);
@@ -269,7 +311,10 @@ namespace cryptonote
     else
     {
       boost::shared_lock<boost::shared_mutex> lock(m_bootstrap_daemon_mutex);
-      res.bootstrap_daemon_address = m_bootstrap_daemon_address;
+      if (m_bootstrap_daemon.get() != nullptr)
+      {
+        res.bootstrap_daemon_address = m_bootstrap_daemon->address();
+      }
       res.was_bootstrap_ever_used = m_was_bootstrap_ever_used;
     }
     res.database_size = m_core.get_blockchain_storage().get_db().get_database_size();
@@ -1592,8 +1637,10 @@ namespace cryptonote
 
     boost::upgrade_lock<boost::shared_mutex> upgrade_lock(m_bootstrap_daemon_mutex);
 
-    if (m_bootstrap_daemon_address.empty())
+    if (m_bootstrap_daemon.get() == nullptr)
+    {
       return false;
+    }
 
     if (!m_should_use_bootstrap_daemon)
     {
@@ -1609,42 +1656,38 @@ namespace cryptonote
         m_bootstrap_height_check_time = current_time;
       }
 
-      uint64_t top_height;
-      crypto::hash top_hash;
-      m_core.get_blockchain_top(top_height, top_hash);
-      ++top_height; // turn top block height into blockchain height
+      boost::optional<uint64_t> bootstrap_daemon_height = m_bootstrap_daemon->get_height();
+      if (!bootstrap_daemon_height)
+      {
+        MERROR("Failed to fetch bootstrap daemon height");
+        return false;
+      }
 
-      // query bootstrap daemon's height
-      cryptonote::COMMAND_RPC_GET_HEIGHT::request getheight_req;
-      cryptonote::COMMAND_RPC_GET_HEIGHT::response getheight_res;
-      bool ok = epee::net_utils::invoke_http_json("/getheight", getheight_req, getheight_res, m_http_client);
-      ok = ok && getheight_res.status == CORE_RPC_STATUS_OK;
+      uint64_t target_height = m_core.get_target_blockchain_height();
+      if (*bootstrap_daemon_height < target_height)
+      {
+        MINFO("Bootstrap daemon is out of sync");
+        return m_bootstrap_daemon->handle_result(false);
+      }
 
-      m_should_use_bootstrap_daemon = ok && top_height + 10 < getheight_res.height;
-      MINFO((m_should_use_bootstrap_daemon ? "Using" : "Not using") << " the bootstrap daemon (our height: " << top_height << ", bootstrap daemon's height: " << (ok ? getheight_res.height : 0) << ")");
+      uint64_t top_height = m_core.get_current_blockchain_height();
+      m_should_use_bootstrap_daemon = top_height + 10 < *bootstrap_daemon_height;
+      MINFO((m_should_use_bootstrap_daemon ? "Using" : "Not using") << " the bootstrap daemon (our height: " << top_height << ", bootstrap daemon's height: " << *bootstrap_daemon_height << ")");
     }
     if (!m_should_use_bootstrap_daemon)
       return false;
 
     if (mode == invoke_http_mode::JON)
     {
-      r = epee::net_utils::invoke_http_json(command_name, req, res, m_http_client);
+      r = m_bootstrap_daemon->invoke_http_json(command_name, req, res);
     }
     else if (mode == invoke_http_mode::BIN)
     {
-      r = epee::net_utils::invoke_http_bin(command_name, req, res, m_http_client);
+      r = m_bootstrap_daemon->invoke_http_bin(command_name, req, res);
     }
     else if (mode == invoke_http_mode::JON_RPC)
     {
-      epee::json_rpc::request<typename COMMAND_TYPE::request> json_req = AUTO_VAL_INIT(json_req);
-      epee::json_rpc::response<typename COMMAND_TYPE::response, std::string> json_resp = AUTO_VAL_INIT(json_resp);
-      json_req.jsonrpc = "2.0";
-      json_req.id = epee::serialization::storage_entry(0);
-      json_req.method = command_name;
-      json_req.params = req;
-      r = net_utils::invoke_http_json("/json_rpc", json_req, json_resp, m_http_client);
-      if (r)
-        res = json_resp.result;
+      r = m_bootstrap_daemon->invoke_http_json_rpc(command_name, req, res);
     }
     else
     {
@@ -2617,7 +2660,8 @@ namespace cryptonote
 
   const command_line::arg_descriptor<std::string> core_rpc_server::arg_bootstrap_daemon_address = {
       "bootstrap-daemon-address"
-    , "URL of a 'bootstrap' remote daemon that the connected wallets can use while this daemon is still not fully synced"
+    , "URL of a 'bootstrap' remote daemon that the connected wallets can use while this daemon is still not fully synced.\n"
+      "Use 'auto' to enable automatic public nodes discovering and bootstrap daemon switching"
     , ""
     };
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -30,9 +30,12 @@
 
 #pragma  once 
 
+#include <memory>
+
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
+#include "bootstrap_daemon.h"
 #include "net/http_server_impl_base.h"
 #include "net/http_client.h"
 #include "core_rpc_server_commands_defs.h"
@@ -243,6 +246,7 @@ private:
     //utils
     uint64_t get_block_reward(const block& blk);
     bool fill_block_header_response(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_response& response, bool fill_pow_hash);
+    boost::optional<std::string> get_random_public_node();
     bool set_bootstrap_daemon(const std::string &address, const std::string &username_password);
     bool set_bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials);
     enum invoke_http_mode { JON, BIN, JON_RPC };
@@ -251,9 +255,8 @@ private:
     
     core& m_core;
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >& m_p2p;
-    std::string m_bootstrap_daemon_address;
-    epee::net_utils::http::http_simple_client m_http_client;
     boost::shared_mutex m_bootstrap_daemon_mutex;
+    std::unique_ptr<bootstrap_daemon> m_bootstrap_daemon;
     bool m_should_use_bootstrap_daemon;
     std::chrono::system_clock::time_point m_bootstrap_height_check_time;
     bool m_was_bootstrap_ever_used;


### PR DESCRIPTION
Implemented `--bootstrap-daemon-address auto` mode.

Allows to sync and use the wallet while the daemon is syncing with
the network.

* **While the daemon is syncing**
  it will automatically select random public node (node that is
running with `--public-node` mode enabled) to serve incoming
requests (i.e. will use it as a remote node). If currently
selected public node fails, the daemon will switch to another
randomly chosen public node.

* **Once the daemon is fully synced**
  it will use the local blockchain to serve incoming requests,
i.e. operating in normal mode.

Ref: https://github.com/monero-project/monero/pull/5799/commits/082730b6e569e155988df5c5b376c45fba56b396