### PR TITLE
[cmake] fix for building static on ubuntu xenial and old linux versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,7 +643,7 @@ else()
   endif()
 
   # linker
-  if (NOT (WIN32 AND (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1)))
+  if (NOT WIN32 AND NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
     # Windows binaries die on startup with PIE when compiled with GCC <9.x
     add_linker_flag_if_supported(-pie LD_SECURITY_FLAGS)
   endif()


### PR DESCRIPTION
The linker flag's if clause, for position-independent executable (pie), was miswritten causing static build with make release-static build on xenial failing.
A clean 16.04 instance needs libusb-1.0-0-dev , libudev1 and libudev-dev installed otherwise build fails. 

(This has nothing to do with cross compile built binaries compatibility with old linux versions but only with make release-static on 16.04 natively. Best way to make cross compile binaries for linux to be compatible with old linux distro releases is to build them at the most clean and old linux version available rather than start patching libraries like monero did with sodium. Cross built linux binaries on 16.04, for example, work with 16.04 and 18.04 however cross built linux binaries on 18.04 are not backward compatible to 16.04 as monero found out in their new release. This is the best way as the more obsolete older versions become and more libraries are updated (like libsodium which was upgraded to latest version and created the issue) the more patches will be needed to retain backwards compatibility)