### PR TITLE
[Utilities] Change cmake fix's location

### DIFF
--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -160,8 +160,6 @@ target_link_libraries(utilities_menu
     ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
-    
-set(CMAKE_EXE_LINKER_FLAGS "${COMMON_CXX_FLAGS}")
 
 set_property(TARGET utilities_menu
 	PROPERTY
@@ -169,6 +167,7 @@ set_property(TARGET utilities_menu
 
 install(TARGETS utilities_menu DESTINATION bin)
 if (UNIX)
+set(CMAKE_EXE_LINKER_FLAGS "${COMMON_CXX_FLAGS}")
 add_custom_command(TARGET utilities_menu POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-utilities-menu ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-utilities-menu)
 endif()


### PR DESCRIPTION
with the fix at that location i build statically on native ubuntu, mingw on windows and cross-compile without problems. I also dont get issues with the statically produced windows binaries from mingw anymore. Please check, confirm and merge