### PR TITLE
[utils] split line(string) with '\n'

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -1239,7 +1239,7 @@ std::string get_nix_version_display_string()
     return get_string_prefix_by_width(s, 999999999).second;
   };
 
-  std::vector<std::pair<std::string, size_t>> split_string_by_width(const std::string &s, size_t columns)
+  std::vector<std::pair<std::string, size_t>> split_line_by_width(const std::string &s, size_t columns)
   {
     std::vector<std::string> words;
     std::vector<std::pair<std::string, size_t>> lines;
@@ -1279,4 +1279,17 @@ std::string get_nix_version_display_string()
     return lines;
   }
 
+  std::vector<std::pair<std::string, size_t>> split_string_by_width(const std::string &s, size_t columns)
+  {
+    std::vector<std::string> lines;
+    std::vector<std::pair<std::string, size_t>> all_lines;
+    boost::split(lines, s, boost::is_any_of("\n"), boost::token_compress_on);
+    for (const auto &e: lines)
+    {
+      std::vector<std::pair<std::string, size_t>> new_lines = split_line_by_width(e, columns);
+      for (auto &l: new_lines)
+        all_lines.push_back(std::move(l));
+    }
+    return all_lines;
+  }
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -314,7 +314,7 @@ namespace cryptonote
       if (version >= 6 && version != hshd.top_version)
       {
         if (version < hshd.top_version && version == m_core.get_ideal_hard_fork_version())
-          MCLOG_RED(el::Level::Warning, "global", context << " peer claims higher version that we think (" <<
+          MCLOG_RED(el::Level::Warning, "global", context << " peer claims higher version than we think (" <<
               (unsigned)hshd.top_version << " for " << (hshd.current_height - 1) << " instead of " << (unsigned)version <<
               ") - we may be forked from the network and a software upgrade may be needed");
         return false;


### PR DESCRIPTION
Partial ref: https://github.com/monero-project/monero/pull/6058
We dont need the extra help message cause we have our own format on lock screen but we do need the split line with /n on string printing redefinition.
(Plus a small typo fix)