### PR TITLE
[DNS] Downgrade DNS TXT records warning

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -571,7 +571,7 @@ bool load_txt_records_from_dns(std::vector<std::string> &good_records, const std
 
   if (num_valid_records < 2)
   {
-    LOG_PRINT_L0("\033[KWARNING: no two valid DNS TXT records were received\033[0m");
+    LOG_PRINT_L2("\033[KWARNING: no two valid DNS TXT records were received\033[0m");
     return false;
   }
 


### PR DESCRIPTION
Downgrading it to debug level (2) so users dont freak out if the pulse txt records need updating