### PR TITLE
[DAEMON] Small display fix

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -646,7 +646,7 @@ void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint6
   // size-based check
   if (need_resize(threshold_size))
   {
-    MGINFO("[batch] DB resize needed");
+    MGINFO("\033[K[batch] DB resize needed\033[0m");
     do_resize(increase_size);
   }
 }


### PR DESCRIPTION
Trivial fix. I was getting left over characters from the sync bar when this line was printed on windows (not on linux) so i added the clean line ansi escape code to clear the line before it is printed.