### PR TITLE
[README] Fix FreeBSD required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Install all dependencies at once on macOS with the provided Brewfile:
 ``` brew update && brew bundle --file=contrib/brew/Brewfile ```
 
 FreeBSD one liner for required to build dependencies
-```pkg install git gmake cmake pkgconf boost-libs libzmq libsodium```
+```pkg install git gmake cmake pkgconf boost-libs libzmq4 libsodium```
 
 ### Cloning the repository
 


### PR DESCRIPTION
there is no libzmq package in FreeBSD there are libzmq1, libzmq2, libzmq3, libzmq4.
Add the latest version