### PR TITLE
[MISC] Misc fixes (from Coverty)

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1353,6 +1353,7 @@ namespace cryptonote
   {
     block_complete_entry bce;
     bce.block = cryptonote::block_to_blob(b);
+    bce.block_weight = 0; // we can leave it to 0, those txes aren't pruned
     for (const auto &tx_hash: b.tx_hashes)
     {
       cryptonote::blobdata txblob;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -261,7 +261,7 @@ namespace cryptonote
           if (!insert_key_images(tx, id, kept_by_block))
             return false;
           // Rounding tx fee/blob_size ratio so that txs with the same priority would be sorted by receive_time
-          uint32_t fee_per_size_ratio = (uint32_t)(fee / (double)tx_weight);
+          uint32_t fee_per_size_ratio = (uint32_t)(fee / (double)(tx_weight ? tx_weight : 1));
           m_txs_by_fee_and_receive_time.emplace(std::pair<uint32_t, std::time_t>(fee_per_size_ratio, receive_time), id);
           lock.commit();
         }
@@ -309,7 +309,7 @@ namespace cryptonote
         if (!insert_key_images(tx, id, kept_by_block))
           return false;
         // Rounding tx fee/blob_size ratio so that txs with the same priority would be sorted by receive_time
-        uint32_t fee_per_size_ratio = (uint32_t)(fee / (double)tx_weight);
+        uint32_t fee_per_size_ratio = (uint32_t)(fee / (double)(tx_weight ? tx_weight : 1));
         m_txs_by_fee_and_receive_time.emplace(std::pair<uint32_t, std::time_t>(fee_per_size_ratio, receive_time), id);
         lock.commit();
       }
@@ -1445,7 +1445,7 @@ namespace cryptonote
           return false;
         }
         // Rounding tx fee/blob_size ratio so that txs with the same priority would be sorted by receive_time
-        uint32_t fee_per_size_ratio = (uint32_t)(meta.fee / (double)meta.weight);
+        uint32_t fee_per_size_ratio = (uint32_t)(meta.fee / (double)(meta.weight ? meta.weight : 1));
         m_txs_by_fee_and_receive_time.emplace(std::pair<uint32_t, std::time_t>(fee_per_size_ratio, meta.receive_time), txid);
         m_txpool_weight += meta.weight;
         return true;

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -160,7 +160,7 @@ namespace cryptonote
       }
     END_KV_SERIALIZE_MAP()
 
-    block_complete_entry(): pruned(false) {}
+    block_complete_entry(): pruned(false), block_weight(0) {}
   };
 
 


### PR DESCRIPTION
- tx_pool: do not divide by 0
- cryptonote: don't leave block_weight uninitialized
- protocol: initialize block_weight in block_complete_entry ctor