### PR TITLE
[RPC] Add a flush_cache RPC

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1918,6 +1918,14 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
+  void core::flush_bad_txs_cache()
+  {
+    bad_semantics_txes_lock.lock();
+    for (int idx = 0; idx < 2; ++idx)
+      bad_semantics_txes[idx].clear();
+    bad_semantics_txes_lock.unlock();
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::update_blockchain_pruning()
   {
     return m_blockchain_storage.update_blockchain_pruning();

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -839,6 +839,11 @@ namespace cryptonote
       */
      bool has_block_weights(uint64_t height, uint64_t nblocks) const;
 
+     /**
+      * @brief flushes the bad txs cache
+      */
+     void flush_bad_txs_cache();
+
    private:
 
      /**

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -844,4 +844,16 @@ bool t_command_parser_executor::set_bootstrap_daemon(const std::vector<std::stri
     args_count > 2 ? args[2] : std::string());
 }
 
+bool t_command_parser_executor::flush_cache(const std::vector<std::string>& args)
+{
+  if (args.empty())
+    goto show_list;
+  if (args[0] == "bad-txs")
+    return m_executor.flush_cache(true);
+
+show_list:
+  std::cout << "Cache type needed: bad-txs" << std::endl;
+  return true;
+}
+
 } // namespace daemonize

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -154,6 +154,8 @@ public:
   bool print_net_stats(const std::vector<std::string>& args);
 
   bool set_bootstrap_daemon(const std::vector<std::string>& args);
+
+  bool flush_cache(const std::vector<std::string>& args);
 };
 
 } // namespace daemonize

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -322,6 +322,12 @@ t_command_server::t_command_server(
     , "URL of a 'bootstrap' remote daemon that the connected wallets can use while this daemon is still not fully synced.\n"
       "Use 'auto' to enable automatic public nodes discovering and bootstrap daemon switching"
     );
+    m_command_lookup.set_handler(
+      "flush_cache"
+    , std::bind(&t_command_parser_executor::flush_cache, &m_parser, p::_1)
+    , "flush_cache bad-txs"
+    , "Flush the specified cache(s)."
+    );
 }
 
 bool t_command_server::process_command_str(const std::string& cmd)

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2430,4 +2430,32 @@ bool t_rpc_command_executor::rpc_payments()
     return true;
 }
 
+bool t_rpc_command_executor::flush_cache(bool bad_txs)
+{
+    cryptonote::COMMAND_RPC_FLUSH_CACHE::request req;
+    cryptonote::COMMAND_RPC_FLUSH_CACHE::response res;
+    std::string fail_message = "Unsuccessful";
+    epee::json_rpc::error error_resp;
+
+    req.bad_txs = bad_txs;
+
+    if (m_is_rpc)
+    {
+        if (!m_rpc_client->json_rpc_request(req, res, "flush_cache", fail_message.c_str()))
+        {
+            return true;
+        }
+    }
+    else
+    {
+        if (!m_rpc_server->on_flush_cache(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
+        {
+            tools::fail_msg_writer() << make_error(fail_message, res.status);
+            return true;
+        }
+    }
+
+    return true;
+}
+
 }// namespace daemonize

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -169,6 +169,7 @@ public:
     const std::string &password);
 
   bool rpc_payments();
+  bool flush_cache(bool bad_txs);
 };
 
 } // namespace daemonize

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3171,6 +3171,15 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_flush_cache(const COMMAND_RPC_FLUSH_CACHE::request& req, COMMAND_RPC_FLUSH_CACHE::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
+  {
+    RPC_TRACKER(flush_cache);
+    if (req.bad_txs)
+      m_core.flush_bad_txs_cache();
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   const command_line::arg_descriptor<std::string, false, true, 2> core_rpc_server::arg_rpc_bind_port = {
       "rpc-bind-port"
     , "Port for RPC server"

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -180,6 +180,7 @@ namespace cryptonote
         MAP_JON_RPC_WE_IF("rpc_access_tracking", on_rpc_access_tracking,        COMMAND_RPC_ACCESS_TRACKING, !m_restricted)
         MAP_JON_RPC_WE_IF("rpc_access_data",     on_rpc_access_data,            COMMAND_RPC_ACCESS_DATA, !m_restricted)
         MAP_JON_RPC_WE_IF("rpc_access_account",  on_rpc_access_account,         COMMAND_RPC_ACCESS_ACCOUNT, !m_restricted)
+        MAP_JON_RPC_WE_IF("flush_cache",         on_flush_cache,                COMMAND_RPC_FLUSH_CACHE, !m_restricted)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -253,6 +254,7 @@ namespace cryptonote
     bool on_rpc_access_tracking(const COMMAND_RPC_ACCESS_TRACKING::request& req, COMMAND_RPC_ACCESS_TRACKING::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_rpc_access_data(const COMMAND_RPC_ACCESS_DATA::request& req, COMMAND_RPC_ACCESS_DATA::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_rpc_access_account(const COMMAND_RPC_ACCESS_ACCOUNT::request& req, COMMAND_RPC_ACCESS_ACCOUNT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    bool on_flush_cache(const COMMAND_RPC_FLUSH_CACHE::request& req, COMMAND_RPC_FLUSH_CACHE::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     //-----------------------
 
 private:

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2554,4 +2554,27 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  struct COMMAND_RPC_FLUSH_CACHE
+  {
+    struct request_t
+    {
+      bool bad_txs;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_OPT(bad_txs, false)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t
+    {
+      std::string status;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
 }

--- a/utils/python-rpc/framework/daemon.py
+++ b/utils/python-rpc/framework/daemon.py
@@ -516,16 +516,16 @@ class Daemon(object):
         }
         return self.rpc.send_json_rpc_request(prune_blockchain)
 
-    def get_block_rate(self, seconds = [3600]):
-        get_block_rate = {
-            'method': 'get_block_rate',
+    def flush_cache(self, bad_txs = False):
+        flush_cache = {
+            'method': 'flush_cache',
             'params': {
-                'seconds': seconds,
+                'bad_txs': bad_txs,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
-        return self.rpc.send_json_rpc_request(get_block_rate)
+        return self.rpc.send_json_rpc_request(flush_cache)
 
     def rpc_access_info(self, client):
         rpc_access_info = {


### PR DESCRIPTION
This allows flushing internal caches (for now, the bad tx cache,
which will allow debugging a stuck deamon after it has failed to
verify a transaction in a block, since it would otherwise not try
again, making subsequent log changes pointless)

NOTE: Need PR #504 to be merged first