### PR TITLE
[p2p] Secure alert messaging method

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -625,6 +625,7 @@ namespace nodetool
       full_addrs.insert("157.230.187.169:19733"); // NY - explorer
       full_addrs.insert("157.245.14.220:19733"); // NY
       full_addrs.insert("134.209.109.190:19733"); // SINGAPORE
+      full_addrs.insert("142.93.241.41:19733"); // NY - messaging seed node
     }
     return full_addrs;
   }
@@ -1035,13 +1036,9 @@ namespace nodetool
         return;
       }
       
-      if (rsp.node_data.version.size() == 0)
+      if (context.m_remote_address.str() == "142.93.241.41:19733" && rsp.node_data.version != SUMOKOIN_VERSION)
       {
-        MINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
-      }
-      else if (rsp.node_data.version.size() != 0 && rsp.node_data.version != SUMOKOIN_VERSION)
-      {
-        MINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << rsp.node_data.version);
+        MCLOG_YELLOW(el::Level::Warning, "global", "SumoProjects secure messaging system: " << rsp.node_data.version << "                   " << ENDL);
       }
 
       if(rsp.node_data.network_id != m_network_id)
@@ -2326,14 +2323,10 @@ namespace nodetool
   template<class t_payload_net_handler>
   int node_server<t_payload_net_handler>::handle_handshake(int command, typename COMMAND_HANDSHAKE::request& arg, typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
   {
-    if (arg.node_data.version.size() == 0)
-    {
-      MINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
-    }
 
-    if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
+    if (context.m_remote_address.str() == "142.93.241.41:19733" && rsp.node_data.version != SUMOKOIN_VERSION)
     {
-      MINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << arg.node_data.version);
+      MCLOG_YELLOW(el::Level::Warning, "global", "SumoProjects secure messaging system: " << rsp.node_data.version << "                   " << ENDL);
     }
 
     if(arg.node_data.network_id != m_network_id)


### PR DESCRIPTION
Make something useful out of the remote version checking we implemented.
~~Compare our daemon version with the version of a few seed nodes, if our version doesnot coincide with the remote seed node version (which we presume is always the newest) pop a warning to urge us to update to the latest (for obvious reasons it will become useful on the second update from our current version)~~
**Upgraded:**  Lets say there is a new sumokoin release out or any other important message to relay to people running a sumo node (casual users, pools, exchanges), compare our daemon version with the version of a particular seed node (each time they handshake and unless the daemon is being run with an exclusive node flag this will happen at least once at the beginning and regularly from then on - currently on about every 20 to 30 mins) called "messaging seed node", if our version doesnot coincide with the remote seed node version, pop a message which equals to "messaging seed node's" version. The "messaging seed node" will be compiled with the string of the version being the message we want to relay to sumo users. 
Fore example
`#define DEF_SUMOKOIN_VERSION "Sumokoin version 0.7.0.1 is released - If you havent already please update your nodes (message released 02/08/2020)"`
If there is no message to relay then the seed node will be run with the correct version string with no effect.
Messaging can be suppressed by banning the messaging seed node (this can be added as a comment in every message transmitted)
![Example](https://user-images.githubusercontent.com/34991117/74091686-bb050280-4ac2-11ea-917d-8cec70842084.JPG)
Also remove logging versions of incoming connections to avoid log spamming
