### PR TITLE
[Version gen] Fix release tag detection

### DIFF
--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -48,7 +48,7 @@ function (get_version_tag_from_git GIT)
         message(STATUS "You are currently on commit ${COMMIT}")
 
         # Get all the tags
-        execute_process(COMMAND "${GIT}" rev-list --tags --max-count=1 --abbrev-commit 
+        execute_process(COMMAND "${GIT}" rev-list --tags --max-count=1 --abbrev=9 --abbrev-commit 
                         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                         RESULT_VARIABLE RET
                         OUTPUT_VARIABLE TAGGEDCOMMIT


### PR DESCRIPTION
or build won't add `release` string to binaries' version