### PR TITLE
[Build] Add 'depends-backcompat' build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ depends:
 	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
 	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
 
+depends-backcompat:
+	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
+	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake -DBACKCOMPAT=ON ../../.. && $(MAKE)
+
 cmake-debug:
 	mkdir -p $(builddir)/debug
 	cd $(builddir)/debug && cmake -D CMAKE_BUILD_TYPE=Debug $(topdir)


### PR DESCRIPTION
to build linux binary with `-DBACKCOMPAT=ON` make sure that the binary will run on systems having at least libc version 2.17