### PR TITLE
[RPC] Don't include an address in mining_status when not mining

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1048,7 +1048,8 @@ namespace cryptonote
       res.block_reward = lMiner.get_block_reward();
     }
     const account_public_address& lMiningAdr = lMiner.get_mining_address();
-    res.address = get_account_address_as_str(nettype(), false, lMiningAdr);
+    if (lMiner.is_mining() || lMiner.get_is_background_mining_enabled())
+      res.address = get_account_address_as_str(nettype(), false, lMiningAdr);
     const uint8_t major_version = m_core.get_blockchain_storage().get_current_hard_fork_version();
     const unsigned variant = major_version >= 7 ? major_version - 3 : 0;
     switch (variant)


### PR DESCRIPTION
Best case is an address mined previously and it'll get returned,
worst case it was never initialized in the first place

Ref: https://github.com/monero-project/monero/pull/5872/commits/495a7e5b97b3795ac598e699a659f50ec0d9a313