### PR TITLE
[cmake] silence unique_ptr non-virtual destructor warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if(NOT MANUAL_SUBMODULES)
         message(FATAL_ERROR "Submodule '${relative_path}' is not up-to-date. Please update all submodules with\ngit submodule update --init --force\nor run cmake with -DMANUAL_SUBMODULES=1\n")
       endif()
     endfunction ()
-    
+
     message(STATUS "Checking submodules")
     check_submodule(external/miniupnp)
     check_submodule(external/unbound)
@@ -471,7 +471,7 @@ include_directories(${LIBUNWIND_INCLUDE})
 link_directories(${LIBUNWIND_LIBRARY_DIRS})
 
 # Final setup for hid
-if (HIDAPI_FOUND) 
+if (HIDAPI_FOUND)
   message(STATUS "Using HIDAPI include dir at ${HIDAPI_INCLUDE_DIR}")
   add_definitions(-DHAVE_HIDAPI)
   include_directories(${HIDAPI_INCLUDE_DIR})
@@ -585,6 +585,9 @@ else()
     set(STATIC_ASSERT_FLAG "")
   else()
     set(STATIC_ASSERT_FLAG "-Dstatic_assert=_Static_assert")
+  endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(WARNINGS "${WARNINGS} -Wno-delete-abstract-non-virtual-dtor")
   endif()
 
   try_compile(STATIC_ASSERT_CPP_RES "${CMAKE_CURRENT_BINARY_DIR}/static-assert" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test-static-assert.cpp" COMPILE_DEFINITIONS "-std=c++11")
@@ -766,7 +769,7 @@ else()
   endif(ARM)
 
   if(ANDROID AND NOT BUILD_GUI_DEPS STREQUAL "ON" OR IOS)
-    #From Android 5: "only position independent executables (PIE) are supported" 
+    #From Android 5: "only position independent executables (PIE) are supported"
     message(STATUS "Enabling PIE executable")
     set(PIC_FLAG "")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIE")


### PR DESCRIPTION
unique_ptr needs a destructor defined and implemented for each class, and making sure they are defined as virtual for inheritance.
That goes for this one https://github.com/sumoprojects/sumokoin/blob/dev/src/rpc/bootstrap_daemon.h#L81 (bootstrap_daemon.h)
Anyhow there is a complex way of fixing this by restructing the classes (derived classes and so on) to make clang happy (clang only warns about it not gcc) but just shut clang up for this case (and reenable it if monero ever decides to take care of this)