### PR TITLE
[rpc] fill miner_tx_hash at root field of on_get block rpc call

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2375,6 +2375,7 @@ namespace cryptonote
       error_resp.message = "Internal error: can't produce valid response.";
       return false;
     }
+    res.miner_tx_hash = res.block_header.miner_tx_hash;
     for (size_t n = 0; n < blk.tx_hashes.size(); ++n)
     {
       res.tx_hashes.push_back(epee::string_tools::pod_to_hex(blk.tx_hashes[n]));


### PR DESCRIPTION
This PR ( ref: https://github.com/monero-project/monero/pull/6259 ) partially reverts this https://github.com/monero-project/monero/pull/5964 as reported by this issue https://github.com/monero-project/monero/issues/6258
In our case it serves us fine cause we had from the beginning an empty string in the response for miner_tx_hash in the root field, although the miner_tx_hash shows above at block header. Now we get response for the miner_tx_hash in the root field as well as shown at the images below
Before
![get_block](https://user-images.githubusercontent.com/34991117/75633723-19c82280-5c10-11ea-8758-3d1701fca9c0.JPG)
After 
![get_block1](https://user-images.githubusercontent.com/34991117/75633727-2c425c00-5c10-11ea-9609-11f4a3d48601.JPG)



