### PR TITLE
[crypto] fix variable typo

### DIFF
--- a/src/crypto/cn_heavy_hash_soft.cpp
+++ b/src/crypto/cn_heavy_hash_soft.cpp
@@ -182,7 +182,7 @@ inline uint32_t rotr(uint32_t value, uint32_t amount)
 #else
 inline uint32_t rotr(uint32_t value, uint32_t amount)
 {
-	return _rotr(value, amount);
+	return rotr(value, amount);
 }
 #endif
 


### PR DESCRIPTION
Caught on testing cross compiling RISC V 64 binaries