### PR TITLE
[P2P] Inform when remote is on a different version

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1030,11 +1030,11 @@ namespace nodetool
       
       if (rsp.node_data.version.size() == 0)
       {
-        MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+        MGINFO_BLUE("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
       }
       else if (rsp.node_data.version.size() != 0 && rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " has a different version than ours: " << rsp.node_data.version);
+        MGINFO_BLUE("Peer " << context.m_remote_address.str() << " has a different version than ours: " << rsp.node_data.version);
       }
 
       if(rsp.node_data.network_id != m_network_id)
@@ -2299,12 +2299,12 @@ namespace nodetool
   {
     if (arg.node_data.version.size() == 0)
     {
-      MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+      MGINFO_BLUE("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
     }
 
     if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
     {
-      MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " has a different version than ours: " << arg.node_data.version);
+      MGINFO_BLUE("Peer " << context.m_remote_address.str() << " has a different version than ours: " << arg.node_data.version);
     }
 
     if(arg.node_data.network_id != m_network_id)

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1027,6 +1027,15 @@ namespace nodetool
         LOG_WARNING_CC(context, "COMMAND_HANDSHAKE invoke failed. (" << code <<  ", " << epee::levin::get_err_descr(code) << ")");
         return;
       }
+      
+      if (rsp.node_data.version.size() == 0)
+      {
+        MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+      }
+      else if (rsp.node_data.version.size() != 0 && rsp.node_data.version != SUMOKOIN_VERSION)
+      {
+        MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " has a different version than ours: " << rsp.node_data.version);
+      }
 
       if(rsp.node_data.network_id != m_network_id)
       {
@@ -1898,6 +1907,7 @@ namespace nodetool
     time(&local_time);
     node_data.local_time = local_time; // \TODO This can be an identifying value across zones (public internet to tor/i2p) ...
     node_data.peer_id = zone.m_config.m_peer_id;
+    node_data.version = SUMOKOIN_VERSION;
     if(!m_hide_my_port && zone.m_can_pingback)
       node_data.my_port = m_external_port ? m_external_port : m_listening_port;
     else
@@ -2287,6 +2297,16 @@ namespace nodetool
   template<class t_payload_net_handler>
   int node_server<t_payload_net_handler>::handle_handshake(int command, typename COMMAND_HANDSHAKE::request& arg, typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
   {
+    if (arg.node_data.version.size() == 0)
+    {
+      MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+    }
+
+    if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
+    {
+      MGINFO_MAGENTA("Peer " << context.m_remote_address.str() << " has a different version than ours: " << arg.node_data.version);
+    }
+
     if(arg.node_data.network_id != m_network_id)
     {
 

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -42,6 +42,7 @@
 #include "cryptonote_config.h"
 #ifdef ALLOW_DEBUG_COMMANDS
 #include "crypto/crypto.h"
+#include "version.h"
 #endif
 
 namespace nodetool
@@ -167,12 +168,14 @@ namespace nodetool
     uint32_t my_port;
     uint16_t rpc_port;
     peerid_type peer_id;
-
+    std::string version;
+   
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE_VAL_POD_AS_BLOB(network_id)
       KV_SERIALIZE(peer_id)
       KV_SERIALIZE(local_time)
       KV_SERIALIZE(my_port)
+       KV_SERIALIZE(version)
       KV_SERIALIZE_OPT(rpc_port, (uint16_t)(0))
     END_KV_SERIALIZE_MAP()
   };


### PR DESCRIPTION
With this, nodes include version on their node data structure which is grabbed by the local node and info is displayed on the daemon if the remote node is on a different version than ours **(Peer {IP} has a different version than ours: {version})** or if no version is received **(Peer {IP} did not provide version information it must be Morioka 0.5.1.1 or earlier)** . 
It gives a good general idea in real time on what versions of sumokoin the network is structured
It will be spammy till the first release that includes this cause nodes at the moment are not transmitting version.

Partly based on https://github.com/angrywasp/nerva/commit/e95bb65c2b628dae04baab86b2397f0d1f72b860
( they used something similar to block nodes on different versions for reasons of their own)