### PR TITLE
[depends] remove obsolete fallback address reference

### DIFF
--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -31,8 +31,7 @@ endef
 
 define fetch_file
     ( test -f $$($(1)_source_dir)/$(4) || \
-    ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
-      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
+    ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5))))
 endef
 
 define int_get_build_recipe_hash


### PR DESCRIPTION
We previously removed that depends fallback address, leading to bitcoin's repo, cause it was obsolete.
Remove this reference as well (when cross building it gives curl a bad time trying to find it when for some reason connection to an official repo fails and ends the building)