### PR TITLE
[Core] Mitigate syncing delay at the end of the chain due to JIT

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -106,6 +106,7 @@
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              50     //by default, blocks count in blocks downloading
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4            1      //by default, blocks count in blocks downloading at the end of the chain
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1157,8 +1157,10 @@ namespace cryptonote
   {
     if (block_sync_size > 0)
       return block_sync_size;
-    
+    if (get_current_blockchain_height() <= ((95 * m_target_blockchain_height) / 100))
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
+    else 
+    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;    
   }
   //-----------------------------------------------------------------------------------------------
   bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const


### PR DESCRIPTION
Its not solved but its mitigated. its due to delays of hash confirmation from "not an optimal" JIT implementation. (monero wont be improving since its now obsolete to them by turning to randomx also according to monero devs small batches of block sync size also seem to give a 30% speed increase at that area so at the end of the chain i drop the default block sync size to 1 from 50)