### PR TITLE
[modules] Grab miniupnp from its official repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 [submodule "external/trezor-common"]
 	path = external/trezor-common
 	url = https://github.com/trezor/trezor-common.git
-[submodule "external/miniupnp"]
-	path = external/miniupnp
-	url = https://github.com/miniupnp/miniupnp

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,13 +2,12 @@
 	path = external/unbound
 	url = https://github.com/monero-project/unbound
 	branch = monero
-[submodule "external/miniupnp"]
-	path = external/miniupnp
-	url = https://github.com/monero-project/miniupnp
-	branch = monero
 [submodule "external/rapidjson"]
 	path = external/rapidjson
 	url = https://github.com/Tencent/rapidjson
 [submodule "external/trezor-common"]
 	path = external/trezor-common
 	url = https://github.com/trezor/trezor-common.git
+[submodule "external/miniupnp"]
+	path = external/miniupnp
+	url = https://github.com/miniupnp/miniupnp


### PR DESCRIPTION
We are still getting the miniupnp from fluffy's repo https://github.com/monero-project/miniupnp. He hasnt updated it since the 6th of July 2018. I guess he didnt cause the latest release of miniupnp is still 2.1 from two years ago
However since that release this has happened
https://www.vdoo.com/blog/security-issues-discovered-in-miniupnp
and at least another 3 more vulnerabilities were found
https://www.cvedetails.com/vulnerability-list/vendor_id-12591/year-2018/Miniupnp-Project.html
https://www.cvedetails.com/vulnerability-list/vendor_id-12591/year-2019/Miniupnp-Project.html
**there are about 224 new commits in miniupnp's master branch since the 2.1 release**

There is no point in taking this from Monero it doesnt have any "special" configuration for Monero and it is never updated as well which leaves us vulnerable.

Updated the submodule to be drawn directly from miniupnp official repo