### PR TITLE
[Android branch] suppress clang pragma warnings

### DIFF
--- a/src/crypto/cn_heavy_hash.hpp
+++ b/src/crypto/cn_heavy_hash.hpp
@@ -61,7 +61,9 @@
 #endif
 
 #if defined(__aarch64__)
+#ifndef __clang__
 #pragma GCC target ("+crypto")
+#endif
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 #include <arm_neon.h>


### PR DESCRIPTION
Suppress annoying clang pragma warnings caused by the same code line on cn_heavy_hash.hpp they dont affect anything on building all archs for android wallet