### PR TITLE
[MSYS2] Fix broken lib linker

### DIFF
--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -174,7 +174,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET utilities_menu POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-utilities-menu.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-utilities-menu.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 set(CMAKE_EXE_LINKER_FLAGS "${LD_BACKCOMPAT_FLAGS}")
@@ -210,7 +210,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_import POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-import.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-import.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_export
@@ -240,7 +240,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_export POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-export.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-export.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_blackball
@@ -271,7 +271,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_blackball POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-mark-spent-outputs.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-mark-spent-outputs.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_usage
@@ -301,7 +301,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_usage POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-usage.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-usage.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_ancestry
@@ -331,7 +331,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_ancestry POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-ancestry.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-ancestry.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_depth
@@ -361,7 +361,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_depth POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-depth.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-depth.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_stats
@@ -391,7 +391,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_stats POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-stats.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-stats.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_prune_known_spent_data
@@ -422,7 +422,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_prune_known_spent_data POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-prune-known-spent-data.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-prune-known-spent-data.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 monero_add_executable(blockchain_prune
@@ -440,7 +440,7 @@ endif()
 if (WIN32)
 add_custom_command(TARGET blockchain_prune POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/bin/sumo-blockchain-prune.exe ${CMAKE_BINARY_DIR}/bin/blockchain_utilities/sumo-blockchain-prune.exe)
-set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc  -static-libstdc++ -Wl,-Bstatic -lstdc++ -lssp -lpthread -Wl,-Bdynamic ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()
 
 target_link_libraries(blockchain_prune


### PR DESCRIPTION
Due to a recent msys2 bug with  -D_FORTIFY_SOURCE and -fstack-protector flags (Ref: https://github.com/msys2/MINGW-packages/issues/5868) libssp dynamic library (dll) was missing (not statically linked) when trying to run  blockchain utilities exe files as it now needs to add -fstack-protector explicitely to these EXEs for -lssp to be added. So just link lssp directly to these binaries