### PR TITLE
[P2P] Downgrade node version info to p2p log level 1

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1030,11 +1030,11 @@ namespace nodetool
       
       if (rsp.node_data.version.size() == 0)
       {
-        MGINFO_BLUE("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+        MINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
       }
       else if (rsp.node_data.version.size() != 0 && rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MGINFO_BLUE("Peer " << context.m_remote_address.str() << " has a different version than ours: " << rsp.node_data.version);
+        MINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << rsp.node_data.version);
       }
 
       if(rsp.node_data.network_id != m_network_id)
@@ -2309,12 +2309,12 @@ namespace nodetool
   {
     if (arg.node_data.version.size() == 0)
     {
-      MGINFO_BLUE("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+      MINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
     }
 
     if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
     {
-      MGINFO_BLUE("Peer " << context.m_remote_address.str() << " has a different version than ours: " << arg.node_data.version);
+      MINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << arg.node_data.version);
     }
 
     if(arg.node_data.network_id != m_network_id)


### PR DESCRIPTION
I downgraded to p2p log level 1 its very nice now cause it comes right after the new incoming or outgoing connection info. Its not spamming at all. I ve tested it with fake versions as well and it seems quite alright
Eg.

2019-09-09 15:24:09.860 I [54.37.131.222:40524 69404eff-95db-469c-bfd0-ad6d5a403c60 INC] NEW CONNECTION
2019-09-09 15:24:09.970 I Peer 54.37.131.222:40524 did not provide version information it must be Morioka 0.5.1.1 or earlier
2019-09-09 15:24:09.970 I switching safe mode on
2019-09-09 15:24:09.970 I clearing used stripe peers
2019-09-09 15:24:09.970 I [54.37.131.222:40524 INC] CONNECTION FROM 54.37.131.222 REFUSED, too many connections from the same address
2019-09-09 15:24:09.971 I [54.37.131.222:40524 INC] [182] state: closed in state normal
2019-09-09 15:24:09.971 I [54.37.131.222:40524 69404eff-95db-469c-bfd0-ad6d5a403c60 INC] CLOSE CONNECTION
2019-09-09 15:24:37.441 I [159.89.48.185:60392 261ad092-b77d-4202-b6ac-4d7d766a67fe INC] NEW CONNECTION
2019-09-09 15:24:37.445 I Peer 159.89.48.185:60392 has a different version than ours: 0.9.4.9
2019-09-09 15:24:37.445 I switching safe mode on
2019-09-09 15:24:37.445 I clearing used stripe peers