### PR TITLE
[P2P] syncing delay at the end of chain update

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1155,7 +1155,7 @@ namespace cryptonote
   {
     if (block_sync_size > 0)
       return block_sync_size;
-    if (get_current_blockchain_height() <= ((95 * m_target_blockchain_height) / 100))
+    if (get_current_blockchain_height() <= ((90 * m_target_blockchain_height) / 100))
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
     else 
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;    


### PR DESCRIPTION
Change the default block_sync_size from 50 to 1 starting from 90% of the chain downloaded instead of 95% as per my previous commit. The delay at the end has a correlation with the distance between the end chain height and the latest checkpoint. So till we update checkpoints the furthest the chain top goes from the checkpoint the earliest the delay starts. (when i committed a month ago delay started at 96% of the chain downloaded now it starts at 94%)