### PR TITLE
[wallet] do not erase rings on tx failure, better iv selection and wording update

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1694,7 +1694,7 @@ bool simple_wallet::print_ring(const std::vector<std::string> &args)
       rings.push_back({key_image, ring});
     else if (!m_wallet->get_rings(txid, rings))
     {
-      fail_msg_writer() << tr("Key image either not spent, or spent with mixin 0");
+      fail_msg_writer() << tr("Key image is not spent");
       return true;
     }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2939,7 +2939,6 @@ void wallet2::update_pool_state(std::vector<std::tuple<cryptonote::transaction, 
         pit->second.m_state = wallet2::unconfirmed_transfer_details::failed;
 
         // the inputs aren't spent anymore, since the tx failed
-        remove_rings(pit->second.m_tx);
         for (size_t vini = 0; vini < pit->second.m_tx.vin.size(); ++vini)
         {
           if (pit->second.m_tx.vin[vini].type() == typeid(txin_to_key))


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6288
(with a minor change in wording as we have no txs with 0 mixin)

That's a good catch by moo what he actually did is figure out that since keys and data are two separate entities in the stored rings table and this is a stream cipher, they need to be combined with a different initialisation vector.
We keep the authentication tag for ciphered data same we dont mind.
Very nice catch. Because of such things Monero is unbeatable in privacy