### PR TITLE
[P2P, RPC] Don't skip p2p or rpc port bind failure by default

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -152,7 +152,7 @@ namespace nodetool
     const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Disable UPnP port mapping"};
     const command_line::arg_descriptor<std::string> arg_igd = {"igd", "UPnP port mapping (disabled, enabled, delayed)", "delayed"};
     const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6  = {"p2p-use-ipv6", "Enable IPv6 for p2p", false};
-    const command_line::arg_descriptor<bool>        arg_p2p_require_ipv4  = {"p2p-require-ipv4", "Require successful IPv4 bind for p2p", true};
+    const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4  = {"p2p-ignore-ipv4", "Ignore unsuccessful IPv4 bind for p2p", false};
     const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};
     const command_line::arg_descriptor<int64_t>     arg_in_peers = {"in-peers", "set max number of in peers", -1};
     const command_line::arg_descriptor<int> arg_tos_flag = {"tos-flag", "set TOS flag", -1};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -510,7 +510,7 @@ namespace nodetool
     extern const command_line::arg_descriptor<std::string, false, true, 2> arg_p2p_bind_port;
     extern const command_line::arg_descriptor<std::string, false, true, 2> arg_p2p_bind_port_ipv6;
     extern const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6;
-    extern const command_line::arg_descriptor<bool>        arg_p2p_require_ipv4;
+    extern const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4;
     extern const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port;
     extern const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip;
     extern const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -97,7 +97,7 @@ namespace nodetool
     command_line::add_arg(desc, arg_p2p_bind_port, false);
     command_line::add_arg(desc, arg_p2p_bind_port_ipv6, false);
     command_line::add_arg(desc, arg_p2p_use_ipv6);
-    command_line::add_arg(desc, arg_p2p_require_ipv4);
+    command_line::add_arg(desc, arg_p2p_ignore_ipv4);
     command_line::add_arg(desc, arg_p2p_external_port);
     command_line::add_arg(desc, arg_p2p_allow_local_ip);
     command_line::add_arg(desc, arg_p2p_add_peer);
@@ -382,7 +382,7 @@ namespace nodetool
     }
     m_offline = command_line::get_arg(vm, cryptonote::arg_offline);
     m_use_ipv6 = command_line::get_arg(vm, arg_p2p_use_ipv6);
-    m_require_ipv4 = command_line::get_arg(vm, arg_p2p_require_ipv4);
+    m_require_ipv4 = !command_line::get_arg(vm, arg_p2p_ignore_ipv4);
     public_zone.m_notifier = cryptonote::levin::notify{
       public_zone.m_net_server.get_io_service(), public_zone.m_net_server.get_config_shared(), nullptr, true
     };

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -92,7 +92,7 @@ namespace cryptonote
      : rpc_bind_ip({"rpc-bind-ip", rpc_args::tr("Specify IP to bind RPC server"), "127.0.0.1"})
      , rpc_bind_ipv6_address({"rpc-bind-ipv6-address", rpc_args::tr("Specify IPv6 address to bind RPC server"), "::1"})
      , rpc_use_ipv6({"rpc-use-ipv6", rpc_args::tr("Allow IPv6 for RPC"), false})
-     , rpc_require_ipv4({"rpc-require-ipv4", rpc_args::tr("Require successful IPv4 bind for RPC"), true})
+     , rpc_ignore_ipv4({"rpc-ignore-ipv4", rpc_args::tr("Ignore unsuccessful IPv4 bind for RPC"), false})
      , rpc_login({"rpc-login", rpc_args::tr("Specify username[:password] required for RPC server"), "", true})
      , confirm_external_bind({"confirm-external-bind", rpc_args::tr("Confirm rpc-bind-ip value is NOT a loopback (local) IP")})
      , rpc_access_control_origins({"rpc-access-control-origins", rpc_args::tr("Specify a comma separated list of origins to allow cross origin resource sharing"), ""})
@@ -113,7 +113,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg.rpc_bind_ip);
     command_line::add_arg(desc, arg.rpc_bind_ipv6_address);
     command_line::add_arg(desc, arg.rpc_use_ipv6);
-    command_line::add_arg(desc, arg.rpc_require_ipv4);
+    command_line::add_arg(desc, arg.rpc_ignore_ipv4);
     command_line::add_arg(desc, arg.rpc_login);
     command_line::add_arg(desc, arg.confirm_external_bind);
     command_line::add_arg(desc, arg.rpc_access_control_origins);
@@ -135,7 +135,7 @@ namespace cryptonote
     config.bind_ip = command_line::get_arg(vm, arg.rpc_bind_ip);
     config.bind_ipv6_address = command_line::get_arg(vm, arg.rpc_bind_ipv6_address);
     config.use_ipv6 = command_line::get_arg(vm, arg.rpc_use_ipv6);
-    config.require_ipv4 = command_line::get_arg(vm, arg.rpc_require_ipv4);
+    config.require_ipv4 = !command_line::get_arg(vm, arg.rpc_ignore_ipv4);
     if (!config.bind_ip.empty())
     {
       // always parse IP here for error consistency

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -54,7 +54,7 @@ namespace cryptonote
       const command_line::arg_descriptor<std::string> rpc_bind_ip;
       const command_line::arg_descriptor<std::string> rpc_bind_ipv6_address;
       const command_line::arg_descriptor<bool> rpc_use_ipv6;
-      const command_line::arg_descriptor<bool> rpc_require_ipv4;
+      const command_line::arg_descriptor<bool> rpc_ignore_ipv4;
       const command_line::arg_descriptor<std::string> rpc_login;
       const command_line::arg_descriptor<bool> confirm_external_bind;
       const command_line::arg_descriptor<std::string> rpc_access_control_origins;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -30,7 +30,6 @@ set(unit_tests_sources
   account.cpp
   apply_permutation.cpp
   address_from_url.cpp
-  ban.cpp
   base58.cpp
   blockchain_db.cpp
   block_queue.cpp
@@ -68,6 +67,7 @@ set(unit_tests_sources
   multiexp.cpp
   multisig.cpp
   net.cpp
+  node_server.cpp
   notify.cpp
   output_distribution.cpp
   parse_amount.cpp


### PR DESCRIPTION
As currently the daemon ignores p2p or rpc port bind failure by default