### PR TITLE
[UTILITIES] Blockchain-import batch size

### DIFF
--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -56,14 +56,7 @@ bool opt_resume  = true;
 bool opt_testnet = true;
 bool opt_stagenet = true;
 
-// number of blocks per batch transaction
-// adjustable through command-line argument according to available RAM
-#if ARCH_WIDTH != 32
-uint64_t db_batch_size = 20000;
-#else
-// set a lower default batch size, pending possible LMDB issue with large transaction size
 uint64_t db_batch_size = 100;
-#endif
 
 // when verifying, use a smaller default batch size so progress is more
 // frequently saved

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -56,8 +56,17 @@ bool opt_resume  = true;
 bool opt_testnet = true;
 bool opt_stagenet = true;
 
+// number of blocks per batch transaction
+// adjustable through command-line argument according to available RAM
+#if ARCH_WIDTH != 32
 uint64_t db_batch_size = 100;
+#else
+// set a lower default batch size, pending possible LMDB issue with large transaction size
+uint64_t db_batch_size = 100;
+#endif
 
+// when verifying, use a smaller default batch size so progress is more
+// frequently saved
 uint64_t db_batch_size_verify = 100;
 
 std::string refresh_string = "\r                                    \r";

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -58,9 +58,7 @@ bool opt_stagenet = true;
 
 uint64_t db_batch_size = 100;
 
-// when verifying, use a smaller default batch size so progress is more
-// frequently saved
-uint64_t db_batch_size_verify = 5000;
+uint64_t db_batch_size_verify = 100;
 
 std::string refresh_string = "\r                                    \r";
 }


### PR DESCRIPTION
batch_size = 100 was set for x32 archs while 20000 for x64 (this was due to a suspected db issue that couldnt handle large batches at 32 bit systems). 20000 means that sometimes even if you import from file you still have to sync normaly up to 20k blocks which is frustrating. Set batch size for all archs to 100. ~~it will take a couple of minutes more to import the entire chain  (-100 blocks worst case)~~ (it is actually faster cause it uses less ram) than having to sync 20k blocks (you can always change it with this flag --batch-size)