### PR TITLE
[epee] wipeable_string: split - treat CR, LF and Tabs as separators

### DIFF
--- a/contrib/epee/src/wipeable_string.cpp
+++ b/contrib/epee/src/wipeable_string.cpp
@@ -188,13 +188,14 @@ void wipeable_string::split(std::vector<wipeable_string> &fields) const
   while (len--)
   {
     const char c = *ptr++;
-    if (c != ' ')
+    const bool space_prev = space;
+    space = std::isspace(c);
+    if (!space)
     {
-      if (space)
+      if (space_prev)
         fields.push_back({});
       fields.back().push_back(c);
     }
-    space = c == ' ';
   }
 }
 

--- a/tests/unit_tests/wipeable_string.cpp
+++ b/tests/unit_tests/wipeable_string.cpp
@@ -182,6 +182,7 @@ TEST(wipeable_string, split)
   ASSERT_TRUE(check_split(" foo     bar   baz         ", {"foo", "bar", "baz"}));
   ASSERT_TRUE(check_split("  foo     bar   baz", {"foo", "bar", "baz"}));
   ASSERT_TRUE(check_split("foo     bar   baz ", {"foo", "bar", "baz"}));
+  ASSERT_TRUE(check_split("\tfoo\n bar\r\nbaz", {"foo", "bar", "baz"}));
 }
 
 TEST(wipeable_string, parse_hexstr)


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6335
It strips whitespaces and line breaks from seed, nice