### PR TITLE
[easylogging++] Always omit ANSI codes when colour is not supported

### DIFF
--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -683,6 +683,13 @@ void LogBuilder::convertToColoredOutput(base::type::string_t* logLine, Level lev
   }
 }
 
+void LogBuilder::setColor(Color color, bool bright) {
+#if !ELPP_OS_WINDOWS
+  if (m_termSupportsColor)
+#endif
+    el::base::utils::setConsoleColor(color, bright);
+}
+
 // Logger
 
 Logger::Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsReference) :
@@ -2496,11 +2503,11 @@ void DefaultLogDispatchCallback::dispatch(base::type::string_t&& rawLinePrefix, 
       if (m_data->logMessage()->logger()->m_typedConfigurations->toStandardOutput(m_data->logMessage()->level())) {
         const el::Level level = m_data->logMessage()->level();
         const el::Color color = m_data->logMessage()->color();
-        el::base::utils::setConsoleColor(el::base::utils::colorFromLevel(level), false);
+        m_data->logMessage()->logger()->logBuilder()->setColor(el::base::utils::colorFromLevel(level), false);
         ELPP_COUT << rawLinePrefix;
-        el::base::utils::setConsoleColor(color == el::Color::Default ? el::base::utils::colorFromLevel(level): color, color != el::Color::Default);
+        m_data->logMessage()->logger()->logBuilder()->setColor(color == el::Color::Default ? el::base::utils::colorFromLevel(level): color, color != el::Color::Default);
         ELPP_COUT << rawLinePayload;
-        el::base::utils::setConsoleColor(el::Color::Default, false);
+        m_data->logMessage()->logger()->logBuilder()->setColor(el::Color::Default, false);
         ELPP_COUT << std::flush;
       }
     }

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -2235,6 +2235,7 @@ class LogBuilder : base::NoCopy {
   }
   virtual base::type::string_t build(const LogMessage* logMessage, bool appendNewLine) const = 0;
   void convertToColoredOutput(base::type::string_t* logLine, Level level, Color color);
+  void setColor(Color color, bool bright);
  private:
   bool m_termSupportsColor;
   friend class el::base::DefaultLogDispatchCallback;


### PR DESCRIPTION
- Re-opened with Windows color fix