### PR TITLE
[CORE] Change default update time

### DIFF
--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -47,7 +47,7 @@ namespace cryptonote
 
     static const uint64_t DEFAULT_ORIGINAL_VERSION_TILL_HEIGHT = 0; // <= actual height
     static const time_t DEFAULT_FORKED_TIME = 31557600; // a year in seconds
-    static const time_t DEFAULT_UPDATE_TIME = 31557600 / 2;
+    static const time_t DEFAULT_UPDATE_TIME = 31557600;
     static const uint64_t DEFAULT_WINDOW_SIZE = 2520; // supermajority window check length - a week
     static const uint8_t DEFAULT_THRESHOLD_PERCENT = 80;
 


### PR DESCRIPTION
Dont freak out our users every 6 months with the the daemon popping up that needs a hardfork and an update soon. I increased it to a year which is more reasonable. Monero has set this cause they were changing pows every six months I guess they will fix this more properly as well soon