### PR TITLE
[Cross-Build] Fix Travis build on Windows + Mac

### DIFF
--- a/contrib/depends/packages/packages.mk
+++ b/contrib/depends/packages/packages.mk
@@ -12,7 +12,7 @@ packages += gtest
 endif
 
 ifneq ($(host_arch),riscv64)
-	packages += unwind
+linux_packages += unwind
 endif
 
 ifeq ($(host_os),mingw32)


### PR DESCRIPTION
The unwind package is being attempted to be built on
Windows and Mac when it should only be built on Linux.

Ref: https://github.com/monero-project/monero/pull/5858/commits/5f4bd92e06f0cee3ab9274440c3807f2047fc190