### PR TITLE
[updates] fix source code URL on _WIN32

### DIFF
--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -101,7 +101,7 @@ namespace tools
   {
     const char *base = user ? "https://downloads.sumokoin.org/" : "https://updates.sumokoin.org/";
 #ifdef _WIN32
-    static const char *extension = strncmp(buildtag.c_str(), "install-", 8) ? ".zip" : ".exe";
+    static const char *extension = strncmp(buildtag.c_str(), "source", 6) ? (strncmp(buildtag.c_str(), "install-", 8) ? ".zip" : ".exe") : ".tar.bz2";
 #else
     static const char extension[] = ".tar.bz2";
 #endif


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6178

AFAIK this isnt fully operational in monero as well (getting the actual updates) it just queries pulse DNS records for a new version than the one we have but apply the fix anyhow.

This pr of ours i think makes things simpler (warning in case there is a newer version)
https://github.com/sumoprojects/sumokoin/pull/663