### PR TITLE
[cmake] add finding ccache automatically for faster (re)building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,15 @@ endif()
 cmake_minimum_required(VERSION 2.8.7)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
+find_program(CCACHE_PROG ccache)
+if (CCACHE_PROG)
+    message("ccache was found...launching it")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROG}")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "${CCACHE_PROG}")
+else()
+    message("ccache was NOT found")
+endif()
+
 project(sumokoin)
 
 enable_language(C ASM)


### PR DESCRIPTION
The idea was borrowed from a recently opened monero pull request (strange that noone thought of adding automatic finding of ccache till now).
I implemented it a bit differently, the guy who pushed that to monero (#6452 - i am not referencing it directly cause i dont know if they are going to merge it) for some reason created a cmake file with it which he included it in cmakelists with `include`. I just added the code directly in there.

ccache can be installed with `apt-get install ccache` on ubuntu and on mingw with `pacman -S mingw-w64-x86_64-ccache`

Why do we need ccache? from https://ccache.dev/
**Quote**
_If you ever run make clean; make, you can probably benefit from ccache. It is common for developers to do a clean build of a project for a whole host of reasons, and this throws away all the information from your previous compilations. By using ccache, recompilation goes much faster.
Another reason to use ccache is that the same cache is used for builds in different directories. If you have several versions or branches of a software stored in different directories, many of the object files in a build directory can probably be taken from the cache even if they were compiled for another version or branch.
A third scenario is using ccache to speed up clean builds performed by servers or build farms that regularly check that the code is buildable.
You can also share the cache between users, which can be very useful on shared compilation servers._
**Unquote**
(I need to check if our travis.yml has it and if it can be included in workflows action)