### PR TITLE
[Depends] upgrade libsodium and fix openssl download location address so curl can grab it 

### DIFF
--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -1,6 +1,6 @@
 package=openssl
 $(package)_version=1.0.2r
-$(package)_download_path=https://www.openssl.org/source
+$(package)_download_path=https://ftp.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
 $(package)_patches=fix_arflags.patch

--- a/contrib/depends/packages/sodium.mk
+++ b/contrib/depends/packages/sodium.mk
@@ -1,8 +1,8 @@
 package=sodium
-$(package)_version=1.0.16
+$(package)_version=1.0.18
 $(package)_download_path=https://download.libsodium.org/libsodium/releases/
 $(package)_file_name=libsodium-$($(package)_version).tar.gz
-$(package)_sha256_hash=eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533
+$(package)_sha256_hash=6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
 $(package)_patches=fix-whitespace.patch
 
 define $(package)_set_vars

--- a/contrib/depends/patches/sodium/fix-whitespace.patch
+++ b/contrib/depends/patches/sodium/fix-whitespace.patch
@@ -5,9 +5,9 @@ index b29f769..ca008ae 100755
 @@ -591,7 +591,7 @@ MAKEFLAGS=
  PACKAGE_NAME='libsodium'
  PACKAGE_TARNAME='libsodium'
- PACKAGE_VERSION='1.0.16'
--PACKAGE_STRING='libsodium 1.0.16'
+ PACKAGE_VERSION='1.0.18'
+-PACKAGE_STRING='libsodium 1.0.18'
 +PACKAGE_STRING='libsodium'
  PACKAGE_BUGREPORT='https://github.com/jedisct1/libsodium/issues'
- PACKAGE_URL='https://github.com/jedisct1/libsodium'
- 
+PACKAGE_URL='https://github.com/jedisct1/libsodium'
+


### PR DESCRIPTION
Upgrade sodium lib as per https://github.com/monero-project/monero/pull/6231 and fix openssl download location address so curl can grab it