### PR TITLE
[wallet rpc] remove unused variable 'ptx'

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1179,7 +1179,6 @@ namespace tools
       }
     }
 
-    std::vector<tools::wallet2::pending_tx> ptx;
     try
     {
       // gather info to ask the user


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6203