### PR TITLE
[simplewallet] Change notification for encrypted payment id

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5045,7 +5045,8 @@ boost::optional<epee::wipeable_string> simple_wallet::open_wallet(const boost::p
     tr("Use the \"help\" command to see a simplified list of available commands.\n") <<
     tr("Use the \"help_advanced\" command to see an advanced list of available commands.\n") <<
     tr("Use \"help_advanced <command>\" to see a command's documentation.\n") <<
-    "**********************************************************************";
+    "**********************************************************************\n" <<
+    tr("NOTE: For privacy reasons avoid using an encrypted payment ID, consider using subaddresses instead");
   return password;
 }
 //----------------------------------------------------------------------------------------------------
@@ -5490,9 +5491,9 @@ void simple_wallet::on_money_received(uint64_t height, const crypto::hash &txid,
      }
     }
 
-    if (payment_id8 != crypto::null_hash8)
-      message_writer() <<
-        tr("NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead");
+//  if (payment_id8 != crypto::null_hash8)
+//    message_writer() <<
+//      tr("NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead");
 
     crypto::hash payment_id = crypto::null_hash;
     if (get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))


### PR DESCRIPTION
This notification warns us when we use an encrypted payment id and suggests to use subaddresses for more privacy instead.
It keeps on appearing annoyingly  (even it was fixed by monero in the past) at random transactions. I think its the way the if clause is defined 
```
    if (payment_id8 != crypto::null_hash8)
      message_writer() <<
        tr("NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead");
```
check if dummy payment id (payment_id8) is different from the dummy crypto::null_hash8 (always created for tx uniformity) which would mean that there is a user defined encrypted payment id. Its kind of sloppy. I wont be changing anything just bring this notification message permantly to be shown once on intro messages and get over and done with it
the warning below that for the unencrypted payment id works just fine
```
    crypto::hash payment_id = crypto::null_hash;
    if (get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
      message_writer(console_color_red, false) <<
        tr("WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.");
```