### PR TITLE
[lmdb] fix race crash using a stale cursor

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1915,6 +1915,7 @@ bool BlockchainLMDB::get_txpool_tx_blob(const crypto::hash& txid, cryptonote::bl
   // if filtering, make sure those requirements are met before copying blob
   if (tx_category != relay_category::all)
   {
+    RCURSOR(txpool_meta)	  
     auto result = mdb_cursor_get(m_cur_txpool_meta, &k, &v, MDB_SET);
     if (result == MDB_NOTFOUND)
       return false;


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6384

Quote
_If a db resize happened, the txpool meta cursor might be stale,
and was not being renewed when necessary.
It would cause this SEGSEGV:_

_in mdb_cursor_set ()
in mdb_cursor_get ()
in cryptonote::BlockchainLMDB::get_txpool_tx_blob(crypto::hash const&,_ _std::__cxx11::basic_string<char, std::char_traits, std::allocator >&, cryptonote::relay_category) const ()
in cryptonote::tx_memory_pool::get_transaction(crypto::hash const&, std::__cxx11::basic_string<char, std::char_traits, std::allocator >&, cryptonote::relay_category) const ()_
_in cryptonote::t_cryptonote_protocol_handlercryptonote::core::handle_notify_new_fluffy_block(int, epee::misc_utils::struct_initcryptonote::NOTIFY_NEW_FLUFFY_BLOCK::request_t&, cryptonote::cryptonote_connection_context&) ()_
Unquote