### PR TITLE
[Daemon] Implement 'set_bootstrap_daemon' command

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -813,4 +813,18 @@ bool t_command_parser_executor::check_blockchain_pruning(const std::vector<std::
   return m_executor.check_blockchain_pruning();
 }
 
+bool t_command_parser_executor::set_bootstrap_daemon(const std::vector<std::string>& args)
+{
+  const size_t args_count = args.size();
+  if (args_count < 1 || args_count > 3)
+  {
+    return false;
+  }
+
+  return m_executor.set_bootstrap_daemon(
+    args[0] != "none" ? args[0] : std::string(),
+    args_count > 1 ? args[1] : std::string(),
+    args_count > 2 ? args[2] : std::string());
+}
+
 } // namespace daemonize

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -150,6 +150,8 @@ public:
   bool check_blockchain_pruning(const std::vector<std::string>& args);
 
   bool print_net_stats(const std::vector<std::string>& args);
+
+  bool set_bootstrap_daemon(const std::vector<std::string>& args);
 };
 
 } // namespace daemonize

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -310,6 +310,13 @@ t_command_server::t_command_server(
     , std::bind(&t_command_parser_executor::check_blockchain_pruning, &m_parser, p::_1)
     , "Check the blockchain pruning."
     );
+    m_command_lookup.set_handler(
+      "set_bootstrap_daemon"
+    , std::bind(&t_command_parser_executor::set_bootstrap_daemon, &m_parser, p::_1)
+    , "set_bootstrap_daemon (auto | none | host[:port] [username] [password])"
+    , "URL of a 'bootstrap' remote daemon that the connected wallets can use while this daemon is still not fully synced.\n"
+      "Use 'auto' to enable automatic public nodes discovering and bootstrap daemon switching"
+    );
 }
 
 bool t_command_server::process_command_str(const std::string& cmd)

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2319,4 +2319,40 @@ bool t_rpc_command_executor::check_blockchain_pruning()
     return true;
 }
 
+bool t_rpc_command_executor::set_bootstrap_daemon(
+  const std::string &address,
+  const std::string &username,
+  const std::string &password)
+{
+    cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::request req;
+    cryptonote::COMMAND_RPC_SET_BOOTSTRAP_DAEMON::response res;
+    const std::string fail_message = "Unsuccessful";
+
+    req.address = address;
+    req.username = username;
+    req.password = password;
+
+    if (m_is_rpc)
+    {
+        if (!m_rpc_client->rpc_request(req, res, "/set_bootstrap_daemon", fail_message))
+        {
+            return true;
+        }
+    }
+    else
+    {
+        if (!m_rpc_server->on_set_bootstrap_daemon(req, res) || res.status != CORE_RPC_STATUS_OK)
+        {
+            tools::fail_msg_writer() << make_error(fail_message, res.status);
+            return true;
+        }
+    }
+
+    tools::success_msg_writer()
+      << "Successfully set bootstrap daemon address to "
+      << (!req.address.empty() ? req.address : "none");
+
+    return true;
+}
+
 }// namespace daemonize

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -162,6 +162,11 @@ public:
   bool check_blockchain_pruning();
 
   bool print_net_stats();
+
+  bool set_bootstrap_daemon(
+    const std::string &address,
+    const std::string &username,
+    const std::string &password);
 };
 
 } // namespace daemonize


### PR DESCRIPTION
To set URL of a 'bootstrap' remote daemon that the connected
wallets can use while this daemon is still not fully synced

Ref: https://github.com/monero-project/monero/pull/5840/commits/063eebbd434d25fc7880edfd31d33d602b9ff306