### PR TITLE
[simplewallet] update tx old age warning threshold

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -98,7 +98,7 @@ typedef cryptonote::simple_wallet sw;
 
 #define MIN_RING_SIZE 49 // Used to inform user about min ring size -- does not track actual protocol
 
-#define OLD_AGE_WARN_THRESHOLD (30 * 86400 / DIFFICULTY_TARGET) // 30 days
+#define OLD_AGE_WARN_THRESHOLD (60 * 86400 / DIFFICULTY_TARGET) // number of blocks emitted in 60 days
 
 #define LOCK_IDLE_SCOPE() \
   bool auto_refresh_enabled = m_auto_refresh_enabled.load(std::memory_order_relaxed); \


### PR DESCRIPTION
Outputs before being spent are being checked for their age and if they are  "old" a warning pops "Transaction spends more than one very old output. Privacy would be better if they were sent separately." . Actually monero devs commented `// 30 days` next to the constant but actually `OLD_AGE_WARN_THRESHOLD (30 * 86400 / DIFFICULTY_TARGET)` is not days its the number of blocks emitted in 30 days. The OLD_AGE_WARN_THRESHOLD is inversely proportional to the difficulty target so in order to keep the output (number of blocks) same as Monero since the denominator is half in sumo (4 minutes instead of 2) the numerator  should be double (60 days)
[Actually the warning altogether has little value at the moment because it has validity for a sufficient rate of included txs per block while we dont have that many at the moment but lets keep this anyhow)