### PR TITLE
[easylogging++] add emscripten support

### DIFF
--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -125,6 +125,11 @@
 #else
 #  define ELPP_OS_NETBSD 0
 #endif
+#if defined(__EMSCRIPTEN__)
+#  define ELPP_OS_EMSCRIPTEN 1
+#else
+#  define ELPP_OS_EMSCRIPTEN 0
+#endif
 #if (defined(__DragonFly__))
 #   define ELPP_OS_DRAGONFLY 1
 #else


### PR DESCRIPTION
Fixed the warnings (build logs on workflow checks for both ubuntu and mingw build for windows confirm that as well). We either merge this now or we can merge it along with https://github.com/monero-project/monero/pull/6332 if it gets approved after review
The implementation was bad from monero side it is supposed to be
```
#if defined(__EMSCRIPTEN__)
#  define ELPP_OS_EMSCRIPTEN 1
#else
#  define ELPP_OS_EMSCRIPTEN 0
#endif
```
not 
```
#if defined(__EMSCRIPTEN__)
#  define ELPP_OS_EMSCRIPTEN 1
#endif
```