### PR TITLE
[CORE] Important!!! change shared-ringdb folder to sumo

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -139,7 +139,7 @@ static std::string get_default_db_path()
   boost::filesystem::path dir = tools::get_default_data_dir();
   // remove .bitmonero, replace with .shared-ringdb
   dir = dir.remove_filename();
-  dir /= ".shared-ringdb";
+  dir /= ".sumo-shared-ringdb";
   return dir.string();
 }
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -74,7 +74,7 @@ namespace {
       boost::filesystem::path dir = tools::get_default_data_dir();
       // remove .bitmonero, replace with .shared-ringdb
       dir = dir.remove_filename();
-      dir /= ".shared-ringdb";
+      dir /= ".sumo-shared-ringdb";
       if (nettype == cryptonote::TESTNET)
         dir /= "testnet";
       else if (nettype == cryptonote::STAGENET)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -151,7 +151,7 @@ namespace
     boost::filesystem::path dir = tools::get_default_data_dir();
     // remove .bitmonero, replace with .shared-ringdb
     dir = dir.remove_filename();
-    dir /= ".shared-ringdb";
+    dir /= ".sumo-shared-ringdb";
     return dir.string();
   }
 


### PR DESCRIPTION
Change shared-ringdb folder name to sumo-shared-ringdb cause if someone uses the same machine to run monero or any other monero fork that hasnt changed the name the shared-ringdb folder gets overwritten (it is created in /root)