### PR TITLE
[crypto] proper fix for _rotr on cn_heavy

### DIFF
--- a/src/crypto/cn_heavy_hash_soft.cpp
+++ b/src/crypto/cn_heavy_hash_soft.cpp
@@ -174,16 +174,19 @@ inline uint32_t sub_word(uint32_t key)
 		(saes_sbox[(key >> 8)  & 0xff] << 8  ) | saes_sbox[key & 0xff];
 }
 
-#if defined(__clang__) || defined(__arm__) || defined(__aarch64__)
-inline uint32_t rotr(uint32_t value, uint32_t amount)
-{
-	return (value >> amount) | (value << ((32 - amount) & 31));
+#if defined(_MSC_VER)
+#include <stdlib.h>
+
+static inline uint32_t rotr(uint32_t value, uint32_t amount) {
+  return _rotr(value, amount);
 }
+
 #else
-inline uint32_t rotr(uint32_t value, uint32_t amount)
-{
-	return _rotr(value, amount);
+
+static inline uint32_t rotr(uint32_t value, uint32_t amount) {
+  return (value >> amount) | (value << ((32 - amount) & 31));
 }
+
 #endif
 
 // sl_xor(a1 a2 a3 a4) = a1 (a2^a1) (a3^a2^a1) (a4^a3^a2^a1)


### PR DESCRIPTION
Builds in all archs this way (tested)