### PR TITLE
[SIMPLEWALLET] Refresh after breaking locked wallet loop

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5875,6 +5875,7 @@ void simple_wallet::check_for_inactivity_lock(bool user)
     m_last_activity_time = time(NULL);
     m_in_command = false;
     m_locked = false;
+    refresh_main(0, ResetNone, true);
   }
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
 Refresh and show balance per account after breaking locked wallet loop cause we might have received something and we wont know if we dont have autorefresh enabled or we dont enter a manual refresh