### PR TITLE
[Simplewallet] Fix password display bug on linux

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -262,7 +262,7 @@ namespace
     PAUSE_READLINE();
     std::cout << prompt;
     if (yesno)
-      std::cout << "  (Y/Yes/N/No)";
+      std::cout << "(Y/Yes/N/No)";
     std::cout << ": " << std::flush;
 
     std::string buf;
@@ -278,7 +278,7 @@ namespace
   epee::wipeable_string input_secure_line(const char *prompt)
   {
     PAUSE_READLINE();
-    auto pwd_container = tools::password_container::prompt(false, prompt, false);
+    auto pwd_container = tools::password_container::prompt(false, prompt, true);
     if (!pwd_container)
     {
       MERROR("Failed to read secure line");


### PR DESCRIPTION
I was trying to fix the bug you have mentioned @quangvu3 about the seed not being displayed when inputted in windows prompt while it was displayed on Linux and then it hit me. The bug is the other way round. Passwords, private keys and seed are not supposed to be shown when inputted. The problem was with linux. A bool was set to false while it was supposed to be true
`auto pwd_container = tools::password_container::prompt(false, prompt, true);`
This is defined at password.h
`static boost::optional<password_container> prompt(bool verify, const char *mesage = "Password", bool hide_input = true);`

~~I dont know why it was working on windows~~ (its the tty) and not on linux (an epee thing obviously) anyway it now works on both os, wipeable strings inside password containers are not supposed to be shown 

A better practice to secure sensitive strings would be to overwrite them with random data than clearing it out, something like
`string password; 
 std::fill_n(&password[0], password.capacity()-1, 0xff); `

In the mean time I found out that the split function of the seed input (seed split in several lines) is not working propely and in some cases leads to false restoring, i ll look into it . 