### PR TITLE
[p2p] use the hardcoded seed nodes directly + fix off by one adding fallback peers

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -666,7 +666,7 @@ namespace nodetool
       {
 /*
   //Spare us the time and resources checking for seed nodes by DNS resolving hardcoded addresses which are not updated regularly anyhow. 
-  //Use the "fallback" harcoded seed IPs which are plenty, regularly checked and updated
+  //use the "fallback" harcoded seed IPs which are plenty, regularly checked and updated
       // for each hostname in the seed nodes list, attempt to DNS resolve and
       // add the result addresses as seed nodes
       // TODO: at some point add IPv6 support, but that won't be relevant
@@ -1567,14 +1567,14 @@ namespace nodetool
           if (!m_fallback_seed_nodes_added)
           {
             MWARNING("Failed to connect to any of seed peers, trying fallback seeds");
-            current_index = m_seed_nodes.size();
+            current_index = m_seed_nodes.size() - 1;
             for (const auto &peer: get_seed_nodes(m_nettype))
             {
               MDEBUG("Fallback seed node: " << peer);
               append_net_address(m_seed_nodes, peer, cryptonote::get_config(m_nettype).P2P_DEFAULT_PORT);
             }
             m_fallback_seed_nodes_added = true;
-            if (current_index == m_seed_nodes.size())
+            if (current_index == m_seed_nodes.size() - 1)
             {
               MWARNING("No fallback seeds, continuing without seeds");
               break;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -69,7 +69,7 @@
 
 #define NET_MAKE_IP(b1,b2,b3,b4)  ((LPARAM)(((DWORD)(b1)<<24)+((DWORD)(b2)<<16)+((DWORD)(b3)<<8)+((DWORD)(b4))))
 
-#define MIN_WANTED_SEED_NODES 12
+// #define MIN_WANTED_SEED_NODES 12
 
 namespace nodetool
 {
@@ -664,6 +664,9 @@ namespace nodetool
       memcpy(&m_network_id, &::config::NETWORK_ID, 16);
       if (m_exclusive_peers.empty() && !m_offline)
       {
+/*
+  //Spare us the time and resources checking for seed nodes by DNS resolving hardcoded addresses which are not updated regularly anyhow. 
+  //Use the "fallback" harcoded seed IPs which are plenty, regularly checked and updated
       // for each hostname in the seed nodes list, attempt to DNS resolve and
       // add the result addresses as seed nodes
       // TODO: at some point add IPv6 support, but that won't be relevant
@@ -738,21 +741,21 @@ namespace nodetool
         }
         ++i;
       }
-
-      // append the fallback nodes if we have too few seed nodes to start with
+      // append the fallback nodes if we have too few seed nodes to start with (not anymore)
+      // always append the fall back hardcoded seed nodes
       if (full_addrs.size() < MIN_WANTED_SEED_NODES)
       {
         if (full_addrs.empty())
           MINFO("DNS seed node lookup either timed out or failed, falling back to defaults");
         else
           MINFO("Not enough DNS seed nodes found, using fallback defaults too");
-
-        for (const auto &peer: get_seed_nodes(cryptonote::MAINNET))
-          full_addrs.insert(peer);
-        m_fallback_seed_nodes_added = true;
+*/
+       for (const auto &peer: get_seed_nodes(cryptonote::MAINNET))
+        full_addrs.insert(peer);
+       m_fallback_seed_nodes_added = true;
       }
     }
-    }
+//  }
 
     for (const auto& full_addr : full_addrs)
     {


### PR DESCRIPTION
Spare us the time and resources checking for seed nodes by DNS resolving hardcoded addresses which are not updated regularly anyhow.  
Use the hardcoded seed list directly. Plenty of seed nodes that are regulary checked and updated.
Also add in the same PR monero's https://github.com/monero-project/monero/pull/6283 
(It resets the connection list to zero by ignoring the first added node which is always a seed (to grab its peerlist) and a new connection)

