### PR TITLE
[build] fix libsodium patch

### DIFF
--- a/contrib/depends/patches/sodium/fix-whitespace.patch
+++ b/contrib/depends/patches/sodium/fix-whitespace.patch
@@ -9,5 +9,5 @@ index b29f769..ca008ae 100755
 -PACKAGE_STRING='libsodium 1.0.18'
 +PACKAGE_STRING='libsodium'
  PACKAGE_BUGREPORT='https://github.com/jedisct1/libsodium/issues'
-PACKAGE_URL='https://github.com/jedisct1/libsodium'
+ PACKAGE_URL='https://github.com/jedisct1/libsodium'
 


### PR DESCRIPTION
Add a whitespace that was missing giving a malformed patch error on cross compiling