### PR TITLE
[p2p] improve syncing

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -106,7 +106,9 @@
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              50     //by default, blocks count in blocks downloading
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4            1      //by default, blocks count in blocks downloading at the end of the chain
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4           1      //by default, blocks count in blocks downloading at the end of the chain
+
+#define LAST_CHECKPOINT				  375000
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1155,7 +1155,7 @@ namespace cryptonote
   {
     if (block_sync_size > 0)
       return block_sync_size;
-    if (get_current_blockchain_height() <= ((90 * m_target_blockchain_height) / 100))
+    if (get_current_blockchain_height() <= LAST_CHECKPOINT)
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
     else 
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;    

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -916,7 +916,7 @@ namespace nodetool
     public_zone.m_net_server.add_idle_handler(boost::bind(&t_payload_net_handler::on_idle, &m_payload_handler), 1000);
 
     //here you can set worker threads count
-    int thrds_count = 15;
+    int thrds_count = 10;
     boost::thread::attributes attrs;
     attrs.set_stack_size(THREAD_STACK_SIZE);
     //go to loop


### PR DESCRIPTION
On considering the latest commit to improve syncing at the end of chain https://github.com/sumoprojects/sumokoin/pull/621
since the delay starts from approximately the last checkpoint (block hashes must be checked from then on causing the delay) there is no point in moving the default block syncing default count change (from 50 to 1) backwards all the time. 
Remove the percentage and make the change to always start from the last checkpoint.

Also revert worker p2p thread count to 10 (it slows down hash verification on low end machines)