### PR TITLE
[Simplewallet]Prompt bug fix kept + revert to old output

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8583,10 +8583,10 @@ std::string simple_wallet::get_prompt() const
   std::string addr_start = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0}).substr(0, 6);
   std::string prompt = std::string ("[wallet " + addr_start + "]: ");
   if (!m_wallet->check_connection(NULL))
-    prompt = std::string ("[wallet (no daemon) " + addr_start + "]: ");
+    prompt = std::string ("[wallet " + addr_start + " (no daemon)]: ");
   else
   if (!m_wallet->is_synced())
-    prompt = std::string ("[wallet (out of sync) " + addr_start + "]: ");
+    prompt = std::string ("[wallet " + addr_start + " (out of sync)]: ");
   return prompt;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8583,9 +8583,10 @@ std::string simple_wallet::get_prompt() const
   std::string addr_start = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0}).substr(0, 6);
   std::string prompt = std::string ("[wallet " + addr_start + "]: ");
   if (!m_wallet->check_connection(NULL))
-    prompt = std::string ("No Connection to Daemon-") + prompt;
+    prompt = std::string ("[wallet (no daemon) " + addr_start + "]: ");
+  else
   if (!m_wallet->is_synced())
-    prompt = std::string ("Wallet is out of sync-") + prompt;
+    prompt = std::string ("[wallet (out of sync) " + addr_start + "]: ");
   return prompt;
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Revert to old output layout but with more solid string definition ( to check messages create new wallet without running daemon to get no daemon message, run daemon first popping a few hundred blocks and refresh wallet to get the out of sync message,  let it sync and refresh to get the standard output)
The bug was reported by users in linux consoles (not just putty) which i trianged.
Bug
![447809469_375625](https://user-images.githubusercontent.com/34991117/65950576-fde50880-e446-11e9-9dd8-a744f4257738.jpg)

Output after this commit
![Capture](https://user-images.githubusercontent.com/34991117/65950685-3ab0ff80-e447-11e9-8f7a-1a758acd1baa.JPG)

