### PR TITLE
[LMDB] mdb_dump/load fix backslash escaping - ITS#9068

### DIFF
--- a/external/db_drivers/liblmdb/mdb_dump.c
+++ b/external/db_drivers/liblmdb/mdb_dump.c
@@ -64,6 +64,8 @@ static void text(MDB_val *v)
 	end = c + v->mv_size;
 	while (c < end) {
 		if (isprint(*c)) {
+			if (*c == '\\')
+				putchar('\\');
 			putchar(*c);
 		} else {
 			putchar('\\');

--- a/external/db_drivers/liblmdb/mdb_load.c
+++ b/external/db_drivers/liblmdb/mdb_load.c
@@ -236,7 +236,7 @@ badend:
 		while (c2 < end) {
 			if (*c2 == '\\') {
 				if (c2[1] == '\\') {
-					c1++; c2 += 2;
+					*c1++ = *c2;
 				} else {
 					if (c2+3 > end || !isxdigit(c2[1]) || !isxdigit(c2[2])) {
 						Eof = 1;
@@ -244,8 +244,8 @@ badend:
 						return EOF;
 					}
 					*c1++ = unhex(++c2);
-					c2 += 2;
 				}
+				c2 += 2;
 			} else {
 				/* copies are redundant when no escapes were used */
 				*c1++ = *c2++;


### PR DESCRIPTION
mdb_load wasn't properly inserting escaped backslashes into the data.
mdb_dump wasn't escaping backslashes when generating printabl

Ref: https://github.com/monero-project/monero/pull/5857/commits/e907305c6c5ee722519ef67911e386490b9a23af