### PR TITLE
[epee]TLS1.2 workaround-boost 1.58 (Xenial build)

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -289,7 +289,7 @@ ssl_options_t::ssl_options_t(std::vector<std::vector<std::uint8_t>> fingerprints
 
 boost::asio::ssl::context ssl_options_t::create_context() const
 {
-  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::tlsv12};
+  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::sslv23};
   if (!bool(*this))
     return ssl_context;
 


### PR DESCRIPTION
At the moment master wont build at Xenial cause Xenial hosts boost 1.58 by default and ssl::context::tls is not declared on this boost version. This is a  "smart and stupid", at the same time, workaround, since monero guys disallowed sslv2 and sslv3 as well as tlsv1 and tlsv2 with ssl flags so as to return tls version 1.2 and up, we set sslv23 by default which is ok with boost 1.58 and we know its wrong and the flags below make sure its upgraded to tlsv1.2 that we wanted anyhow