### PR TITLE
[depends] amend fallback address to point to sumokoin server

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ You can also cross-compile static binaries on Linux for Windows and macOS with t
 * ```make depends target=x86_64-w64-mingw32``` for 64-bit windows binaries.
   * Requires: `python3 g++-mingw-w64-x86-64 wine1.6 bc`
 * ```make depends target=x86_64-apple-darwin11``` for macOS binaries.
-  * Requires: `cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev` and `MacOSX10.11.sdk` (download and extract it to `contrib/depends/SDKs`)
+  * Requires: `cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev` and `MacOSX10.11.sdk` (download and extract it to `contrib/depends/SDKs`, it can be downloaded from https://www.sumokoin.org/depends/MacOSX10.11.sdk.tar.xz)
 * ```make depends target=i686-linux-gnu``` for 32-bit linux binaries.
   * Requires: `g++-multilib bc`
 * ```make depends target=i686-w64-mingw32``` for 32-bit windows binaries.

--- a/contrib/depends/Makefile
+++ b/contrib/depends/Makefile
@@ -3,6 +3,7 @@
 SOURCES_PATH ?= $(BASEDIR)/sources
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
+FALLBACK_DOWNLOAD_PATH ?= https://sumokoin.org/depends
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/contrib/depends/funcs.mk
+++ b/contrib/depends/funcs.mk
@@ -31,7 +31,8 @@ endef
 
 define fetch_file
     ( test -f $$($(1)_source_dir)/$(4) || \
-    ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5))))
+    ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
+      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
 endef
 
 define int_get_build_recipe_hash


### PR DESCRIPTION
since bitcoin.org's server didnot keep almost all of the dependencies we needed it was no use of keeping it as a fallback address any more. Back up of the files needed are now kept on sumokoin's servers so the fallback address was reintroduced and amended accordingly.
Tested its fine