### PR TITLE
[CMake] Ensure PYTHON_EXECUTABLE is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
 include(CheckLibraryExists)
 include(CheckFunctionExists)
+include(FindPythonInterp)
 
 if (IOS)
     INCLUDE(CmakeLists_IOS.txt)


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/5869/commits/6e46b06308cd2b4427d9810e5146b434b5d225cb