### PR TITLE
[core] increase default stack size to normal size

### DIFF
--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -31,6 +31,12 @@
 #include "cryptonote_config.h"
 #include "common/util.h"
 
+#ifdef __APPLE__
+#define THREAD_STACK_SIZE 5 * 1024 * 1024
+#else
+#define THREAD_STACK_SIZE 10 * 1024 * 1024
+#endif
+
 static __thread int depth = 0;
 static __thread bool is_leaf = false;
 

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -77,6 +77,12 @@
 #define AUTODETECT_WINDOW 10 // seconds
 #define AUTODETECT_GAIN_THRESHOLD 1.02f  // 2%
 
+#ifdef __APPLE__
+#define THREAD_STACK_SIZE 5 * 1024 * 1024
+#else
+#define THREAD_STACK_SIZE 10 * 1024 * 1024
+#endif
+
 using namespace epee;
 
 #include "miner.h"

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -165,7 +165,6 @@
 #define RPC_PAYMENTS_DATA_FILENAME              "rpcpayments.bin"
 #define MINER_CONFIG_FILE_NAME                  "miner_conf.json"
 
-#define THREAD_STACK_SIZE                       5 * 1024 * 1024
 
 // coin emission change interval/speed configs
 #define COIN_EMISSION_MONTH_INTERVAL                    6  // months to change emission speed

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -71,6 +71,12 @@
 
 #define MIN_WANTED_SEED_NODES 12
 
+#ifdef __APPLE__
+#define THREAD_STACK_SIZE 5 * 1024 * 1024
+#else
+#define THREAD_STACK_SIZE 10 * 1024 * 1024
+#endif
+
 namespace nodetool
 {
   template<class t_payload_net_handler>


### PR DESCRIPTION
I was considering increasing the p2p threads initially when noticed that the stack size was predetermined to 512Kb instead of 1 Mb in order to accomodate macOS which has half the default stack size compared to Linux and Windows (even iOS's is 1 Mb).
So remove it from config and set it explicetely to the places that this variable was used.
Time and testing will tell if this speeds up things at all cause even with half the stack size there was no overflows but in any case this is the correct way to address the stack size (1 Mb for all OS except for macOS)