### PR TITLE
[P2P] Network connectivity improvements

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -129,22 +129,22 @@
 #define P2P_DEFAULT_CONNECTIONS_COUNT_IN                32
 #define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //seconds
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
-#define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  250
+#define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  150
 #define P2P_DEFAULT_CONNECTION_TIMEOUT                  5000       //5 seconds
 #define P2P_DEFAULT_SOCKS_CONNECT_TIMEOUT               45         // seconds
-#define P2P_DEFAULT_PING_CONNECTION_TIMEOUT             2000       //2 seconds
+#define P2P_DEFAULT_PING_CONNECTION_TIMEOUT             5000       //5 seconds
 #define P2P_DEFAULT_INVOKE_TIMEOUT                      60*2*1000  //2 minutes
 #define P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT            5000       //5 seconds
 #define P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT       70
-#define P2P_DEFAULT_ANCHOR_CONNECTIONS_COUNT            2
+#define P2P_DEFAULT_ANCHOR_CONNECTIONS_COUNT            4
 #define P2P_DEFAULT_SYNC_SEARCH_CONNECTIONS_COUNT       2
 #define P2P_DEFAULT_LIMIT_RATE_UP                       2048       // kB/s
 #define P2P_DEFAULT_LIMIT_RATE_DOWN                     8192       // kB/s
 
-#define P2P_FAILED_ADDR_FORGET_SECONDS                  (60*60)     //1 hour
-#define P2P_IP_BLOCKTIME                                (60*60*24)  //24 hour
-#define P2P_IP_FAILS_BEFORE_BLOCK                       10
-#define P2P_IDLE_CONNECTION_KILL_INTERVAL               (5*60) //5 minutes
+#define P2P_FAILED_ADDR_FORGET_SECONDS                  (24*60*60)     //a day
+#define P2P_IP_BLOCKTIME                                (2*60*60*24)  //two days
+#define P2P_IP_FAILS_BEFORE_BLOCK                       5
+#define P2P_IDLE_CONNECTION_KILL_INTERVAL               (30) //30 seconds
 
 #define P2P_SUPPORT_FLAG_FLUFFY_BLOCKS                  0x01
 #define P2P_SUPPORT_FLAGS                               P2P_SUPPORT_FLAG_FLUFFY_BLOCKS

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -463,8 +463,8 @@ namespace nodetool
 
     epee::math_helper::once_a_time_seconds<P2P_DEFAULT_HANDSHAKE_INTERVAL> m_peer_handshake_idle_maker_interval;
     epee::math_helper::once_a_time_seconds<1> m_connections_maker_interval;
-    epee::math_helper::once_a_time_seconds<60*30, false> m_peerlist_store_interval;
-    epee::math_helper::once_a_time_seconds<60> m_gray_peerlist_housekeeping_interval;
+    epee::math_helper::once_a_time_seconds<60*10, false> m_peerlist_store_interval;
+    epee::math_helper::once_a_time_seconds<10> m_gray_peerlist_housekeeping_interval;
     epee::math_helper::once_a_time_seconds<3600, false> m_incoming_connections_interval;
 
 #ifdef ALLOW_DEBUG_COMMANDS

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -916,7 +916,7 @@ namespace nodetool
     public_zone.m_net_server.add_idle_handler(boost::bind(&t_payload_net_handler::on_idle, &m_payload_handler), 1000);
 
     //here you can set worker threads count
-    int thrds_count = 10;
+    int thrds_count = 15;
     boost::thread::attributes attrs;
     attrs.set_stack_size(THREAD_STACK_SIZE);
     //go to loop


### PR DESCRIPTION
Networking connectivity improvements based on the below
https://eprint.iacr.org/2019/411.pdf

cryptonote_config.h
1. Decrease peers in handshake to mitigate high load (even though we dont have that many peers)
2. Increase default ping time out connection to compensate for nodes running in china or via vpn or with very slow connections or they are just too isolated, dont exclude them cause they delay to pong
3. Increase anchor connections to 4 to avoid isolation of nodes and create a more robust network among nodes that cover the criteria of number 2
4. Increase forget time of a failed address to a day. Dont try every one hour to reconnect to an address that most likely is dead or problematic
5. Increase block time to two days. Nodes are blocked if they are sending a bad pow, a hugely wrong difficulty, a bad fork version, a hugely wrong timestamp and so on. 99.9% of the time are either past fork leftovers, might be unupdated botnets or even malicious nodes created to spam the network. Ban them for 2 days instead of one.
6. Decrease P2P fails before block. If they fail for the above reasons on 5 tries they wont connect on the 6th or 7th. 5 is enough to get them banned and avoid having our node retry so many times.
7. P2P code of monero is not the best around and although there are functions preventing connections to an already connected address there are many of those lingering on idle and are kicked every 5 minutes. Kick them in 30 seconds. The print_cn list is much cleaner with this and there is more space for really active new nodes.

net_node.h
1. store the peer list (gray white anchor) more often cause it gets cleaned up faster due to no 2 below
2. Check the gray list ips if they are still alive one every 10 seconds instead of one every 1 minute. There are almost thousands of gray ips in peerlists of active nodes that never have the chance to get cleaned and disappear. With each fork we have more bad or dead ips created and the gray list must get cleaned up faster (the full node GUI wallet increases this number).

net_node.inl
I increased the threads(workers) to 15 instead of 10 so nodes can perform more tasks concurrently like the faster peer list housekeeping above. I dont know if this will cause concurrency issues to very weak machines and lead to core dumps but it seems stable to small server instances i have tried syncing from scratch. If we get any issue we revert this back to 10. ( i dont think we will) 

