### PR TITLE
[core] drop unused verification_context::m_not_rct field

### DIFF
--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -48,7 +48,6 @@ namespace cryptonote
     bool m_too_big;
     bool m_overspend;
     bool m_fee_too_low;
-    bool m_not_rct;
     bool m_invalid_tx_version;
     bool m_too_few_outputs;
   };

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1309,8 +1309,6 @@ namespace cryptonote
         add_reason(reason, "overspend");
       if ((res.fee_too_low = tvc.m_fee_too_low))
         add_reason(reason, "fee too low");
-      if ((res.not_rct = tvc.m_not_rct))
-        add_reason(reason, "tx is not ringct");
       if ((res.too_few_outputs = tvc.m_too_few_outputs))
         add_reason(reason, "too few outputs");
       const std::string punctuation = reason.empty() ? "" : ": ";

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -653,7 +653,6 @@ namespace cryptonote
       bool too_big;
       bool overspend;
       bool fee_too_low;
-      bool not_rct;
       bool too_few_outputs;
       bool sanity_check_failed;
 
@@ -668,7 +667,6 @@ namespace cryptonote
         KV_SERIALIZE(too_big)
         KV_SERIALIZE(overspend)
         KV_SERIALIZE(fee_too_low)
-        KV_SERIALIZE(not_rct)
         KV_SERIALIZE(too_few_outputs)
         KV_SERIALIZE(sanity_check_failed)
       END_KV_SERIALIZE_MAP()

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -338,11 +338,6 @@ namespace rpc
         if (!res.error_details.empty()) res.error_details += " and ";
         res.error_details += "fee too low";
       }
-      if (tvc.m_not_rct)
-      {
-        if (!res.error_details.empty()) res.error_details += " and ";
-        res.error_details += "tx is not ringct";
-      }
       if (tvc.m_too_few_outputs)
       {
         if (!res.error_details.empty()) res.error_details += " and ";

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -240,8 +240,6 @@ namespace
         add_reason(reason, "overspend");
       if (res.fee_too_low)
         add_reason(reason, "fee too low");
-      if (res.not_rct)
-        add_reason(reason, "tx is not ringct");
       if (res.sanity_check_failed)
         add_reason(reason, "tx sanity check failed");
       if (res.not_relayed)

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -257,7 +257,6 @@ class TransferTest():
         assert res.too_big == False
         assert res.overspend == False
         assert res.fee_too_low == False
-        assert res.not_rct == False
 
         self.wallet[0].refresh()
 
@@ -599,7 +598,6 @@ class TransferTest():
         assert res.too_big == False
         assert res.overspend == False
         assert res.fee_too_low == False
-        assert res.not_rct == False
 
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
@@ -616,7 +614,6 @@ class TransferTest():
         assert res.too_big == False
         assert res.overspend == False
         assert res.fee_too_low == False
-        assert res.not_rct == False
         assert res.too_few_outputs == False
 
         res = daemon.get_transactions([txes[0][0]])


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6286