### PR TITLE
[Blockchain] Keep block template timestamp not above recent median

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1437,7 +1437,9 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     if (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce
       && m_btc_pool_cookie == m_tx_pool.cookie() && m_btc.prev_id == get_tail_id()) {
       MDEBUG("Using cached template");
-      m_btc.timestamp = time(NULL); // update timestamp unconditionally
+      const uint64_t now = time(NULL);
+      if (m_btc.timestamp < now) // ensures it can't get below the median of the last few blocks
+        m_btc.timestamp = now;
       b = m_btc;
       diffic = m_btc_difficulty;
       height = m_btc_height;


### PR DESCRIPTION
Such a template would yield an invalid block, though would require
an attacker to have mined a long blockchain with drifting times
(assuming the miner's clock is roughly correct)

Ref: https://github.com/monero-project/monero/pull/5902/commits/4a7fcfc42503ab7295e8ca869492add548bdbbb8