### PR TITLE
[daemon] new command 'disk'

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -123,6 +123,13 @@ bool t_command_parser_executor::show_difficulty(const std::vector<std::string>& 
   return m_executor.show_difficulty();
 }
 
+bool t_command_parser_executor::show_disk(const std::vector<std::string>& args)
+{
+  if (!args.empty()) return false;
+
+  return m_executor.show_disk();
+}
+
 bool t_command_parser_executor::show_status(const std::vector<std::string>& args)
 {
   if (!args.empty()) return false;

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -71,6 +71,8 @@ public:
 
   bool show_difficulty(const std::vector<std::string>& args);
 
+  bool show_disk(const std::vector<std::string>& args);
+
   bool show_status(const std::vector<std::string>& args);
 
   bool print_connections(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -165,6 +165,11 @@ t_command_server::t_command_server(
     , "Show the current difficulty."
     );
   m_command_lookup.set_handler(
+      "disk"
+    , std::bind(&t_command_parser_executor::show_disk, &m_parser, p::_1)
+    , "Show db size and remaining disk space."
+    );
+  m_command_lookup.set_handler(
       "status"
     , std::bind(&t_command_parser_executor::show_status, &m_parser, p::_1)
     , "Show the current status."

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -439,6 +439,38 @@ static float get_sync_percentage(const cryptonote::COMMAND_RPC_GET_INFO::respons
   return get_sync_percentage(ires.height, ires.target_height);
 }
 
+bool t_rpc_command_executor::show_disk() {
+  cryptonote::COMMAND_RPC_GET_INFO::request ireq;
+  cryptonote::COMMAND_RPC_GET_INFO::response ires;
+  epee::json_rpc::error error_resp;
+
+  std::string fail_message = "Problem fetching info";
+
+  if (m_is_rpc)
+  {
+    if (!m_rpc_client->rpc_request(ireq, ires, "/getinfo", fail_message.c_str()))
+    {
+      return true;
+    }
+  }
+  else
+  {
+    if (!m_rpc_server->on_get_info(ireq, ires) || ires.status != CORE_RPC_STATUS_OK)
+    {
+      tools::fail_msg_writer() << make_error(fail_message, ires.status);
+      return true;
+    }
+  }
+
+  size_t chainsize = (ires.database_size)/1000000;
+  uint64_t freespace = (ires.free_space)/1000000;
+
+  std::cout << std:: endl << "\033[1mBlockchain db current size on disk: \033[0m" << "\033[32;1m" << chainsize << " MB" << "\033[0m"  << "  " << std::endl;
+  std::cout << "\033[1mRemaining disk space: \033[0m" << "\033[32;1m" << freespace << " MB" << "\033[0m" << std::endl;
+
+  return true;
+}
+
 bool t_rpc_command_executor::show_status() {
   cryptonote::COMMAND_RPC_GET_INFO::request ireq;
   cryptonote::COMMAND_RPC_GET_INFO::response ires;

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -81,6 +81,8 @@ public:
 
   bool show_difficulty();
 
+  bool show_disk();
+
   bool show_status();
 
   bool print_connections();


### PR DESCRIPTION
Typing  `disk ` on the daemon displays the blockchain db size on disk as well as the remaining disk space on the drive the chain is located.

This goes in unison with https://github.com/sumoprojects/sumokoin/pull/687