### PR TITLE
Fix trezor CMAKE warnings and errors

### DIFF
--- a/src/device_trezor/trezor/messages/.gitignore
+++ b/src/device_trezor/trezor/messages/.gitignore
@@ -1,0 +1,2 @@
+# protobuf generated code
+*


### PR DESCRIPTION
Fix "Trezor protobuf messages could not be regenerated (err=1, python )" warning and errors while cmake running on the beginning