### PR TITLE
[wallet2] improve decoy outputs selection

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -110,10 +110,11 @@ using namespace cryptonote;
 #define SIGNED_TX_PREFIX "Sumokoin signed tx set\004"
 #define MULTISIG_UNSIGNED_TX_PREFIX "Sumokoin multisig unsigned tx set\001"
 
-#define RECENT_OUTPUT_RATIO (0.5) // 50% of outputs are from the recent zone
-#define RECENT_OUTPUT_DAYS (1.8) // last 1.8 day makes up the recent zone (taken from monerolink.pdf, Miller et al)
+#define GENERATE_RECENT_OUTPUT_RATIO (crypto::rand_range(2, 3)) // random percentage between 30% to 20% of outputs are from the recent zone
+#define RECENT_OUTPUT_RATIO (GENERATE_RECENT_OUTPUT_RATIO / 10)
+#define RECENT_OUTPUT_DAYS (crypto::rand_range(60, 100)) // random number beween last 60 to 100 days makes up the recent zone 
 #define RECENT_OUTPUT_ZONE ((time_t)(RECENT_OUTPUT_DAYS * 86400))
-#define RECENT_OUTPUT_BLOCKS (RECENT_OUTPUT_DAYS * 360)
+#define RECENT_OUTPUT_BLOCKS ((uint64_t)RECENT_OUTPUT_DAYS * 360) // unsigned cause its compared with SEGREGATION_FORK_HEIGHT which is also unsigned and throws a warning
 
 #define FEE_ESTIMATE_GRACE_BLOCKS 10 // estimate fee valid for that many blocks
 


### PR DESCRIPTION
Monero uses a selection of decoys method by picking 50% of their "chaff" decoys from their chain history as well as 50% from the last 1.8 days since Monero is constraint by the Miller et al traceability analysis paper https://arxiv.org/pdf/1704.04299.pdf which deduced that at least 50% of the decoys 
should come from the "recent" chain as per the empirical analysis of Monero users usage of the blockchain. 
That paper is based on a chain like Monero which has a major part of its chain early history based on txs exclusively on Ring size 1 which means it can always be subject to "chain-reactions" traceability attacks as described on the MRL paper here https://web.getmonero.org/resources/research-lab/pubs/MRL-0007.pdf
Monero did a great job with picking the triangular distribution algorithm to "pretend" outputs uniformity as well as the gamma distribution selection to generate maximum level of entropy but Monero's outputs selection will always be bound to these two constants due to the Miller paper (costants and high entropy dont go together)
```
#define RECENT_OUTPUT_RATIO (0.5) // 50% of outputs are from the recent zone
#define RECENT_OUTPUT_DAYS (1.8) // last 1.8 day makes up the recent zone (taken from monerolink.pdf, Miller et al)
```
Fortunately Sumokoin is not bound to any of the above because its earlier history has a ringsize of 13 and its latest a ringsize of 49! 
On the other hand unfortunately Sumokoin doesnt have the amount of txs per unit of time as Monero does so the 1.8 empirically deduced constant obviously doesnt apply and should be way greater (sumo has less than 1/20th the amount of Monero's txs per unit time!).
All the above lead to the majority of the outputs selected for decoys on Sumo to be from the distant past of the chain and only a couple from the very recent history as it is obvious by analysing recent txs on the explorer (Sumokoin's very high ringsize also worsens this fact).

So the good news first: skyrocket the entropy of Sumokoin's output selection by keeping the RECENT_OUTPUT_RATIO and RECENT_OUTPUT_DAYS but making them a constrained but **randomly generated** percentage-number respectively.
50% is very a high number for Sumokoin as the usage of its chain is much lower than Monero's and the rate of new Sumo users are less than Monero's as well (new users mean more new outputs) so Sumokoin's recent output ratio should be reduced to a random value between 20% to 30% (even these numbers are very high with our current rate of txs included per block). 
For the same reasons described above recent output days being inversely propotional in a way to the recent output ratio should be extended to a random value of 60 to 100 days. 

The bad news: we are very short of txs at the moment (for our high ringsize) so the above min max limits can be changed if Sumo picks up or i can make it change automatically (in the future) by calculating the average of txs included per block during a period say of 100 days. 

Now we removed two constants and intruduced two random values that do not depend on each other so along with monero's gamma distribution we achieved maximum entropy and retained the uniformity the triangular distribution provides.

_The above wont mean a lot till the txs included per block increase a lot for now its just a mitigation_