### PR TITLE
[daemon] auto public nodes - cache and prioritize most stable nodes

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -35,6 +35,7 @@ set(rpc_base_sources
 
 set(rpc_sources
   bootstrap_daemon.cpp
+  bootstrap_node_selector.cpp
   core_rpc_server.cpp
   rpc_payment.cpp
   rpc_version_str.cpp

--- a/src/rpc/bootstrap_daemon.cpp
+++ b/src/rpc/bootstrap_daemon.cpp
@@ -2,6 +2,8 @@
 
 #include <stdexcept>
 
+#include <boost/thread/locks.hpp>
+
 #include "crypto/crypto.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "misc_log_ex.h"
@@ -12,15 +14,22 @@
 namespace cryptonote
 {
 
-  bootstrap_daemon::bootstrap_daemon(std::function<boost::optional<std::string>()> get_next_public_node)
-    : m_get_next_public_node(get_next_public_node)
+  bootstrap_daemon::bootstrap_daemon(
+    std::function<std::map<std::string, bool>()> get_public_nodes,
+    bool rpc_payment_enabled)
+    : m_selector(new bootstrap_node::selector_auto(std::move(get_public_nodes)))
+    , m_rpc_payment_enabled(rpc_payment_enabled)
   {
   }
 
-  bootstrap_daemon::bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials)
-    : bootstrap_daemon(nullptr)
+  bootstrap_daemon::bootstrap_daemon(
+    const std::string &address,
+    boost::optional<epee::net_utils::http::login> credentials,
+    bool rpc_payment_enabled)
+    : m_selector(nullptr)
+    , m_rpc_payment_enabled(rpc_payment_enabled)
   {
-    if (!set_server(address, credentials))
+    if (!set_server(address, std::move(credentials)))
     {
       throw std::runtime_error("invalid bootstrap daemon address or credentials");
     }
@@ -54,11 +63,16 @@ namespace cryptonote
     return res.height;
   }
 
-  bool bootstrap_daemon::handle_result(bool success)
+  bool bootstrap_daemon::handle_result(bool success, const std::string &status)
   {
-    if (!success && m_get_next_public_node)
+    const bool failed = !success || (!m_rpc_payment_enabled && status == CORE_RPC_STATUS_PAYMENT_REQUIRED);
+    if (failed && m_selector)
     {
+      const std::string current_address = address();
       m_http_client.disconnect();
+
+      const boost::unique_lock<boost::mutex> lock(m_selector_mutex);
+      m_selector->handle_result(current_address, !failed);
     }
 
     return success;
@@ -79,14 +93,18 @@ namespace cryptonote
 
   bool bootstrap_daemon::switch_server_if_needed()
   {
-    if (!m_get_next_public_node || m_http_client.is_connected())
+    if (m_http_client.is_connected() || !m_selector)
     {
       return true;
     }
 
-    const boost::optional<std::string> address = m_get_next_public_node();
-    if (address) {
-      return set_server(*address);
+    boost::optional<bootstrap_node::node_info> node;
+    {
+      const boost::unique_lock<boost::mutex> lock(m_selector_mutex);
+      node = m_selector->next_node();
+    }
+    if (node) {
+      return set_server(node->address, node->credentials);
     }
 
     return false;

--- a/src/rpc/bootstrap_node_selector.cpp
+++ b/src/rpc/bootstrap_node_selector.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "bootstrap_node_selector.h"
+
+#include "crypto/crypto.h"
+
+namespace cryptonote
+{
+namespace bootstrap_node
+{
+
+  void selector_auto::node::handle_result(bool success)
+  {
+    if (!success)
+    {
+      fails = std::min(std::numeric_limits<size_t>::max() - 2, fails) + 2;
+    }
+    else
+    {
+      fails = std::max(std::numeric_limits<size_t>::min() + 2, fails) - 2;
+    }
+  }
+
+  void selector_auto::handle_result(const std::string &address, bool success)
+  {
+    auto &nodes_by_address = m_nodes.get<by_address>();
+    const auto it = nodes_by_address.find(address);
+    if (it != nodes_by_address.end())
+    {
+      nodes_by_address.modify(it, [success](node &entry) {
+        entry.handle_result(success);
+      });
+    }
+  }
+
+  boost::optional<node_info> selector_auto::next_node()
+  {
+    if (!has_at_least_one_good_node())
+    {
+      append_new_nodes();
+    }
+
+    if (m_nodes.empty())
+    {
+      return {};
+    }
+
+    auto node = m_nodes.get<by_fails>().begin();
+    const size_t count = std::distance(node, m_nodes.get<by_fails>().upper_bound(node->fails));
+    std::advance(node, crypto::rand_idx(count));
+
+    return {{node->address, {}}};
+  }
+
+  bool selector_auto::has_at_least_one_good_node() const
+  {
+    return !m_nodes.empty() && m_nodes.get<by_fails>().begin()->fails == 0;
+  }
+
+  void selector_auto::append_new_nodes()
+  {
+    bool updated = false;
+
+    for (const auto &node : m_get_nodes())
+    {
+      const auto &address = node.first;
+      const auto &white = node.second;
+      const size_t initial_score = white ? 0 : 1;
+      updated |= m_nodes.get<by_address>().insert({address, initial_score}).second;
+    }
+
+    if (updated)
+    {
+      truncate();
+    }
+  }
+
+  void selector_auto::truncate()
+  {
+    const size_t total = m_nodes.size();
+    if (total > m_max_nodes)
+    {
+      auto &nodes_by_fails = m_nodes.get<by_fails>();
+      auto from = nodes_by_fails.rbegin();
+      std::advance(from, total - m_max_nodes);
+      nodes_by_fails.erase(from.base(), nodes_by_fails.end());
+    }
+  }
+
+}
+}

--- a/src/rpc/bootstrap_node_selector.h
+++ b/src/rpc/bootstrap_node_selector.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma  once
+
+#include <functional>
+#include <limits>
+#include <map>
+#include <string>
+#include <utility>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/optional/optional.hpp>
+
+#include "net/http_client.h"
+
+namespace cryptonote
+{
+namespace bootstrap_node
+{
+
+  struct node_info
+  {
+    std::string address;
+    boost::optional<epee::net_utils::http::login> credentials;
+  };
+
+  struct selector
+  {
+    virtual void handle_result(const std::string &address, bool success) = 0;
+    virtual boost::optional<node_info> next_node() = 0;
+  };
+
+  class selector_auto : public selector
+  {
+  public:
+    selector_auto(std::function<std::map<std::string, bool>()> get_nodes, size_t max_nodes = 1000)
+      : m_get_nodes(std::move(get_nodes))
+      , m_max_nodes(max_nodes)
+    {}
+
+    void handle_result(const std::string &address, bool success) final;
+    boost::optional<node_info> next_node() final;
+
+  private:
+    bool has_at_least_one_good_node() const;
+    void append_new_nodes();
+    void truncate();
+
+  private:
+    struct node
+    {
+      std::string address;
+      size_t fails;
+
+      void handle_result(bool success);
+    };
+
+    struct by_address {};
+    struct by_fails {};
+
+    typedef boost::multi_index_container<
+      node,
+      boost::multi_index::indexed_by<
+        boost::multi_index::ordered_unique<boost::multi_index::tag<by_address>, boost::multi_index::member<node, std::string, &node::address>>,
+        boost::multi_index::ordered_non_unique<boost::multi_index::tag<by_fails>, boost::multi_index::member<node, size_t, &node::fails>>
+      >
+    > nodes_list;
+
+    const std::function<std::map<std::string, bool>()> m_get_nodes;
+    const size_t m_max_nodes;
+    nodes_list m_nodes;
+  };
+
+}
+}

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <boost/preprocessor/stringize.hpp>
@@ -173,7 +173,7 @@ namespace cryptonote
     return set_bootstrap_daemon(address, credentials);
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  boost::optional<std::string> core_rpc_server::get_random_public_node()
+  std::map<std::string, bool> core_rpc_server::get_public_nodes(uint32_t credits_per_hash_threshold/* = 0*/)
   {
     COMMAND_RPC_GET_PUBLIC_NODES::request request;
     COMMAND_RPC_GET_PUBLIC_NODES::response response;
@@ -182,35 +182,36 @@ namespace cryptonote
     request.white = true;
     if (!on_get_public_nodes(request, response) || response.status != CORE_RPC_STATUS_OK)
     {
-      return boost::none;
+      return {};
     }
 
-    const auto get_random_node_address = [](const std::vector<public_node>& public_nodes) -> std::string {
-      const auto& random_node = public_nodes[crypto::rand_idx(public_nodes.size())];
-      const auto address = random_node.host + ":" + std::to_string(random_node.rpc_port);
-      return address;
+    std::map<std::string, bool> result;
+
+    const auto append = [&result, &credits_per_hash_threshold](const std::vector<public_node> &nodes, bool white) {
+      for (const auto &node : nodes)
+      {
+        const bool rpc_payment_enabled = credits_per_hash_threshold > 0;
+        const bool node_rpc_payment_enabled = node.rpc_credits_per_hash > 0;
+        if (!node_rpc_payment_enabled ||
+            (rpc_payment_enabled && node.rpc_credits_per_hash >= credits_per_hash_threshold))
+        {
+          result.insert(std::make_pair(node.host + ":" + std::to_string(node.rpc_port), white));
+        }
+      }
     };
 
-    if (!response.white.empty())
-    {
-      return get_random_node_address(response.white);
-    }
+    append(response.white, true);
+    append(response.gray, false);
 
-    MDEBUG("No white public node found, checking gray peers");
-
-    if (!response.gray.empty())
-    {
-      return get_random_node_address(response.gray);
-    }
-
-    MERROR("Failed to find any suitable public node");
-
-    return boost::none;
+    return result;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::set_bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials)
   {
     boost::unique_lock<boost::shared_mutex> lock(m_bootstrap_daemon_mutex);
+
+    constexpr const uint32_t credits_per_hash_threshold = 0;
+    constexpr const bool rpc_payment_enabled = credits_per_hash_threshold != 0;
 
     if (address.empty())
     {
@@ -218,11 +219,14 @@ namespace cryptonote
     }
     else if (address == "auto")
     {
-      m_bootstrap_daemon.reset(new bootstrap_daemon([this]{ return get_random_public_node(); }));
+      auto get_nodes = [this, credits_per_hash_threshold]() {
+        return get_public_nodes(credits_per_hash_threshold);
+      };
+      m_bootstrap_daemon.reset(new bootstrap_daemon(std::move(get_nodes), rpc_payment_enabled));
     }
     else
     {
-      m_bootstrap_daemon.reset(new bootstrap_daemon(address, credentials));
+      m_bootstrap_daemon.reset(new bootstrap_daemon(address, credentials, rpc_payment_enabled));
     }
 
     m_should_use_bootstrap_daemon = m_bootstrap_daemon.get() != nullptr;
@@ -1421,7 +1425,7 @@ namespace cryptonote
     res.active = lMiner.is_mining();
     res.is_background_mining_enabled = lMiner.get_is_background_mining_enabled();
     store_difficulty(m_core.get_blockchain_storage().get_difficulty_for_next_block(), res.difficulty, res.wide_difficulty, res.difficulty_top64);
-    
+
     res.block_target = DIFFICULTY_TARGET;
     if ( lMiner.is_mining() ) {
       res.speed = lMiner.get_speed();
@@ -1929,7 +1933,7 @@ namespace cryptonote
       error_resp.message = "Wrong block blob";
       return false;
     }
-    
+
     // Fixing of high orphan issue for most pools
     // Thanks Boolberry!
     block b;
@@ -1965,13 +1969,13 @@ namespace cryptonote
     RPC_TRACKER(generateblocks);
 
     CHECK_CORE_READY();
-    
+
     res.status = CORE_RPC_STATUS_OK;
 
     if(m_core.get_nettype() != FAKECHAIN)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_REGTEST_REQUIRED;
-      error_resp.message = "Regtest required when generating blocks";      
+      error_resp.message = "Regtest required when generating blocks";
       return false;
     }
 
@@ -1991,7 +1995,7 @@ namespace cryptonote
       bool r = on_getblocktemplate(template_req, template_res, error_resp, ctx);
       res.status = template_res.status;
       template_req.prev_block.clear();
-      
+
       if (!r) return false;
 
       blobdata blockblob;
@@ -2100,7 +2104,7 @@ namespace cryptonote
       if (*bootstrap_daemon_height < target_height)
       {
         MINFO("Bootstrap daemon is out of sync");
-        return m_bootstrap_daemon->handle_result(false);
+        return m_bootstrap_daemon->handle_result(false, {});
       }
 
       uint64_t top_height = m_core.get_current_blockchain_height();

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,10 +25,10 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#pragma  once 
+#pragma  once
 
 #include <memory>
 
@@ -105,7 +105,7 @@ namespace cryptonote
       MAP_URI_AUTO_BIN2("/getblocks_by_height.bin", on_get_blocks_by_height, COMMAND_RPC_GET_BLOCKS_BY_HEIGHT)
       MAP_URI_AUTO_BIN2("/get_hashes.bin", on_get_hashes, COMMAND_RPC_GET_HASHES_FAST)
       MAP_URI_AUTO_BIN2("/gethashes.bin", on_get_hashes, COMMAND_RPC_GET_HASHES_FAST)
-      MAP_URI_AUTO_BIN2("/get_o_indexes.bin", on_get_indexes, COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES)      
+      MAP_URI_AUTO_BIN2("/get_o_indexes.bin", on_get_indexes, COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES)
       MAP_URI_AUTO_BIN2("/get_outs.bin", on_get_outs_bin, COMMAND_RPC_GET_OUTPUTS_BIN)
       MAP_URI_AUTO_JON2("/get_transactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
@@ -136,7 +136,7 @@ namespace cryptonote
       MAP_URI_AUTO_JON2_IF("/set_limit", on_set_limit, COMMAND_RPC_SET_LIMIT, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/in_peers", on_in_peers, COMMAND_RPC_IN_PEERS, !m_restricted)
-      MAP_URI_AUTO_JON2("/get_outs", on_get_outs, COMMAND_RPC_GET_OUTPUTS)      
+      MAP_URI_AUTO_JON2("/get_outs", on_get_outs, COMMAND_RPC_GET_OUTPUTS)
       MAP_URI_AUTO_JON2_IF("/update", on_update, COMMAND_RPC_UPDATE, !m_restricted)
       MAP_URI_AUTO_BIN2("/get_output_distribution.bin", on_get_output_distribution_bin, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION)
       MAP_URI_AUTO_JON2_IF("/pop_blocks", on_pop_blocks, COMMAND_RPC_POP_BLOCKS, !m_restricted)
@@ -223,7 +223,7 @@ namespace cryptonote
     bool on_update(const COMMAND_RPC_UPDATE::request& req, COMMAND_RPC_UPDATE::response& res, const connection_context *ctx = NULL);
     bool on_get_output_distribution_bin(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, const connection_context *ctx = NULL);
     bool on_pop_blocks(const COMMAND_RPC_POP_BLOCKS::request& req, COMMAND_RPC_POP_BLOCKS::response& res, const connection_context *ctx = NULL);
-    
+
     //json_rpc
     bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res, const connection_context *ctx = NULL);
     bool on_getblockhash(const COMMAND_RPC_GETBLOCKHASH::request& req, COMMAND_RPC_GETBLOCKHASH::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
@@ -265,11 +265,11 @@ private:
     bool check_core_busy();
     bool check_core_ready();
     bool add_host_fail(const connection_context *ctx, unsigned int score = 1);
-    
+
     //utils
     uint64_t get_block_reward(const block& blk);
     bool fill_block_header_response(const block& blk, bool orphan_status, uint64_t height, const crypto::hash& hash, block_header_response& response, bool fill_pow_hash);
-    boost::optional<std::string> get_random_public_node();
+    std::map<std::string, bool> get_public_nodes(uint32_t credits_per_hash_threshold = 0);
     bool set_bootstrap_daemon(const std::string &address, const std::string &username_password);
     bool set_bootstrap_daemon(const std::string &address, const boost::optional<epee::net_utils::http::login> &credentials);
     enum invoke_http_mode { JON, BIN, JON_RPC };
@@ -277,7 +277,7 @@ private:
     bool use_bootstrap_daemon_if_necessary(const invoke_http_mode &mode, const std::string &command_name, const typename COMMAND_TYPE::request& req, typename COMMAND_TYPE::response& res, bool &r);
     bool get_block_template(const account_public_address &address, const crypto::hash *prev_block, const cryptonote::blobdata &extra_nonce, size_t &reserved_offset, cryptonote::difficulty_type &difficulty, uint64_t &height, uint64_t &expected_reward, block &b, uint64_t &seed_height, crypto::hash &seed_hash, crypto::hash &next_seed_hash, epee::json_rpc::error &error_resp);
     bool check_payment(const std::string &client, uint64_t payment, const std::string &rpc, bool same_ts, std::string &message, uint64_t &credits, std::string &top_hash);
-    
+
     core& m_core;
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> >& m_p2p;
     boost::shared_mutex m_bootstrap_daemon_mutex;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(unit_tests_sources
   blockchain_db.cpp
   block_queue.cpp
 #  block_reward.cpp (Needs have manipulation to work with sumo TODO)
+  bootstrap_node_selector.cpp
   bulletproofs.cpp
   canonical_amounts.cpp
   chacha.cpp

--- a/tests/unit_tests/bootstrap_node_selector.cpp
+++ b/tests/unit_tests/bootstrap_node_selector.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//  conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//  of conditions and the following disclaimer in the documentation and/or other
+//  materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//  used to endorse or promote products derived from this software without specific
+//  prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "rpc/bootstrap_node_selector.h"
+
+class bootstrap_node_selector : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    nodes.insert(white_nodes.begin(), white_nodes.end());
+    nodes.insert(gray_nodes.begin(), gray_nodes.end());
+  }
+
+  const std::map<std::string, bool> white_nodes = {
+    {
+      "white_node_1:18089", true
+    },
+    {
+      "white_node_2:18081", true
+    }
+  };
+  const std::map<std::string, bool> gray_nodes = {
+    {
+      "gray_node_1:18081", false
+    },
+    {
+      "gray_node_2:18089", false
+    }
+  };
+
+  std::map<std::string, bool> nodes;
+};
+
+TEST_F(bootstrap_node_selector, selector_auto_empty)
+{
+  cryptonote::bootstrap_node::selector_auto selector([]() {
+    return std::map<std::string, bool>();
+  });
+
+  EXPECT_FALSE(selector.next_node());
+}
+
+TEST_F(bootstrap_node_selector, selector_auto_no_credentials)
+{
+  cryptonote::bootstrap_node::selector_auto selector([this]() {
+    return nodes;
+  });
+
+  for (size_t fails = 0; fails < nodes.size(); ++fails)
+  {
+    const auto current = selector.next_node();
+    EXPECT_FALSE(current->credentials);
+
+    selector.handle_result(current->address, false);
+  }
+}
+
+TEST_F(bootstrap_node_selector, selector_auto_success)
+{
+  cryptonote::bootstrap_node::selector_auto selector([this]() {
+    return nodes;
+  });
+
+  auto current = selector.next_node();
+  for (size_t fails = 0; fails < nodes.size(); ++fails)
+  {
+    selector.handle_result(current->address, true);
+
+    current = selector.next_node();
+    EXPECT_TRUE(white_nodes.count(current->address) > 0);
+  }
+}
+
+TEST_F(bootstrap_node_selector, selector_auto_failure)
+{
+  cryptonote::bootstrap_node::selector_auto selector([this]() {
+    return nodes;
+  });
+
+  auto current = selector.next_node();
+  for (size_t fails = 0; fails < nodes.size(); ++fails)
+  {
+    const auto previous = current;
+
+    selector.handle_result(current->address, false);
+
+    current = selector.next_node();
+    EXPECT_NE(current->address, previous->address);
+  }
+}
+
+TEST_F(bootstrap_node_selector, selector_auto_white_nodes_first)
+{
+  cryptonote::bootstrap_node::selector_auto selector([this]() {
+    return nodes;
+  });
+
+  for (size_t iterations = 0; iterations < 2; ++iterations)
+  {
+    for (size_t fails = 0; fails < white_nodes.size(); ++fails)
+    {
+      const auto current = selector.next_node();
+      EXPECT_TRUE(white_nodes.count(current->address) > 0);
+
+      selector.handle_result(current->address, false);
+    }
+
+    for (size_t fails = 0; fails < gray_nodes.size(); ++fails)
+    {
+      const auto current = selector.next_node();
+      EXPECT_TRUE(gray_nodes.count(current->address) > 0);
+
+      selector.handle_result(current->address, false);
+    }
+  }
+}
+
+TEST_F(bootstrap_node_selector, selector_auto_max_nodes)
+{
+  const size_t max_nodes = nodes.size() / 2;
+
+  bool populated_once = false;
+  cryptonote::bootstrap_node::selector_auto selector([this, &populated_once]() {
+    if (!populated_once)
+    {
+      populated_once = true;
+      return nodes;
+    }
+
+    return std::map<std::string, bool>();
+  }, max_nodes);
+
+  std::set<std::string> unique_nodes;
+
+  for (size_t fails = 0; fails < nodes.size(); ++fails)
+  {
+    const auto current = selector.next_node();
+    unique_nodes.insert(current->address);
+
+    selector.handle_result(current->address, false);
+  }
+
+  EXPECT_EQ(unique_nodes.size(), max_nodes);
+}


### PR DESCRIPTION
This is a very good one, it optimizes the selection of nodes for bootstrapping improving the overall Sumokoin (and Monero) experience
Ref: https://github.com/monero-project/monero/pull/6357

**Quote**
_Improved public node selection algo used in Simple mode/---bootstrap-daemon-address auto._

_1. In-memory public nodes cache storing up to N (N=1000 by default) entries
 2. If the cache doesn't have at least one good public node (having fails count == 0):
          i. Get public nodes from P2P_
        _ii. Add new white public nodes to cache with initial fails count = 0
         iii. Add new gray public nodes to cache with initial fails count = 1
         iv. Truncate the cache to N public nodes, keep the nodes having lower fails count
  3. Select most stable public node (sorted by fails count), if there are multiple - choose a random one
  4. Send an RPC request:
i. On fail - increase the node's fails count by 2 and go to step 2
ii. On success - decrease the node's fails count by 2 and go to step 4_
**Unquote**