### PR TITLE
[cmake] add finding ccache automatically for faster (re)building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,15 @@ endif()
 cmake_minimum_required(VERSION 2.8.7)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
+find_program(CCACHE_PROG ccache)
+if (CCACHE_PROG)
+    message("ccache was found...launching it")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    ccache)
+else(CCACHE_PROG)
+    message("ccache was NOT found")
+endif(CCACHE_PROG)
+
 project(sumokoin)
 
 enable_language(C ASM)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -98,7 +98,8 @@ typedef cryptonote::simple_wallet sw;
 
 #define MIN_RING_SIZE 49 // Used to inform user about min ring size -- does not track actual protocol
 
-#define OLD_AGE_WARN_THRESHOLD (60 * 86400 / DIFFICULTY_TARGET) // number of blocks emitted in 60 days
+#define OLD_AGE_WARN_THRESHOLD_DAYS 60
+#define OLD_AGE_WARN_THRESHOLD (OLD_AGE_WARN_THRESHOLD_DAYS * 86400 / DIFFICULTY_TARGET) // number of blocks emitted in 60 days
 
 #define LOCK_IDLE_SCOPE() \
   bool auto_refresh_enabled = m_auto_refresh_enabled.load(std::memory_order_relaxed); \
@@ -3119,7 +3120,7 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("locked_sweep_all",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::locked_sweep_all,_1),
                            tr(USAGE_LOCKED_SWEEP_ALL),
-                           tr("Send all unlocked balance to an address and lock it for <lockblocks> (max. 500000). If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. <priority> is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability."));  
+                           tr("Send all unlocked balance to an address and lock it for <lockblocks> (max. 500000). If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. <priority> is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability."));
   m_cmd_binder.set_handler("sweep_unmixable",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_unmixable, _1),
                            tr("Send all unmixable outputs to yourself with ring_size 1"));
@@ -5046,7 +5047,9 @@ boost::optional<epee::wipeable_string> simple_wallet::open_wallet(const boost::p
     tr("Use the \"help_advanced\" command to see an advanced list of available commands.\n") <<
     tr("Use \"help_advanced <command>\" to see a command's documentation.\n") <<
     "**********************************************************************\n" <<
-    tr("NOTE: For privacy reasons avoid using an encrypted payment ID, consider using subaddresses instead");
+    tr("NOTES:\n") <<
+    tr("1. If you wallet has more than one output older than ") << OLD_AGE_WARN_THRESHOLD_DAYS <<  tr(" days (") << OLD_AGE_WARN_THRESHOLD << tr(" blocks), privacy would be better if they were spent separately.\n") <<
+    tr("2. For privacy reasons avoid using an encrypted payment ID, consider using subaddresses instead.");
   return password;
 }
 //----------------------------------------------------------------------------------------------------
@@ -6184,6 +6187,7 @@ bool simple_wallet::process_ring_members(const std::vector<tools::wallet2::pendi
   }
   return true;
 }
+/*
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::prompt_if_old(const std::vector<tools::wallet2::pending_tx> &ptx_vector)
 {
@@ -6221,6 +6225,8 @@ bool simple_wallet::prompt_if_old(const std::vector<tools::wallet2::pending_tx> 
   }
   return true;
 }
+*/
+//----------------------------------------------------------------------------------------------------
 void simple_wallet::check_for_inactivity_lock(bool user)
 {
   if (m_locked)
@@ -6271,7 +6277,7 @@ void simple_wallet::check_for_inactivity_lock(bool user)
       {
         if (get_and_verify_password())
           break;
-        else 
+        else
         {
           ++attempt;
           int left = 3 - attempt;
@@ -6279,7 +6285,7 @@ void simple_wallet::check_for_inactivity_lock(bool user)
         }
         if (attempt > 2)
         {
-          close_wallet(); 
+          close_wallet();
           message_writer(console_color_red, true) << "Your wallet is now closed, press Ctrl^C to exit to terminal" << std::endl;
           break;
         }
@@ -6587,11 +6593,11 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
       }
     }
 
-    if (!prompt_if_old(ptx_vector))
-    {
-      fail_msg_writer() << tr("transaction cancelled.");
-      return false;
-    }
+//    if (!prompt_if_old(ptx_vector))
+//    {
+//      fail_msg_writer() << tr("transaction cancelled.");
+//      return false;
+//    }
 
     // if more than one tx necessary, prompt user to confirm
     if (m_wallet->always_confirm_transfers() || ptx_vector.size() > 1)
@@ -7080,11 +7086,11 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
       return true;
     }
 
-    if (!prompt_if_old(ptx_vector))
-    {
-      fail_msg_writer() << tr("transaction cancelled.");
-      return false;
-    }
+//    if (!prompt_if_old(ptx_vector))
+//    {
+//      fail_msg_writer() << tr("transaction cancelled.");
+//      return false;
+//    }
 
     // give user total and fee, and prompt to confirm
     uint64_t total_fee = 0, total_sent = 0;
