### PR TITLE
Revert linker fix

### DIFF
--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -160,8 +160,6 @@ target_link_libraries(utilities_menu
     ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
-    
-set(CMAKE_EXE_LINKER_FLAGS "${COMMON_CXX_FLAGS}")
 
 set_property(TARGET utilities_menu
 	PROPERTY


### PR DESCRIPTION
The fix creates issues with statically linking libs at blockchain utilities exe files. I am reverting it. (when running the compiled binaries they search for dlls in the output folder and not finding them)
However i still manage to statically build on windows without it (with mingw) and get proper running windows binaries, i still cannot triag the problem that lead to this bad fix of mine