### PR TITLE
[daemon] Modify show db_size

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -566,10 +566,14 @@ bool t_rpc_command_executor::show_disk() {
     }
   }
 
-  size_t chainsize = (ires.database_size)/1000000;
+  uint64_t chainsize = (ires.database_size)/1000000;
   uint64_t freespace = (ires.free_space)/1000000;
-
-  std::cout << std:: endl << "\033[1mBlockchain db current size on disk: \033[0m" << "\033[32;1m" << chainsize << " MB" << "\033[0m"  << "  " << std::endl;
+  std::string os_version = tools::get_os_version_string();
+  std::string win = "Windows";
+  if (!(os_version.find(win) != std::string::npos)) 
+  {
+    std::cout << std:: endl << "\033[1mBlockchain db current size on disk: \033[0m" << "\033[32;1m" << chainsize << " MB" << "\033[0m"  << "  " << std::endl;
+  }
   std::cout << "\033[1mRemaining disk space: \033[0m" << "\033[32;1m" << freespace << " MB" << "\033[0m" << std::endl;
 
   return true;
@@ -646,8 +650,9 @@ bool t_rpc_command_executor::show_status() {
       bootstrap_msg += " was used before";
     }
   }
-  size_t chainsize = (ires.database_size)/1000000;
+  uint64_t chainsize = (ires.database_size)/1000000;
   std::string os_version = tools::get_os_version_string();
+  std::string win = "Windows";
   std::string network_type = (ires.testnet ? "testnet" : ires.stagenet ? "stagenet" : "mainnet");
   double perc = round(get_sync_percentage(ires));
   std::stringstream str;
@@ -676,8 +681,11 @@ bool t_rpc_command_executor::show_status() {
   std::cout << "\033[1mCurrent Height: \033[0m" << "\033[32;1m" << (unsigned long long)ires.height << "\033[0m" << "  " <<
    	         "\033[1mNetwork Height: \033[0m" << "\033[32;1m" << (unsigned long long)net_height << "\033[0m" << "  " <<
    	         "\033[1mSync percentage: \033[0m" << "\033[32;1m" << perc << "%" << "\033[0m" << "  " << 
-	         "\033[1mBootstrap: \033[0m" << "\033[32;1m" << bootstrap_msg << "\033[0m" << std::endl <<
-	         "\033[1mBlockchain db current size on disk: \033[0m" << "\033[32;1m" << chainsize << " MB" << "\033[0m"  << "  " << std::endl;
+	         "\033[1mBootstrap: \033[0m" << "\033[32;1m" << bootstrap_msg << "\033[0m" << std::endl;
+  if (!(os_version.find(win) != std::string::npos)) 
+  {
+    std::cout <<   "\033[1mBlockchain db current size on disk: \033[0m" << "\033[32;1m" << chainsize << " MB" << "\033[0m"  << "  " << std::endl;
+  }
   std::cout << "\033[1m------------" << std::endl;
   std::cout << "NETWORK INFO" << std::endl;
   std::cout << "------------\033[0m" << std::endl;


### PR DESCRIPTION
Windows doesnt like revealing file size while Linux has not problem with that.
Omit printing current db size on windows on "status" and the recently added "disk" calls.
Unconvential way of checking if daemon is running on windows but it was the easiest i could think of :)