### PR TITLE
[CORE] Tone down the warning of excessive blocks

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1852,7 +1852,7 @@ namespace cryptonote
     const time_t now = time(NULL);
     const std::vector<time_t> timestamps = m_blockchain_storage.get_last_block_timestamps(60);
 
-    static const unsigned int seconds[] = { 5400, 3600, 1800, 1200, 600 };
+    static const unsigned int seconds[] = { 5400, 3600, 2700, 1800, 900 };
     for (size_t n = 0; n < sizeof(seconds)/sizeof(seconds[0]); ++n)
     {
       unsigned int b = 0;


### PR DESCRIPTION
Tone it down a bit so it starts hitting from 15 minutes instead of 10 minutes (intervals were 10, 20, 30, 60, 90 minutes - i changed it to 15, 30, 45, 60, 90 minutes).

I did so cause we have twice the difficulty retargeting of Monero (4 minutes instead of 2) so in the function that calculates the probability 
 ```
const time_t time_boundary = now - static_cast<time_t>(seconds[n]);
      for (time_t ts: timestamps) b += ts >= time_boundary;
      const double p = probability(b, seconds[n] / DIFFICULTY_TARGET);

```
the numerator (where time in seconds is ) should be multiplied by 2 since the denominator is twice as big in sumo. I use 15 minutes as starting point instead of 20 just to be safe, you can double the initial argument
`static const unsigned int seconds[] = { 5400, 3600, 1800, 1200, 600 };`    to
`static const unsigned int seconds[] = { 10800, 7200, 3600, 2400, 1200 };`
if you want to be accurate.

Our diff algo is more sensitive as well and also since sumokoin is very profitable to mine many opportunistic miners jump in when diff hits a low point to get blocks fast, triggering the warning constantly.
I wrote an entire book for something trivial :D