@@ -8570,7 +8576,7 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
      }
 
     std::string payment_id;
-  
+
     auto formatter = boost::format("%7.7llu %6.6s %20.20s %10.10s %s %-9.9s %s %s - %s %4.4s");
 
     message_writer(color, false) << formatter
@@ -8584,7 +8590,7 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
       % boost::algorithm::join(transfer.index | boost::adaptors::transformed([](uint32_t i) { return std::to_string(i); }), ", ")
       % transfer.note
       % lock_status;
-    
+
    if (!transfer.payment_id.empty() && transfer.payment_id != "0000000000000000")
     {
      payment_id = "payment id: "+transfer.payment_id;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,12 +25,12 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 /*!
  * \file simplewallet.h
- * 
+ *
  * \brief Header file that declares simple_wallet class.
  */
 #pragma once
@@ -278,7 +278,7 @@ namespace cryptonote
     void on_refresh_finished(uint64_t start_height, uint64_t fetched_blocks, bool is_init, bool received_money);
     std::pair<std::string, std::string> show_outputs_line(const std::vector<uint64_t> &heights, uint64_t blockchain_height, uint64_t highlight_idx = std::numeric_limits<uint64_t>::max()) const;
     bool freeze_thaw(const std::vector<std::string>& args, bool freeze);
-    bool prompt_if_old(const std::vector<tools::wallet2::pending_tx> &ptx_vector);
+//  bool prompt_if_old(const std::vector<tools::wallet2::pending_tx> &ptx_vector);
     bool on_command(bool (simple_wallet::*cmd)(const std::vector<std::string>&), const std::vector<std::string> &args);
     bool on_empty_command();
     bool on_cancelled_command();
@@ -307,7 +307,7 @@ namespace cryptonote
      * \param seed seed to print
      */
     void print_seed(const epee::wipeable_string &seed);
-    
+
    /*!
      * \brief Prints the seed in bold without a message
      * \param seed seed to print
@@ -316,9 +316,9 @@ namespace cryptonote
 
     /*!
      * \brief Gets the word seed language from the user.
-     * 
+     *
      * User is asked to choose from a list of supported languages.
-     * 
+     *
      * \return The chosen language.
      */
     std::string get_mnemonic_language();
@@ -462,7 +462,7 @@ namespace cryptonote
     epee::math_helper::once_a_time_seconds_range<get_random_interval<80 * 1000000, 100 * 1000000>> m_refresh_checker;
     epee::math_helper::once_a_time_seconds_range<get_random_interval<90 * 1000000, 110 * 1000000>> m_mms_checker;
     epee::math_helper::once_a_time_seconds_range<get_random_interval<90 * 1000000, 115 * 1000000>> m_rpc_payment_checker;
-    
+
     std::atomic<bool> m_need_payment;
     boost::posix_time::ptime m_last_rpc_payment_mining_time;
     bool m_rpc_payment_mining_requested;
@@ -485,7 +485,7 @@ namespace cryptonote
     void check_for_messages();
     bool user_confirms(const std::string &question);
     bool get_message_from_arg(const std::string &arg, mms::message &m);
-    bool get_number_from_arg(const std::string &arg, uint32_t &number, const uint32_t lower_bound, const uint32_t upper_bound); 
+    bool get_number_from_arg(const std::string &arg, uint32_t &number, const uint32_t lower_bound, const uint32_t upper_bound);
 
     void mms_init(const std::vector<std::string> &args);
     void mms_info(const std::vector<std::string> &args);


### PR DESCRIPTION
The idea was borrowed from a recently opened monero pull request (strange that noone thought of adding automatic finding ccache till now).
I implemented it a bit differently, the guy who pushed that to monero (#6452 - i am not referencing it directly cause i dont know if they are going to merge it) for some reason created a cmake file with it which he included it in cmakelists with `include`. I just added the code directly in there.

ccache can be installed with apt on ubuntu (and this is only for ubuntu at the moment).

Why do we need ccache? from https://ccache.dev/
**Quote**
_If you ever run make clean; make, you can probably benefit from ccache. It is common for developers to do a clean build of a project for a whole host of reasons, and this throws away all the information from your previous compilations. By using ccache, recompilation goes much faster.
Another reason to use ccache is that the same cache is used for builds in different directories. If you have several versions or branches of a software stored in different directories, many of the object files in a build directory can probably be taken from the cache even if they were compiled for another version or branch.
A third scenario is using ccache to speed up clean builds performed by servers or build farms that regularly check that the code is buildable.
You can also share the cache between users, which can be very useful on shared compilation servers._
**Unquote**
(I need to check if our travis.yml has it)