### PR TITLE
[wallet2] revert the warning fix and silence it in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,7 +558,7 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAG}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAG}")
 
-  set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-unused-lambda-capture -Wno-unused-command-line-argument -Wno-unused-parameter -Wno-unused-variable -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
+  set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Wno-error=extra -Wno-error=deprecated-declarations -Wno-maybe-uninitialized -Wno-unknown-warning -Wno-unused-lambda-capture -Wno-unused-command-line-argument -Wno-unused-parameter -Wno-unused-variable -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized")
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     if(ARM)
       set(WARNINGS "${WARNINGS} -Wno-error=inline-asm")

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -481,7 +481,6 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   }
 
   std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(nettype, kdf_rounds, unattended));
-  trusted_daemon = false;
   wallet->init(std::move(daemon_address), std::move(login), std::move(proxy), 0, *trusted_daemon, std::move(ssl_options));
   boost::filesystem::path ringdb_path = command_line::get_arg(vm, opts.shared_ringdb_dir);
   wallet->set_ring_database(ringdb_path.string());


### PR DESCRIPTION
Revert the fix on wallet2 for the warning that trusted_daemon variable may be used uninitialized cause the trusted daemon logic is defined in a messy way so instead of rewritting it just silence it on cmake.
Added as well a flag to not emmit warnings that may arise from flags not recognised between different gcc versions (-Wno-unknown-warning)