### PR TITLE
[easylogging++] Disable crash log on non-glibc libraries

### DIFF
--- a/external/easylogging++/ea_config.h
+++ b/external/easylogging++/ea_config.h
@@ -9,7 +9,7 @@
 #define ELPP_UTC_DATETIME
 
 #ifdef EASYLOGGING_CC
-#if !(!defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__)
+#if !(!defined __GLIBC__ || !defined __GNUC__ || defined __MINGW32__ || defined __MINGW64__ || defined __ANDROID__)
 #define ELPP_FEATURE_CRASH_LOG
 #endif
 #endif


### PR DESCRIPTION
- easylogging assumes certain non-standard headers and functions
- these function only exist in glibc
- compiling under linux without glibc thus broke compilation