### PR TITLE
[Pulse] Disable Checking for pulse DNS TXT records

### DIFF
--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -46,10 +46,13 @@ namespace tools
 
     // All four MoneroPulse domains have DNSSEC on and valid
     static const std::vector<std::string> dns_urls = {
+        // Disabling them till we set up the TXT records of the below sumo pulse nodes
+        /*
         "updates.sumopulse.stream",
         "updates.sumopulse.download",
         "updates.sumopulse.win",
         "updates.sumopulse.bid"
+        */
     };
 
     if (!tools::dns_utils::load_txt_records_from_dns(records, dns_urls))

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -13057,10 +13057,13 @@ uint64_t wallet2::get_segregation_fork_height() const
   {
     // All four SumoPulse domains have DNSSEC on and valid
     static const std::vector<std::string> dns_urls = {
+	//Disabling till we update the DNS records of these domains
+	/*
         "segheights.sumopulse.stream",
         "segheights.sumopulse.download",
         "segheights.sumopulse.win",
         "segheights.sumopulse.bid"
+	*/
     };
 
     const uint64_t current_height = get_blockchain_current_height();


### PR DESCRIPTION
We are using monero's nodes in vain and getting the warning on daemon. We dont have a pulse infrastructure for emergency checkpointing. Commenting it out till we create one