### PR TITLE
Change output folder to sumokoin

### DIFF
--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -35,7 +35,7 @@
 
 namespace daemon_args
 {
-  std::string const WINDOWS_SERVICE_NAME = "Monero Daemon";
+  std::string const WINDOWS_SERVICE_NAME = "Sumokoin Daemon";
 
   const command_line::arg_descriptor<std::string, false, true, 2> arg_config_file = {
     "config-file"

--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -120,7 +120,7 @@ void fork(const std::string & pidfile)
   if (!tmpdir)
     tmpdir = TMPDIR;
   std::string output = tmpdir;
-  output += "/bitmonero.daemon.stdout.stderr";
+  output += "/sumokoin.daemon.stdout.stderr";
   const int flags = O_WRONLY | O_CREAT | O_APPEND;
   const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
   if (open(output.c_str(), flags, mode) < 0)


### PR DESCRIPTION
To prevent overwrites in case someone is using monero on the same machine as well (plus a monero to sumo change on the windows daemon service name)
