### PR TITLE
[EPEE] levin: armour against some "should not happen" case

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -272,6 +272,11 @@ public:
   bool add_invoke_response_handler(const callback_t &cb, uint64_t timeout,  async_protocol_handler& con, int command)
   {
     CRITICAL_REGION_LOCAL(m_invoke_response_handlers_lock);
+    if (m_protocol_released)
+    {
+      MERROR("Adding response handler to a released object");
+      return false;
+    }
     boost::shared_ptr<invoke_response_handler_base> handler(boost::make_shared<anvoke_handler<callback_t>>(cb, timeout, con, command));
     m_invoke_response_handlers.push_back(handler);
     return handler->is_timer_started();


### PR DESCRIPTION
If adding a response handler after the protocol is released, they could never be cancelled again, and would end up keeping a ref that never goes away