### PR TITLE
[Core, Wallet] Disable rct offset sanity check for testnet

### DIFF
--- a/src/cryptonote_core/tx_sanity_check.cpp
+++ b/src/cryptonote_core/tx_sanity_check.cpp
@@ -39,7 +39,7 @@
 namespace cryptonote
 {
 
-bool tx_sanity_check(Blockchain &blockchain, const cryptonote::blobdata &tx_blob)
+bool tx_sanity_check(Blockchain &blockchain, const cryptonote::blobdata &tx_blob, const network_type nettype)
 {
   cryptonote::transaction tx;
 
@@ -88,7 +88,7 @@ bool tx_sanity_check(Blockchain &blockchain, const cryptonote::blobdata &tx_blob
 
   std::vector<uint64_t> offsets(rct_indices.begin(), rct_indices.end());
   uint64_t median = epee::misc_utils::median(offsets);
-  if (median < n_available * 4 / 10)
+  if (nettype == MAINNET && median < n_available * 4 / 10) // this sanity check valid for mainnet only
   {
     MERROR("median offset index is too low (median is " << median << " out of total " << n_available << "offsets). Transactions should contain a higher fraction of recent outputs.");
     return false;

--- a/src/cryptonote_core/tx_sanity_check.h
+++ b/src/cryptonote_core/tx_sanity_check.h
@@ -32,5 +32,5 @@ namespace cryptonote
 {
   class Blockchain;
 
-  bool tx_sanity_check(Blockchain &blockchain, const cryptonote::blobdata &tx_blob);
+  bool tx_sanity_check(Blockchain &blockchain, const cryptonote::blobdata &tx_blob, const network_type nettype);
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1086,7 +1086,7 @@ namespace cryptonote
       return true;
     }
 
-    if (req.do_sanity_checks && !cryptonote::tx_sanity_check(m_core.get_blockchain_storage(), tx_blob))
+    if (req.do_sanity_checks && !cryptonote::tx_sanity_check(m_core.get_blockchain_storage(), tx_blob, nettype()))
     {
       res.status = "Failed";
       res.reason = "Sanity check failed";

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7712,8 +7712,10 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       // check we're clear enough of rct start, to avoid corner cases below
       THROW_WALLET_EXCEPTION_IF(rct_offsets.size() <= CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
           error::get_output_distribution, "Not enough rct outputs");
-      THROW_WALLET_EXCEPTION_IF(rct_offsets.back() <= max_rct_index * 4 / 10,
+      if (m_nettype == MAINNET){ // this sanity check valid for mainnet only
+        THROW_WALLET_EXCEPTION_IF(rct_offsets.back() <= max_rct_index * 4 / 10,
           error::get_output_distribution, "Daemon reports suspicious number of rct outputs");
+      }
     }
 
     // get histogram for the amounts we need


### PR DESCRIPTION
that failed due to low number of txes at testnet