### PR TITLE
[gitignore] include trezor compiled python files after building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ version/
 *.out
 *.app
 
+### Python ###
+# Trezor compiled python files
+*.pyc
 
 ### CMake ###
 CMakeCache.txt


### PR DESCRIPTION
include in gitignore the pyc files that are build from the py files at src/device_trezor/trezor/tools/py2backports/ folder 