### PR TITLE
[cn_protocol+rpc+p2p] Dandelion++ support to sumokoin public networks

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -53,9 +53,7 @@ bool matches_category(relay_method method, relay_category category) noexcept
     case relay_category::all:
       return true;
     case relay_category::relayable:
-      if (method == relay_method::none)
-        return false;
-      return true;
+      return method != relay_method::none;
     case relay_category::broadcasted:
     case relay_category::legacy:
       break;
@@ -65,6 +63,7 @@ bool matches_category(relay_method method, relay_category category) noexcept
   {
     default:
     case relay_method::local:
+    case relay_method::stem:
       return false;
     case relay_method::block:
     case relay_method::fluff:
@@ -80,6 +79,7 @@ void txpool_tx_meta_t::set_relay_method(relay_method method) noexcept
   kept_by_block = 0;
   do_not_relay = 0;
   is_local = 0;
+  dandelionpp_stem = 0;
 
   switch (method)
   {
@@ -91,6 +91,9 @@ void txpool_tx_meta_t::set_relay_method(relay_method method) noexcept
       break;
     default:
     case relay_method::fluff:
+      break;
+    case relay_method::stem:
+      dandelionpp_stem = 1;
       break;
     case relay_method::block:
       kept_by_block = 1;
@@ -106,12 +109,29 @@ relay_method txpool_tx_meta_t::get_relay_method() const noexcept
     return relay_method::none;
   if (is_local)
     return relay_method::local;
+  if (dandelionpp_stem)
+    return relay_method::stem;
   return relay_method::fluff;
+}
+
+bool txpool_tx_meta_t::upgrade_relay_method(relay_method method) noexcept
+{
+  static_assert(relay_method::none < relay_method::local, "bad relay_method value");
+  static_assert(relay_method::local < relay_method::stem, "bad relay_method value");
+  static_assert(relay_method::stem < relay_method::fluff, "bad relay_method value");
+  static_assert(relay_method::fluff < relay_method::block, "bad relay_method value");
+
+  if (get_relay_method() < method)
+  {
+    set_relay_method(method);
+    return true;
+  }
+  return false;
 }
 
 const command_line::arg_descriptor<std::string> arg_db_sync_mode = {
   "db-sync-mode"
-, "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[<nblocks_per_sync>[blocks]|<nbytes_per_sync>[bytes]]." 
+, "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[<nblocks_per_sync>[blocks]|<nbytes_per_sync>[bytes]]."
 , "fast:async:250000000bytes"
 };
 const command_line::arg_descriptor<bool> arg_db_salvage  = {

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -160,7 +160,7 @@ struct txpool_tx_meta_t
   uint64_t max_used_block_height;
   uint64_t last_failed_height;
   uint64_t receive_time;
-  uint64_t last_relayed_time;
+  uint64_t last_relayed_time; //!< If Dandelion++ stem, randomized embargo timestamp. Otherwise, last relayed timestmap.
   // 112 bytes
   uint8_t kept_by_block;
   uint8_t relayed;
@@ -168,12 +168,16 @@ struct txpool_tx_meta_t
   uint8_t double_spend_seen: 1;
   uint8_t pruned: 1;
   uint8_t is_local: 1;
-  uint8_t bf_padding: 5;
+  uint8_t dandelionpp_stem : 1;
+  uint8_t bf_padding: 4;
 
   uint8_t padding[76]; // till 192 bytes
 
   void set_relay_method(relay_method method) noexcept;
   relay_method get_relay_method() const noexcept;
+
+  //! \return True if `get_relay_method()` now returns `method`.
+  bool upgrade_relay_method(relay_method method) noexcept;
 
   //! See `relay_category` description
   bool matches(const relay_category category) const noexcept
@@ -1308,7 +1312,7 @@ public:
    * @return true iff the blocks and transactions were found
    */
   virtual bool get_blocks_from(uint64_t start_height, size_t min_count, size_t max_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const = 0;
-  
+
   /**
    * @brief fetches the prunable transaction blob with the given hash
    *

--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,10 +25,13 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
+
+#include "cryptonote_protocol/enums.h"
+
 namespace cryptonote
 {
   /************************************************************************/
@@ -36,10 +39,12 @@ namespace cryptonote
   /************************************************************************/
   struct tx_verification_context
   {
-    bool m_should_be_relayed;
+    static_assert(unsigned(relay_method::none) == 0, "default m_relay initialization is not to relay_method::none");
+
+    relay_method m_relay; // gives indication on how tx should be relayed (if at all)
     bool m_verifivation_failed; //bad tx, should drop connection
     bool m_verifivation_impossible; //the transaction is related with an alternative blockchain
-    bool m_added_to_pool; 
+    bool m_added_to_pool;
     bool m_low_mixin;
     bool m_high_mixin;
     bool m_double_spend;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -1,22 +1,22 @@
 // Copyright (c) 2017-2019, Sumokoin Project
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -26,7 +26,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
@@ -112,7 +112,12 @@
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                  (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME   604800 //seconds, one week
 
-#define CRYPTONOTE_DANDELIONPP_FLUSH_AVERAGE            5 // seconds
+#define CRYPTONOTE_DANDELIONPP_STEMS                    2 // number of outgoing stem connections per epoch
+#define CRYPTONOTE_DANDELIONPP_FLUFF_PROBABILITY        10 // out of 100
+#define CRYPTONOTE_DANDELIONPP_MIN_EPOCH                10 // minutes
+#define CRYPTONOTE_DANDELIONPP_EPOCH_RANGE              30 // seconds
+#define CRYPTONOTE_DANDELIONPP_FLUSH_AVERAGE            5 // seconds average for poisson distributed fluff flush
+#define CRYPTONOTE_DANDELIONPP_EMBARGO_AVERAGE          173 // seconds (see tx_pool.cpp for more info)
 
 // see src/cryptonote_protocol/levin_notify.cpp
 #define CRYPTONOTE_NOISE_MIN_EPOCH                      5      // minutes
@@ -171,8 +176,8 @@
 #define PEAK_COIN_EMISSION_HEIGHT                       ((uint64_t) (((12 * 30.4375 * 24 * 3600)/DIFFICULTY_TARGET) * PEAK_COIN_EMISSION_YEAR)) // = (# of heights emmitted per year) * PEAK_COIN_EMISSION_YEAR
 
 #define DEFAULT_MIXIN                                   12     // default & minimum mixin allowed
-#define MAX_MIXIN                                       240 
-#define DEFAULT_MIXIN_V2                                48   
+#define MAX_MIXIN                                       240
+#define DEFAULT_MIXIN_V2                                48
 
 #define TRANSACTION_WEIGHT_LIMIT                        ((uint64_t) ((CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 110 / 100) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE))
 #define BLOCK_SIZE_GROWTH_FAVORED_ZONE                  ((uint64_t) (CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4))
@@ -229,7 +234,7 @@ namespace config
   const unsigned char HASH_KEY_RPC_PAYMENT_NONCE = 0x58;
   const unsigned char HASH_KEY_MEMORY = 'k';
   const unsigned char HASH_KEY_MULTISIG[] = {'M', 'u', 'l', 't' , 'i', 's', 'i', 'g', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-  
+
   // Funding for exchange burned coins
   static constexpr const char* EXCHANGE_FUND_ADDRESS = "Sumoo2y7AAteNGJ5yepUUFX3taqDRfM5eYHmCc1qnhwx6cJp3htcjTbKWH7NxkcADcT82pRwns9Us7NdCmuw3gx8bnzYGg14L2o";
   // aa0d3ec96e05fd154235fdcff4c2ebce79f49f4ce76f0aeabeb4a40cf64cc30b
@@ -238,7 +243,7 @@ namespace config
   static constexpr uint64_t EXCHANGE_BURNED_AMOUNT = 1044138500000000;   // 1,044,138.5 coins burned
   static constexpr uint64_t EXCHANGE_FUND_AMOUNT = EXCHANGE_BURNED_AMOUNT; // fund amount = burned coins
   static constexpr uint64_t EXCHANGE_FUND_RELEASE_HEIGHT = 199800;  // equal v6 hardfork
-    
+
   namespace testnet
   {
     uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 0x37751a; // Suto

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1145,8 +1145,8 @@ namespace cryptonote
       return block_sync_size;
     if (get_current_blockchain_height() <= LAST_CHECKPOINT)
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
-    else 
-    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;    
+    else
+    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const
@@ -1168,18 +1168,18 @@ namespace cryptonote
       std::vector<transaction> txs;
       std::vector<crypto::hash> missed_txs;
       uint64_t coinbase_amount = get_outs_money_amount(b.miner_tx);
-      this->get_transactions(b.tx_hashes, txs, missed_txs);      
+      this->get_transactions(b.tx_hashes, txs, missed_txs);
       uint64_t tx_fee_amount = 0;
       for(const auto& tx: txs)
       {
         tx_fee_amount += get_tx_fee(tx);
       }
-      
+
       emission_amount += coinbase_amount - tx_fee_amount;
       total_fee_amount += tx_fee_amount;
       return true;
       });
-      
+
       // subtract burned coins
       if (start_offset <= config::EXCHANGE_FUND_RELEASE_HEIGHT && end >= config::EXCHANGE_FUND_RELEASE_HEIGHT)
         emission_amount -= config::EXCHANGE_BURNED_AMOUNT;
@@ -1276,6 +1276,7 @@ namespace cryptonote
             break;
           case relay_method::block:
           case relay_method::fluff:
+          case relay_method::stem:
             public_req.txs.push_back(std::move(std::get<1>(tx)));
             break;
         }
@@ -1287,9 +1288,9 @@ namespace cryptonote
          re-relaying public and private _should_ be acceptable here. */
       const boost::uuids::uuid source = boost::uuids::nil_uuid();
       if (!public_req.txs.empty())
-        get_protocol()->relay_transactions(public_req, source, epee::net_utils::zone::public_);
+        get_protocol()->relay_transactions(public_req, source, epee::net_utils::zone::public_, relay_method::fluff);
       if (!private_req.txs.empty())
-        get_protocol()->relay_transactions(private_req, source, epee::net_utils::zone::invalid);
+        get_protocol()->relay_transactions(private_req, source, epee::net_utils::zone::invalid, relay_method::local);
     }
     return true;
   }
@@ -1576,7 +1577,7 @@ namespace cryptonote
   bool core::get_pool_transaction(const crypto::hash &id, cryptonote::blobdata& tx, relay_category tx_category) const
   {
     return m_mempool.get_transaction(id, tx, tx_category);
-  }  
+  }
   //-----------------------------------------------------------------------------------------------
   bool core::pool_has_tx(const crypto::hash &id) const
   {
@@ -1667,13 +1668,13 @@ namespace cryptonote
     hours = minutes / 60;
     if((get_blockchain_storage().get_current_blockchain_height() >= m_target_blockchain_height) && (m_target_blockchain_height > 0))
     {
-     MGINFO_GREEN(ENDL << "Sumokoin node is on idle and fully synchronized | Height: " << get_blockchain_storage().get_current_blockchain_height() 
-       << " | Uptime: " << int(hours) << " hours " << int(minutes%60) << " minutes " 
+     MGINFO_GREEN(ENDL << "Sumokoin node is on idle and fully synchronized | Height: " << get_blockchain_storage().get_current_blockchain_height()
+       << " | Uptime: " << int(hours) << " hours " << int(minutes%60) << " minutes "
        << int(seconds%60) << " seconds" << ENDL);
     }
    return true;
   }
-  //----------------------------------------------------------------------------------------------- 
+  //-----------------------------------------------------------------------------------------------
   bool core::check_fork_time()
   {
     if (m_nettype == FAKECHAIN)

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -47,6 +47,7 @@
 #include "warnings.h"
 #include "common/perf_timer.h"
 #include "crypto/hash.h"
+#include "crypto/duration.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "txpool"
@@ -59,6 +60,27 @@ namespace cryptonote
 {
   namespace
   {
+    /*! The Dandelion++ has formula for calculating the average embargo timeout:
+                          (-k*(k-1)*hop)/(2*log(1-ep))
+        where k is the number of hops before this node and ep is the probability
+        that one of the k hops hits their embargo timer, and hop is the average
+        time taken between hops. So decreasing ep will make it more probable
+        that "this" node is the first to expire the embargo timer. Increasing k
+        will increase the number of nodes that will be "hidden" as a prior
+        recipient of the tx.
+        As example, k=5 and ep=0.1 means "this" embargo timer has a 90%
+        probability of being the first to expire amongst 5 nodes that saw the
+        tx before "this" one. These values are independent to the fluff
+        probability, but setting a low k with a low p (fluff probability) is
+        not ideal since a blackhole is more likely to reveal earlier nodes in
+        the chain.
+        This value was calculated with k=10, ep=0.10, and hop = 175 ms. A
+        testrun from a recent Intel laptop took ~80ms to
+        receive+parse+proces+send transaction. At least 50ms will be added to
+        the latency if crossing an ocean. So 175ms is the fudge factor for
+        a single hop with 173s being the embargo timer. */
+    constexpr const std::chrono::seconds dandelionpp_embargo_average{CRYPTONOTE_DANDELIONPP_EMBARGO_AVERAGE};
+
     //TODO: constants such as these should at least be in the header,
     //      but probably somewhere more accessible to the rest of the
     //      codebase.  As it stands, it is at best nontrivial to test
@@ -267,36 +289,53 @@ namespace cryptonote
       }
     }else
     {
-      //update transactions container
-      meta.weight = tx_weight;
-      meta.fee = fee;
-      meta.max_used_block_id = max_used_block_id;
-      meta.max_used_block_height = max_used_block_height;
-      meta.last_failed_height = 0;
-      meta.last_failed_id = null_hash;
-      meta.receive_time = receive_time;
-      meta.last_relayed_time = time(NULL);
-      meta.relayed = relayed;
-      meta.set_relay_method(tx_relay);
-      meta.double_spend_seen = false;
-      meta.pruned = tx.pruned;
-      meta.bf_padding = 0;
-      memset(meta.padding, 0, sizeof(meta.padding));
-
       try
       {
         if (kept_by_block)
           m_parsed_tx_cache.insert(std::make_pair(id, tx));
         CRITICAL_REGION_LOCAL1(m_blockchain);
         LockedTXN lock(m_blockchain.get_db());
-        m_blockchain.remove_txpool_tx(id);
-        if (!insert_key_images(tx, id, tx_relay))
-          return false;
 
-        m_blockchain.add_txpool_tx(id, blob, meta);
-        // Rounding tx fee/blob_size ratio so that txs with the same priority would be sorted by receive_time
-        uint32_t fee_per_size_ratio = (uint32_t)(fee / (double)(tx_weight ? tx_weight : 1));
-        m_txs_by_fee_and_receive_time.emplace(std::pair<uint32_t, std::time_t>(fee_per_size_ratio, receive_time), id);
+        const bool existing_tx = m_blockchain.get_txpool_tx_meta(id, meta);
+        if (existing_tx)
+        {
+          /* If Dandelion++ loop. Do not use txes in the `local` state in the
+             loop detection - txes in that state should be outgoing over i2p/tor
+             then routed back via public dandelion++ stem. Pretend to be
+             another stem node in that situation, a loop over the public
+             network hasn't been hit yet. */
+          if (tx_relay == relay_method::stem && meta.dandelionpp_stem)
+            tx_relay = relay_method::fluff;
+        }
+        else
+          meta.set_relay_method(relay_method::none);
+
+        if (meta.upgrade_relay_method(tx_relay) || !existing_tx) // synchronize with embargo timer or stem/fluff out-of-order messages
+        {
+          //update transactions container
+          meta.last_relayed_time = std::numeric_limits<decltype(meta.last_relayed_time)>::max();
+          meta.receive_time = receive_time;
+          meta.weight = tx_weight;
+          meta.fee = fee;
+          meta.max_used_block_id = max_used_block_id;
+          meta.max_used_block_height = max_used_block_height;
+          meta.last_failed_height = 0;
+          meta.last_failed_id = null_hash;
+          meta.relayed = relayed;
+          meta.double_spend_seen = false;
+          meta.pruned = tx.pruned;
+          meta.bf_padding = 0;
+          memset(meta.padding, 0, sizeof(meta.padding));
+
+          if (!insert_key_images(tx, id, tx_relay))
+            return false;
+
+          m_blockchain.remove_txpool_tx(id);
+          m_blockchain.add_txpool_tx(id, blob, meta);
+          // Rounding tx fee/blob_size ratio so that txs with the same priority would be sorted by receive_time
+          uint32_t fee_per_size_ratio = (uint32_t)(fee / (double)(tx_weight ? tx_weight : 1));
+          m_txs_by_fee_and_receive_time.emplace(std::pair<uint32_t, std::time_t>(fee_per_size_ratio, receive_time), id);
+        }
         lock.commit();
       }
       catch (const std::exception &e)
@@ -306,8 +345,9 @@ namespace cryptonote
       }
       tvc.m_added_to_pool = true;
 
-      if(meta.fee > 0 && tx_relay != relay_method::none)
-        tvc.m_should_be_relayed = true;
+      static_assert(unsigned(relay_method::none) == 0, "expected relay_method::none value to be zero");
+      if(meta.fee > 0)
+        tvc.m_relay = tx_relay;
     }
 
     tvc.m_verifivation_failed = false;
@@ -559,7 +599,7 @@ namespace cryptonote
       td.last_failed_height = meta.last_failed_height;
       td.last_failed_id = meta.last_failed_id;
       td.receive_time = meta.receive_time;
-      td.last_relayed_time = meta.last_relayed_time;
+      td.last_relayed_time = meta.dandelionpp_stem ? 0 : meta.last_relayed_time;
       td.relayed = meta.relayed;
       td.do_not_relay = meta.do_not_relay;
       td.double_spend_seen = meta.double_spend_seen;
@@ -692,8 +732,13 @@ namespace cryptonote
     txs.reserve(m_blockchain.get_txpool_tx_count());
     m_blockchain.for_all_txpool_txes([this, now, &txs](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata *){
       // 0 fee transactions are never relayed
-      if(!meta.pruned && meta.fee > 0 && !meta.do_not_relay && now - meta.last_relayed_time > get_relay_delay(now, meta.receive_time))
+      if(!meta.pruned && meta.fee > 0 && !meta.do_not_relay)
       {
+        if (!meta.dandelionpp_stem && now - meta.last_relayed_time <= get_relay_delay(now, meta.receive_time))
+          return true;
+        if (meta.dandelionpp_stem && meta.last_relayed_time < now) // for dandelion++ stem, this value is the embargo timeout
+          return true;
+
         // if the tx is older than half the max lifetime, we don't re-relay it, to avoid a problem
         // mentioned by smooth where nodes would flush txes at slightly different times, causing
         // flushed txes to be re-added when received from a node which was just about to flush it
@@ -718,9 +763,11 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   void tx_memory_pool::set_relayed(const epee::span<const crypto::hash> hashes, const relay_method method)
   {
+    crypto::random_poisson_seconds embargo_duration{dandelionpp_embargo_average};
+    const auto now = std::chrono::system_clock::now();
+
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
-    const time_t now = time(NULL);
     LockedTXN lock(m_blockchain.get_db());
     for (const auto& hash : hashes)
     {
@@ -729,9 +776,15 @@ namespace cryptonote
         txpool_tx_meta_t meta;
         if (m_blockchain.get_txpool_tx_meta(hash, meta))
         {
+          // txes can be received as "stem" or "fluff" in either order
+          meta.upgrade_relay_method(method);
           meta.relayed = true;
-          meta.last_relayed_time = now;
-          meta.set_relay_method(method);
+
+          if (meta.dandelionpp_stem)
+            meta.last_relayed_time = std::chrono::system_clock::to_time_t(now + embargo_duration());
+          else
+            meta.last_relayed_time = std::chrono::system_clock::to_time_t(now);
+
           m_blockchain.update_txpool_tx(hash, meta);
         }
       }
@@ -917,7 +970,7 @@ namespace cryptonote
       txi.receive_time = include_sensitive_data ? meta.receive_time : 0;
       txi.relayed = meta.relayed;
       // In restricted mode we do not include this data:
-      txi.last_relayed_time = include_sensitive_data ? meta.last_relayed_time : 0;
+      txi.last_relayed_time = (include_sensitive_data && !meta.dandelionpp_stem) ? meta.last_relayed_time : 0;
       txi.do_not_relay = meta.do_not_relay;
       txi.double_spend_seen = meta.double_spend_seen;
       tx_infos.push_back(std::move(txi));
@@ -969,7 +1022,7 @@ namespace cryptonote
       txi.last_failed_block_hash = meta.last_failed_id;
       txi.receive_time = meta.receive_time;
       txi.relayed = meta.relayed;
-      txi.last_relayed_time = meta.last_relayed_time;
+      txi.last_relayed_time = meta.dandelionpp_stem ? 0 : meta.last_relayed_time;
       txi.do_not_relay = meta.do_not_relay;
       txi.double_spend_seen = meta.double_spend_seen;
       tx_infos.push_back(txi);

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
@@ -72,10 +72,10 @@ namespace cryptonote
 
 	uint64_t avg_download;
 	uint64_t current_download;
-	
+
 	uint64_t avg_upload;
 	uint64_t current_upload;
-  
+
 	uint32_t support_flags;
 
 	std::string connection_id;
@@ -197,10 +197,12 @@ namespace cryptonote
     {
       std::vector<blobdata>   txs;
       std::string _; // padding
+      bool dandelionpp_fluff; //zero initialization defaults to stem mode
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txs)
         KV_SERIALIZE(_)
+        KV_SERIALIZE_OPT(dandelionpp_fluff, true) // backwards compatible mode is fluff        
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -311,7 +313,7 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
   };
-  
+
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
@@ -330,7 +332,7 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
-  };  
+  };
 
   /************************************************************************/
   /*                                                                      */
@@ -342,9 +344,9 @@ namespace cryptonote
     struct request_t
     {
       crypto::hash block_hash;
-      uint64_t current_blockchain_height;      
+      uint64_t current_blockchain_height;
       std::vector<uint64_t> missing_tx_indices;
-      
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_VAL_POD_AS_BLOB(block_hash)
         KV_SERIALIZE(current_blockchain_height)
@@ -352,7 +354,7 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
-  }; 
+  };
 
   /************************************************************************/
   /*                                                                      */
@@ -371,5 +373,5 @@ namespace cryptonote
     };
     typedef epee::misc_utils::struct_init<request_t> request;
   };
-    
+
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -3,23 +3,23 @@
 /// @brief This is the original cryptonote protocol network-events handler, modified by us
 
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -29,7 +29,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
@@ -66,14 +66,14 @@ namespace cryptonote
 			virtual ~cryptonote_protocol_handler_base();
 			void handler_request_blocks_history(std::list<crypto::hash>& ids); // before asking for list of objects, we can change the list still
 			void handler_response_blocks_now(size_t packet_size);
-			
+
 			virtual double get_avg_block_size() = 0;
 			virtual double estimate_one_block_size() noexcept; // for estimating size of blocks to download
 	};
 
   template<class t_core>
   class t_cryptonote_protocol_handler:  public i_cryptonote_protocol, cryptonote_protocol_handler_base
-  { 
+  {
   public:
     typedef cryptonote_connection_context connection_context;
     typedef t_cryptonote_protocol_handler<t_core> cryptonote_protocol_handler;
@@ -88,8 +88,8 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_GET_OBJECTS, &cryptonote_protocol_handler::handle_response_get_objects)
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_CHAIN, &cryptonote_protocol_handler::handle_request_chain)
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_CHAIN_ENTRY, &cryptonote_protocol_handler::handle_response_chain_entry)
-      HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)			
-      HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)						
+      HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)
+      HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)
       HANDLE_NOTIFY_T2(NOTIFY_GET_TXPOOL_COMPLEMENT, &cryptonote_protocol_handler::handle_notify_get_txpool_complement)
     END_INVOKE_MAP2()
 
@@ -126,10 +126,10 @@ namespace cryptonote
     int handle_notify_new_fluffy_block(int command, NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& context);
     int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
     int handle_notify_get_txpool_complement(int command, NOTIFY_GET_TXPOOL_COMPLEMENT::request& arg, cryptonote_connection_context& context);
-		
+
     //----------------- i_bc_protocol_layout ---------------------------------------
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
-    virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, const boost::uuids::uuid& source, epee::net_utils::zone zone);
+    virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, const boost::uuids::uuid& source, epee::net_utils::zone zone, relay_method tx_relay);
     //----------------------------------------------------------------------------------
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);
     bool should_drop_connection(cryptonote_connection_context& context, uint32_t next_stripe);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -926,29 +926,59 @@ namespace cryptonote
       return 1;
     }
 
-    std::vector<cryptonote::blobdata> newtxs;
-    newtxs.reserve(arg.txs.size());
-    for (size_t i = 0; i < arg.txs.size(); ++i)
+    relay_method tx_relay;
+    std::vector<blobdata> stem_txs{};
+    std::vector<blobdata> fluff_txs{};
+    if (arg.dandelionpp_fluff)
     {
-      cryptonote::tx_verification_context tvc{};
-      m_core.handle_incoming_tx({arg.txs[i], crypto::null_hash}, tvc, relay_method::fluff, true);
-      if(tvc.m_verifivation_failed)
+      tx_relay = relay_method::fluff;
+      fluff_txs.reserve(arg.txs.size());
+    }
+    else
+    {
+      tx_relay = relay_method::stem;
+      stem_txs.reserve(arg.txs.size());
+    }
+
+        for (auto& tx : arg.txs)
+        {
+          tx_verification_context tvc{};
+          if (!m_core.handle_incoming_tx({tx, crypto::null_hash}, tvc, tx_relay, true))
       {
         LOG_PRINT_CCONTEXT_L1("Tx verification failed, dropping connection");
         drop_connection(context, false, false);
         return 1;
       }
-      if(tvc.m_should_be_relayed)
-        newtxs.push_back(std::move(arg.txs[i]));
+      switch (tvc.m_relay)
+      {
+        case relay_method::local:
+        case relay_method::stem:
+          stem_txs.push_back(std::move(tx));
+          break;
+        case relay_method::block:
+        case relay_method::fluff:
+          fluff_txs.push_back(std::move(tx));
+          break;
+        default:
+        case relay_method::none:
+          break;
+      }
     }
-    arg.txs = std::move(newtxs);
 
-    if(arg.txs.size())
+    if (!stem_txs.empty())
     {
       //TODO: add announce usage here
-      relay_transactions(arg, context.m_connection_id, context.m_remote_address.get_zone());
+      arg.dandelionpp_fluff = false;
+      arg.txs = std::move(stem_txs);
+      relay_transactions(arg, context.m_connection_id, context.m_remote_address.get_zone(), relay_method::stem);
     }
-
+    if (!fluff_txs.empty())
+    {
+      //TODO: add announce usage here
+      arg.dandelionpp_fluff = true;
+      arg.txs = std::move(fluff_txs);
+      relay_transactions(arg, context.m_connection_id, context.m_remote_address.get_zone(), relay_method::fluff);
+    }
     return 1;
   }
   //------------------------------------------------------------------------------------------------------------------------
@@ -2402,14 +2432,14 @@ skip:
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>
-  bool t_cryptonote_protocol_handler<t_core>::relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, const boost::uuids::uuid& source, epee::net_utils::zone zone)
+  bool t_cryptonote_protocol_handler<t_core>::relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, const boost::uuids::uuid& source, epee::net_utils::zone zone, relay_method tx_relay)
   {
     /* Push all outgoing transactions to this function. The behavior needs to
        identify how the transaction is going to be relayed, and then update the
        local mempool before doing the relay. The code was already updating the
        DB twice on received transactions - it is difficult to workaround this
        due to the internal design. */
-    return m_p2p->send_txs(std::move(arg.txs), zone, source, m_core) != epee::net_utils::zone::invalid;
+    return m_p2p->send_txs(std::move(arg.txs), zone, source, m_core, tx_relay) != epee::net_utils::zone::invalid;
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>

--- a/src/cryptonote_protocol/enums.h
+++ b/src/cryptonote_protocol/enums.h
@@ -37,7 +37,8 @@ namespace cryptonote
   {
     none = 0, //!< Received via RPC with `do_not_relay` set
     local,    //!< Received via RPC; trying to send over i2p/tor, etc.
-    block,    //!< Received in block, takes precedence over others
-    fluff     //!< Received/sent over public networks
+    stem,     //!< Received/send over network using Dandelion++ stem
+    fluff,    //!< Received/sent over network using Dandelion++ fluff
+    block     //!< Received in block, takes precedence over others
   };
 }

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -30,6 +30,7 @@
 
 #include <boost/asio/steady_timer.hpp>
 #include <boost/system/system_error.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <chrono>
 #include <deque>
 #include <stdexcept>
@@ -38,8 +39,10 @@
 #include "common/expect.h"
 #include "common/varint.h"
 #include "cryptonote_config.h"
-#include "crypto/random.h"
+#include "crypto/crypto.h"
+#include "crypto/duration.h"
 #include "cryptonote_basic/connection_context.h"
+#include "cryptonote_core/i_core_events.h"
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "net/dandelionpp.h"
 #include "p2p/net_node.h"
@@ -61,10 +64,13 @@ namespace levin
 {
   namespace
   {
-    constexpr std::size_t connection_id_reserve_size = 100;
+    constexpr const std::size_t connection_id_reserve_size = 100;
 
     constexpr const std::chrono::minutes noise_min_epoch{CRYPTONOTE_NOISE_MIN_EPOCH};
     constexpr const std::chrono::seconds noise_epoch_range{CRYPTONOTE_NOISE_EPOCH_RANGE};
+
+    constexpr const std::chrono::minutes dandelionpp_min_epoch{CRYPTONOTE_DANDELIONPP_MIN_EPOCH};
+    constexpr const std::chrono::seconds dandelionpp_epoch_range{CRYPTONOTE_DANDELIONPP_EPOCH_RANGE};
 
     constexpr const std::chrono::seconds noise_min_delay{CRYPTONOTE_NOISE_MIN_DELAY};
     constexpr const std::chrono::seconds noise_delay_range{CRYPTONOTE_NOISE_DELAY_RANGE};
@@ -83,22 +89,8 @@ namespace levin
         connections (Dandelion++ makes similar assumptions in its stem
         algorithm). The randomization yields 95% values between 1s-4s in
 	1/4s increments. */
-    constexpr const fluff_stepsize fluff_average_out{fluff_stepsize{fluff_average_in} / 2};
-
-    class random_poisson
-    {
-      std::poisson_distribution<fluff_stepsize::rep> dist;
-    public:
-      explicit random_poisson(fluff_stepsize average)
-        : dist(average.count() < 0 ? 0 : average.count())
-      {}
-
-      fluff_stepsize operator()()
-      {
-        crypto::random_device rand{};
-        return fluff_stepsize{dist(rand)};
-      }
-    };
+  using fluff_duration = crypto::random_poisson_subseconds::result_type;
+  constexpr const fluff_duration fluff_average_out{fluff_duration{fluff_average_in} / 2};
 
     /*! Select a randomized duration from 0 to `range`. The precision will be to
         the systems `steady_clock`. As an example, supplying 3 seconds to this
@@ -132,10 +124,11 @@ namespace levin
       return outs;
     }
 
-    std::string make_tx_payload(std::vector<blobdata>&& txs, const bool pad)
+    std::string make_tx_payload(std::vector<blobdata>&& txs, const bool pad, const bool fluff)
     {
       NOTIFY_NEW_TRANSACTIONS::request request{};
       request.txs = std::move(txs);
+      request.dandelionpp_fluff = fluff;
 
       if (pad)
       {
@@ -172,9 +165,9 @@ namespace levin
       return fullBlob;
     }
 
-    bool make_payload_send_txs(connections& p2p, std::vector<blobdata>&& txs, const boost::uuids::uuid& destination, const bool pad)
+    bool make_payload_send_txs(connections& p2p, std::vector<blobdata>&& txs, const boost::uuids::uuid& destination, const bool pad, const bool fluff)
     {
-      const cryptonote::blobdata blob = make_tx_payload(std::move(txs), pad);
+      const cryptonote::blobdata blob = make_tx_payload(std::move(txs), pad, fluff);
       p2p.for_connection(destination, [&blob](detail::p2p_context& context) {
         on_levin_traffic(context, true, true, false, blob.size(), get_command_from_message(blob));
         return true;
@@ -251,7 +244,8 @@ namespace levin
           flush_time(std::chrono::steady_clock::time_point::max()),
           connection_count(0),
           is_public(is_public),
-          pad_txs(pad_txs)
+          pad_txs(pad_txs),
+          fluffing(false)
       {
         for (std::size_t count = 0; !noise.empty() && count < CRYPTONOTE_NOISE_CHANNELS; ++count)
           channels.emplace_back(io_service);
@@ -268,6 +262,7 @@ namespace levin
       std::atomic<std::size_t> connection_count; //!< Only update in strand, can be read at any time
       const bool is_public;                      //!< Zone is public ipv4/ipv6 connections
       const bool pad_txs;                        //!< Pad txs to the next boundary for privacy
+      bool fluffing;                             //!< Zone is in Dandelion++ fluff epoch
     };
   } // detail
 
@@ -362,10 +357,11 @@ namespace levin
           return true;
         });
 
+        // Always send txs in stem mode over i2p/tor, see comments in `send_txs` below.
         for (auto& connection : connections)
         {
           std::sort(connection.first.begin(), connection.first.end()); // don't leak receive order
-          make_payload_send_txs(*zone_->p2p, std::move(connection.first), connection.second, zone_->pad_txs);
+          make_payload_send_txs(*zone_->p2p, std::move(connection.first), connection.second, zone_->pad_txs, zone_->is_public);
         }
 
         if (next_flush != std::chrono::steady_clock::time_point::max())
@@ -387,29 +383,38 @@ namespace levin
 
       void operator()()
       {
-        if (!zone_ || !zone_->p2p || txs_.empty())
+        run(std::move(zone_), epee::to_span(txs_), source_);
+      }
+
+      static void run(std::shared_ptr<detail::zone> zone, epee::span<const blobdata> txs, const boost::uuids::uuid& source)
+      {
+        if (!zone || !zone->p2p || txs.empty())
           return;
 
-        assert(zone_->strand.running_in_this_thread());
+        assert(zone->strand.running_in_this_thread());
 
         const auto now = std::chrono::steady_clock::now();
         auto next_flush = std::chrono::steady_clock::time_point::max();
 
-        random_poisson in_duration(fluff_average_in);
-        random_poisson out_duration(fluff_average_out);
+        crypto::random_poisson_subseconds in_duration(fluff_average_in);
+        crypto::random_poisson_subseconds out_duration(fluff_average_out);
+
+
+        MDEBUG("Queueing " << txs.size() << " transaction(s) for Dandelion++ fluffing");
 
         bool available = false;
-        zone_->p2p->foreach_connection([this, now, &in_duration, &out_duration, &next_flush, &available] (detail::p2p_context& context)
+        zone->p2p->foreach_connection([txs, now, &zone, &source, &in_duration, &out_duration, &next_flush, &available] (detail::p2p_context& context)
         {
-          if (this->source_ != context.m_connection_id && (this->zone_->is_public || !context.m_is_income))
+          // When i2p/tor, only fluff to outbound connections
+          if (source != context.m_connection_id && (zone->is_public || !context.m_is_income))
           {
             available = true;
             if (context.fluff_txs.empty())
               context.flush_time = now + (context.m_is_income ? in_duration() : out_duration());
 
             next_flush = std::min(next_flush, context.flush_time);
-            context.fluff_txs.reserve(context.fluff_txs.size() + this->txs_.size());
-            for (const blobdata& tx : this->txs_)
+            context.fluff_txs.reserve(context.fluff_txs.size() + txs.size());
+            for (const blobdata& tx : txs)
               context.fluff_txs.push_back(tx); // must copy instead of move (multiple conns)
           }
           return true;
@@ -418,8 +423,8 @@ namespace levin
         if (!available)
           MWARNING("Unable to send transaction(s), no available connections");
 
-        if (next_flush < zone_->flush_time)
-          fluff_flush::queue(std::move(zone_), next_flush);
+       if (next_flush < zone->flush_time)
+         fluff_flush::queue(std::move(zone), next_flush);
       }
     };
 
@@ -471,6 +476,11 @@ namespace levin
         assert(zone->strand.running_in_this_thread());
 
         zone->connection_count = zone->map.size();
+
+        // only noise uses the "noise channels", only update when enabled
+        if (zone->noise.empty())
+          return;
+
         for (auto id = zone->map.begin(); id != zone->map.end(); ++id)
         {
           const std::size_t i = id - zone->map.begin();
@@ -479,26 +489,75 @@ namespace levin
       }
 
       //! \pre Called within `zone_->strand`.
-      void operator()()
+      static void run(std::shared_ptr<detail::zone> zone, std::vector<boost::uuids::uuid> out_connections)
       {
-        if (!zone_)
+        if (!zone)
           return;
 
-        assert(zone_->strand.running_in_this_thread());
-        if (zone_->map.update(std::move(out_connections_)))
-          post(std::move(zone_));
+        assert(zone->strand.running_in_this_thread());
+        if (zone->map.update(std::move(out_connections)))
+          post(std::move(zone));
+      }
+
+      //! \pre Called within `zone_->strand`.
+      void operator()()
+      {
+        run(std::move(zone_), std::move(out_connections_));
       }
     };
 
-    //! Swaps out noise channels entirely; new epoch start.
+    //! Checks fluff status for this node, and then does stem or fluff for txes
+    struct dandelionpp_notify
+    {
+      std::shared_ptr<detail::zone> zone_;
+      i_core_events* core_;
+      std::vector<blobdata> txs_;
+      boost::uuids::uuid source_;
+
+      //! \pre Called in `zone_->strand`
+      void operator()()
+      {
+        if (!zone_ || !core_ || txs_.empty())
+          return;
+
+        if (zone_->fluffing)
+        {
+          core_->on_transactions_relayed(epee::to_span(txs_), relay_method::fluff);
+          fluff_notify::run(std::move(zone_), epee::to_span(txs_), source_);
+        }
+        else // forward tx in stem
+        {
+          core_->on_transactions_relayed(epee::to_span(txs_), relay_method::stem);
+          for (int tries = 2; 0 < tries; tries--)
+          {
+            const boost::uuids::uuid destination = zone_->map.get_stem(source_);
+            if (!destination.is_nil() && make_payload_send_txs(*zone_->p2p, std::vector<blobdata>{txs_}, destination, zone_->pad_txs, false))
+            {
+              /* Source is intentionally omitted in debug log for privacy - a
+                  nil uuid indicates source is that node. */
+              MDEBUG("Sent " << txs_.size() << " transaction(s) to " << destination << " using Dandelion++ stem");
+              return;
+            }
+
+            // connection list may be outdated, try again
+            update_channels::run(zone_, get_out_connections(*zone_->p2p));
+          }
+
+          MERROR("Unable to send transaction(s) via Dandelion++ stem");
+        }
+      }
+    };
+
+    //! Swaps out noise/dandelionpp channels entirely; new epoch start.
     class change_channels
     {
       std::shared_ptr<detail::zone> zone_;
       net::dandelionpp::connection_map map_; // Requires manual copy constructor
+      bool fluffing_;
 
     public:
-      explicit change_channels(std::shared_ptr<detail::zone> zone, net::dandelionpp::connection_map map)
-        : zone_(std::move(zone)), map_(std::move(map))
+      explicit change_channels(std::shared_ptr<detail::zone> zone, net::dandelionpp::connection_map map, const bool fluffing)
+        : zone_(std::move(zone)), map_(std::move(map)), fluffing_(fluffing)
       {}
 
       change_channels(change_channels&&) = default;
@@ -510,11 +569,15 @@ namespace levin
       void operator()()
       {
         if (!zone_)
-          return
+          return;
 
         assert(zone_->strand.running_in_this_thread());
 
+        if (zone_->is_public)
+          MDEBUG("Starting new Dandelion++ epoch: " << (fluffing_ ? "fluff" : "stem"));
+
         zone_->map = std::move(map_);
+        zone_->fluffing = fluffing_;
         update_channels::post(std::move(zone_));
       }
     };
@@ -608,9 +671,10 @@ namespace levin
         if (error && error != boost::system::errc::operation_canceled)
           throw boost::system::system_error{error, "start_epoch timer failed"};
 
+        const bool fluffing = crypto::rand_idx(unsigned(100)) < CRYPTONOTE_DANDELIONPP_FLUFF_PROBABILITY;
         const auto start = std::chrono::steady_clock::now();
         zone_->strand.dispatch(
-          change_channels{zone_, net::dandelionpp::connection_map{get_out_connections(*(zone_->p2p)), count_}}
+          change_channels{zone_, net::dandelionpp::connection_map{get_out_connections(*(zone_->p2p)), count_}, fluffing}
         );
 
         detail::zone& alias = *zone_;
@@ -626,10 +690,16 @@ namespace levin
     if (!zone_->p2p)
       throw std::logic_error{"cryptonote::levin::notify cannot have nullptr p2p argument"};
 
-    if (!zone_->noise.empty())
+    const bool noise_enabled = !zone_->noise.empty();
+    if (noise_enabled || is_public)
     {
       const auto now = std::chrono::steady_clock::now();
-      start_epoch{zone_, noise_min_epoch, noise_epoch_range, CRYPTONOTE_NOISE_CHANNELS}();
+      const auto min_epoch = noise_enabled ? noise_min_epoch : dandelionpp_min_epoch;
+      const auto epoch_range = noise_enabled ? noise_epoch_range : dandelionpp_epoch_range;
+      const std::size_t out_count = noise_enabled ? CRYPTONOTE_NOISE_CHANNELS : CRYPTONOTE_DANDELIONPP_STEMS;
+
+      start_epoch{zone_, min_epoch, epoch_range, out_count}();
+
       for (std::size_t channel = 0; channel < zone_->channels.size(); ++channel)
         send_noise::wait(now, zone_, channel);
     }
@@ -679,13 +749,23 @@ namespace levin
     zone_->flush_txs.cancel();
   }
 
-  bool notify::send_txs(std::vector<blobdata> txs, const boost::uuids::uuid& source)
+  bool notify::send_txs(std::vector<blobdata> txs, const boost::uuids::uuid& source, i_core_events& core, relay_method tx_relay)
   {
     if (txs.empty())
       return true;
 
     if (!zone_)
       return false;
+
+    /* If noise is enabled in a zone, it always takes precedence. The technique
+        provides good protection against ISP adversaries, but not sybil
+        adversaries. Noise is currently only enabled over I2P/Tor - those
+        networks provide protection against sybil attacks (we only send to
+        outgoing connections).
+        If noise is disabled, Dandelion++ is used for public networks only.
+        Dandelion++ over I2P/Tor should be an interesting case to investigate,
+        but the mempool/stempool needs to know the zone a tx originated from to
+        work properly. */
 
     if (!zone_->noise.empty() && !zone_->channels.empty())
     {
@@ -694,8 +774,17 @@ namespace levin
         CRYPTONOTE_MAX_FRAGMENTS * CRYPTONOTE_NOISE_BYTES <= LEVIN_DEFAULT_MAX_PACKET_SIZE, "most nodes will reject this fragment setting"
       );
 
-      // padding is not useful when using noise mode
-      const std::string payload = make_tx_payload(std::move(txs), false);
+      if (tx_relay == relay_method::stem)
+      {
+        MWARNING("Dandelion++ stem not supported over noise networks");
+        tx_relay = relay_method::local; // do not put into stempool embargo (hopefully not there already!).
+      }
+
+      core.on_transactions_relayed(epee::to_span(txs), tx_relay);
+
+      // Padding is not useful when using noise mode. Send as stem so receiver
+      // forwards in Dandelion++ mode.
+      const std::string payload = make_tx_payload(std::move(txs), false, false);
       epee::byte_slice message = epee::levin::make_fragmented_notify(
         zone_->noise, NOTIFY_NEW_TRANSACTIONS::ID, epee::strspan<std::uint8_t>(payload)
       );
@@ -714,9 +803,31 @@ namespace levin
     }
     else
     {
-      zone_->strand.dispatch(fluff_notify{zone_, std::move(txs), source});
+      switch (tx_relay)
+      {
+        default:
+        case relay_method::none:
+        case relay_method::block:
+          return false;
+        case relay_method::stem:
+	      tx_relay = relay_method::fluff; // don't set stempool embargo when skipping to fluff
+        /* fallthrough */
+        case relay_method::local:
+          if (zone_->is_public)
+          {
+	        // this will change a local tx to stem or fluff ...
+            zone_->strand.dispatch(
+              dandelionpp_notify{zone_, std::addressof(core), std::move(txs), source}
+            );
+            break;
+          }
+          /* fallthrough */
+        case relay_method::fluff:
+          core.on_transactions_relayed(epee::to_span(txs), tx_relay);
+          zone_->strand.dispatch(fluff_notify{zone_, std::move(txs), source});
+          break;
+      }
     }
-
     return true;
   }
 } // levin

--- a/src/cryptonote_protocol/levin_notify.h
+++ b/src/cryptonote_protocol/levin_notify.h
@@ -35,6 +35,7 @@
 
 #include "byte_slice.h"
 #include "cryptonote_basic/blobdatatype.h"
+#include "cryptonote_protocol/enums.h"
 #include "cryptonote_protocol/fwd.h"
 #include "net/enums.h"
 #include "span.h"
@@ -122,7 +123,7 @@ namespace levin
           particular stem.
 
       \return True iff the notification is queued for sending. */
-    bool send_txs(std::vector<blobdata> txs, const boost::uuids::uuid& source);
+    bool send_txs(std::vector<blobdata> txs, const boost::uuids::uuid& source, i_core_events& core, relay_method tx_relay);
   };
 } // levin
 } // net

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -334,7 +334,7 @@ namespace nodetool
     virtual void callback(p2p_connection_context& context);
     //----------------- i_p2p_endpoint -------------------------------------------------------------
     virtual bool relay_notify_to_list(int command, const epee::span<const uint8_t> data_buff, std::vector<std::pair<epee::net_utils::zone, boost::uuids::uuid>> connections);
-    virtual epee::net_utils::zone send_txs(std::vector<cryptonote::blobdata> txs, const epee::net_utils::zone origin, const boost::uuids::uuid& source, cryptonote::i_core_events& core);
+    virtual epee::net_utils::zone send_txs(std::vector<cryptonote::blobdata> txs, const epee::net_utils::zone origin, const boost::uuids::uuid& source, cryptonote::i_core_events& core, cryptonote::relay_method tx_relay);
     virtual bool invoke_command_to_peer(int command, const epee::span<const uint8_t> req_buff, std::string& resp_buff, const epee::net_utils::connection_context_base& context);
     virtual bool invoke_notify_to_peer(int command, const epee::span<const uint8_t> req_buff, const epee::net_utils::connection_context_base& context);
     virtual bool drop_connection(const epee::net_utils::connection_context_base& context);
@@ -537,4 +537,3 @@ namespace nodetool
 }
 
 POP_WARNINGS
-

--- a/src/p2p/net_node_common.h
+++ b/src/p2p/net_node_common.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
@@ -50,7 +50,7 @@ namespace nodetool
   struct i_p2p_endpoint
   {
     virtual bool relay_notify_to_list(int command, const epee::span<const uint8_t> data_buff, std::vector<std::pair<epee::net_utils::zone, boost::uuids::uuid>> connections)=0;
-    virtual epee::net_utils::zone send_txs(std::vector<cryptonote::blobdata> txs, const epee::net_utils::zone origin, const boost::uuids::uuid& source, cryptonote::i_core_events& core)=0;
+    virtual epee::net_utils::zone send_txs(std::vector<cryptonote::blobdata> txs, const epee::net_utils::zone origin, const boost::uuids::uuid& source, cryptonote::i_core_events& core, cryptonote::relay_method tx_relay)=0;
     virtual bool invoke_command_to_peer(int command, const epee::span<const uint8_t> req_buff, std::string& resp_buff, const epee::net_utils::connection_context_base& context)=0;
     virtual bool invoke_notify_to_peer(int command, const epee::span<const uint8_t> req_buff, const epee::net_utils::connection_context_base& context)=0;
     virtual bool drop_connection(const epee::net_utils::connection_context_base& context)=0;
@@ -75,7 +75,7 @@ namespace nodetool
     {
       return false;
     }
-    virtual epee::net_utils::zone send_txs(std::vector<cryptonote::blobdata> txs, const epee::net_utils::zone origin, const boost::uuids::uuid& source, cryptonote::i_core_events& core)
+    virtual epee::net_utils::zone send_txs(std::vector<cryptonote::blobdata> txs, const epee::net_utils::zone origin, const boost::uuids::uuid& source, cryptonote::i_core_events& core, cryptonote::relay_method tx_relay)
     {
       return epee::net_utils::zone::invalid;
     }
@@ -104,7 +104,7 @@ namespace nodetool
       return false;
     }
 
-    virtual uint64_t get_public_connections_count()    
+    virtual uint64_t get_public_connections_count()
     {
       return false;
     }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1330,7 +1330,7 @@ namespace cryptonote
       return true;
     }
 
-    if(!tvc.m_should_be_relayed)
+    if(tvc.m_relay == relay_method::none)
     {
       LOG_PRINT_L0("[on_send_raw_tx]: tx accepted, but not relayed");
       res.reason = "Not relayed";
@@ -1340,8 +1340,8 @@ namespace cryptonote
     }
 
     NOTIFY_NEW_TRANSACTIONS::request r;
-    r.txs.push_back(tx_blob);
-    m_core.get_protocol()->relay_transactions(r, boost::uuids::nil_uuid(), epee::net_utils::zone::invalid);
+    r.txs.push_back(std::move(tx_blob));
+    m_core.get_protocol()->relay_transactions(r, boost::uuids::nil_uuid(), epee::net_utils::zone::invalid, relay_method::local);
     //TODO: make sure that tx has reached other nodes here, probably wait to receive reflections from other nodes
     res.status = CORE_RPC_STATUS_OK;
     return true;
@@ -2938,8 +2938,8 @@ namespace cryptonote
       if (!m_core.get_pool_transaction(txid, txblob, relay_category::legacy))
       {
         NOTIFY_NEW_TRANSACTIONS::request r;
-        r.txs.push_back(txblob);
-        m_core.get_protocol()->relay_transactions(r, boost::uuids::nil_uuid(), epee::net_utils::zone::invalid);
+        r.txs.push_back(std::move(txblob));
+        m_core.get_protocol()->relay_transactions(r, boost::uuids::nil_uuid(), epee::net_utils::zone::invalid, relay_method::local);
         //TODO: make sure that tx has reached other nodes here, probably wait to receive reflections from other nodes
       }
       else

--- a/src/rpc/daemon_handler.h
+++ b/src/rpc/daemon_handler.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2017-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -138,7 +138,7 @@ class DaemonHandler : public RpcHandler
 
     bool getBlockHeaderByHash(const crypto::hash& hash_in, cryptonote::rpc::BlockHeaderResponse& response);
 
-    void handleTxBlob(const std::string& tx_blob, bool relay, SendRawTx::Response& res);
+    void handleTxBlob(std::string&& tx_blob, bool relay, SendRawTx::Response& res);
 
     cryptonote::core& m_core;
     t_p2p& m_p2p;

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -175,7 +175,7 @@ bool gen_block_invalid_nonce::generate(std::vector<test_event_entry>& events) co
     return false;
 
   // Create invalid nonce
-  difficulty_type diffic = next_difficulty(timestamps, commulative_difficulties,DIFFICULTY_TARGET);
+  difficulty_type diffic = next_difficulty(timestamps, commulative_difficulties,3);
   assert(1 < diffic);
   const block& blk_last = boost::get<block>(events.back());
   uint64_t timestamp = blk_last.timestamp;
@@ -637,6 +637,21 @@ bool gen_block_invalid_binary_format::check_all_blocks_purged(cryptonote::core& 
 
   CHECK_EQ(1, c.get_pool_transactions_count());
   CHECK_EQ(m_corrupt_blocks_begin_idx - 2, c.get_current_blockchain_height());
+
+  return true;
+}
+
+bool gen_block_late_v1_coinbase_tx::generate(std::vector<test_event_entry>& events) const
+{
+  BLOCK_VALIDATION_INIT_GENERATE();
+
+  block blk_1;
+  generator.construct_block_manually(blk_1, blk_0, miner_account,
+      test_generator::bf_major_ver | test_generator::bf_minor_ver,
+      9, 9);
+  events.push_back(blk_1);
+
+  DO_CALLBACK(events, "check_block_purged");
 
   return true;
 }

--- a/tests/core_tests/block_validation.h
+++ b/tests/core_tests/block_validation.h
@@ -206,3 +206,15 @@ struct gen_block_invalid_binary_format : public test_chain_unit_base
 private:
   size_t m_corrupt_blocks_begin_idx;
 };
+
+struct gen_block_late_v1_coinbase_tx : public gen_block_verification_base<1>
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<>
+struct get_test_options<gen_block_late_v1_coinbase_tx> {
+  const std::pair<uint8_t, uint64_t> hard_forks[3] = {std::make_pair(1, 0), std::make_pair(9, 1), std::make_pair(0, 0)};
+  const cryptonote::test_options test_options = {
+    hard_forks, 0
+  };
+};

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -116,7 +116,8 @@ struct event_visitor_settings
   {
     set_txs_keeped_by_block = 1 << 0,
     set_txs_do_not_relay = 1 << 1,
-    set_local_relay = 1 << 2
+    set_local_relay = 1 << 2,
+    set_txs_stem = 1 << 3
   };
 
   event_visitor_settings(int a_mask = 0)
@@ -542,6 +543,10 @@ public:
     else if (settings.mask & event_visitor_settings::set_txs_do_not_relay)
     {
       m_tx_relay = cryptonote::relay_method::none;
+    }
+    else if (settings.mask & event_visitor_settings::set_txs_stem)
+    {
+      m_tx_relay = cryptonote::relay_method::stem;
     }
     else
     {

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -134,6 +134,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_block_has_invalid_tx);
     GENERATE_AND_PLAY(gen_block_is_too_big);
     GENERATE_AND_PLAY(gen_block_invalid_binary_format); // Takes up to 3 hours, if CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW == 500, up to 30 minutes, if CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW == 10
+    GENERATE_AND_PLAY(gen_block_late_v1_coinbase_tx);
 
     // Transaction verification tests
     GENERATE_AND_PLAY(gen_tx_big_version);
@@ -161,6 +162,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(txpool_double_spend_norelay);
     GENERATE_AND_PLAY(txpool_double_spend_local);
     GENERATE_AND_PLAY(txpool_double_spend_keyimage);
+    GENERATE_AND_PLAY(txpool_stem_loop);
 
     // Double spend
     GENERATE_AND_PLAY(gen_double_spend_in_tx<false>);

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -552,7 +552,6 @@ bool txpool_double_spend_local::generate(std::vector<test_event_entry>& events) 
   DO_CALLBACK(events, "mark_no_new");
   events.push_back(tx_0);
   DO_CALLBACK(events, "check_txpool_spent_keys");
-  DO_CALLBACK(events, "mark_timestamp_change");
   DO_CALLBACK(events, "check_unchanged");
   SET_EVENT_VISITOR_SETT(events, 0);
   DO_CALLBACK(events, "timestamp_change_pause");
@@ -580,6 +579,7 @@ bool txpool_double_spend_keyimage::generate(std::vector<test_event_entry>& event
   const std::size_t tx_index1 = events.size();
   MAKE_TX(events, tx_0, miner_account, bob_account, send_amount, blk_0);
 
+  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_stem);
   DO_CALLBACK(events, "increase_all_tx_count");
   DO_CALLBACK(events, "check_txpool_spent_keys");
   DO_CALLBACK(events, "mark_timestamp_change");
@@ -606,6 +606,34 @@ bool txpool_double_spend_keyimage::generate(std::vector<test_event_entry>& event
   DO_CALLBACK(events, "timestamp_change_pause");
   DO_CALLBACK(events, "mark_failed");
   events.push_back(tx_1);
+  DO_CALLBACK(events, "check_unchanged");
+
+  return true;
+}
+
+bool txpool_stem_loop::generate(std::vector<test_event_entry>& events) const
+{
+  INIT_MEMPOOL_TEST();
+
+  DO_CALLBACK(events, "check_txpool_spent_keys");
+  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_stem);
+  DO_CALLBACK(events, "mark_no_new");
+
+  MAKE_TX(events, tx_0, miner_account, bob_account, send_amount, blk_0);
+
+  DO_CALLBACK(events, "increase_all_tx_count");
+  DO_CALLBACK(events, "check_txpool_spent_keys");
+  DO_CALLBACK(events, "mark_timestamp_change");
+  DO_CALLBACK(events, "check_new_hidden");
+  DO_CALLBACK(events, "timestamp_change_pause");
+  events.push_back(tx_0);
+  DO_CALLBACK(events, "increase_broadcasted_tx_count");
+  DO_CALLBACK(events, "check_txpool_spent_keys");
+  DO_CALLBACK(events, "mark_timestamp_change");
+  DO_CALLBACK(events, "check_new_broadcasted");
+  DO_CALLBACK(events, "timestamp_change_pause");
+  DO_CALLBACK(events, "mark_no_new");
+  events.push_back(tx_0);
   DO_CALLBACK(events, "check_unchanged");
 
   return true;

--- a/tests/core_tests/tx_pool.h
+++ b/tests/core_tests/tx_pool.h
@@ -127,3 +127,12 @@ struct txpool_double_spend_keyimage : txpool_double_spend_base
 
   bool generate(std::vector<test_event_entry>& events) const;
 };
+
+struct txpool_stem_loop : txpool_double_spend_base
+{
+  txpool_stem_loop()
+    : txpool_double_spend_base()
+  {}
+
+  bool generate(std::vector<test_event_entry>& events) const;
+};

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -34,11 +34,14 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <set>
+#include <map>
 
 #include "byte_slice.h"
 #include "crypto/crypto.h"
 #include "cryptonote_basic/connection_context.h"
+#include "cryptonote_config.h"
 #include "cryptonote_core/cryptonote_core.h"
+#include "cryptonote_core/i_core_events.h"
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "cryptonote_protocol/levin_notify.h"
 #include "int-util.h"
@@ -113,6 +116,44 @@ namespace
         std::deque<epee::byte_slice> send_queue_;
     };
 
+    class test_core_events final : public cryptonote::i_core_events
+    {
+        std::map<cryptonote::relay_method, std::vector<cryptonote::blobdata>> relayed_;
+
+        virtual void on_transactions_relayed(epee::span<const cryptonote::blobdata> txes, cryptonote::relay_method relay) override final
+        {
+            std::vector<cryptonote::blobdata>& cached = relayed_[relay];
+            for (const auto& tx : txes)
+                cached.push_back(tx);
+        }
+
+    public:
+        test_core_events()
+          : relayed_()
+        {}
+
+        std::size_t relayed_method_size() const noexcept
+        {
+            return relayed_.size();
+        }
+
+        bool has_stem_txes() const noexcept
+        {
+            return relayed_.count(cryptonote::relay_method::stem);
+        }
+
+        std::vector<cryptonote::blobdata> take_relayed(cryptonote::relay_method relay)
+        {
+            auto elems = relayed_.find(relay);
+            if (elems == relayed_.end())
+                throw std::logic_error{"on_transactions_relayed empty"};
+
+            std::vector<cryptonote::blobdata> out{std::move(elems->second)};
+            relayed_.erase(elems);
+            return out;
+        }
+    };
+
     class test_connection
     {
         test_endpoint endpoint_;
@@ -146,6 +187,11 @@ namespace
         {
             return context_.m_connection_id;
         }
+
+        bool is_incoming() const noexcept
+        {
+            return context_.m_is_income;
+        }
     };
 
     struct received_message
@@ -155,7 +201,7 @@ namespace
         std::string payload;
     };
 
-    class test_receiver : public epee::levin::levin_commands_handler<cryptonote::levin::detail::p2p_context>
+    class test_receiver final : public epee::levin::levin_commands_handler<cryptonote::levin::detail::p2p_context>
     {
         std::deque<received_message> invoked_;
         std::deque<received_message> notified_;
@@ -253,7 +299,8 @@ namespace
             random_generator_(),
             io_service_(),
             receiver_(),
-            contexts_()
+            contexts_(),
+            events_()
         {
             connections_->set_handler(std::addressof(receiver_), nullptr);
         }
@@ -262,6 +309,7 @@ namespace
         {
             EXPECT_EQ(0u, receiver_.invoked_size());
             EXPECT_EQ(0u, receiver_.notified_size());
+            EXPECT_EQ(0u, events_.relayed_method_size());
         }
 
         void add_connection(const bool is_incoming)
@@ -283,6 +331,7 @@ namespace
         boost::asio::io_service io_service_;
         test_receiver receiver_;
         std::deque<test_connection> contexts_;
+        test_core_events events_;
     };
 }
 
@@ -434,11 +483,11 @@ TEST_F(levin_notify, defaulted)
         EXPECT_FALSE(status.has_noise);
         EXPECT_FALSE(status.connections_filled);
     }
-    EXPECT_TRUE(notifier.send_txs({}, random_generator_()));
+    EXPECT_TRUE(notifier.send_txs({}, random_generator_(), events_, cryptonote::relay_method::local));
 
     std::vector<cryptonote::blobdata> txs(2);
     txs[0].resize(100, 'e');
-    EXPECT_FALSE(notifier.send_txs(std::move(txs), random_generator_()));
+    EXPECT_FALSE(notifier.send_txs(std::move(txs), random_generator_(), events_, cryptonote::relay_method::local));
 }
 
 TEST_F(levin_notify, fluff_without_padding)
@@ -455,11 +504,6 @@ TEST_F(levin_notify, fluff_without_padding)
     }
     notifier.new_out_connection();
     io_service_.poll();
-    {
-        const auto status = notifier.get_status();
-        EXPECT_FALSE(status.has_noise);
-        EXPECT_FALSE(status.connections_filled); // not tracked
-    }
 
     std::vector<cryptonote::blobdata> txs(2);
     txs[0].resize(100, 'f');
@@ -468,7 +512,7 @@ TEST_F(levin_notify, fluff_without_padding)
     ASSERT_EQ(10u, contexts_.size());
     {
         auto context = contexts_.begin();
-        EXPECT_TRUE(notifier.send_txs(txs, context->get_id()));
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::fluff));
 
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
@@ -479,6 +523,7 @@ TEST_F(levin_notify, fluff_without_padding)
         for (++context; context != contexts_.end(); ++context)
             EXPECT_EQ(1u, context->process_send_queue());
 
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
         std::sort(txs.begin(), txs.end());
         ASSERT_EQ(9u, receiver_.notified_size());
         for (unsigned count = 0; count < 9; ++count)
@@ -486,7 +531,210 @@ TEST_F(levin_notify, fluff_without_padding)
             auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
             EXPECT_EQ(txs, notification.txs);
             EXPECT_TRUE(notification._.empty());
+            EXPECT_TRUE(notification.dandelionpp_fluff);
         }
+    }
+}
+
+TEST_F(levin_notify, stem_without_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'f');
+    txs[1].resize(200, 'e');
+
+    std::vector<cryptonote::blobdata> sorted_txs = txs;
+    std::sort(sorted_txs.begin(), sorted_txs.end());
+
+    ASSERT_EQ(10u, contexts_.size());
+    bool has_stemmed = false;
+    bool has_fluffed = false;
+    while (!has_stemmed || !has_fluffed)
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        const bool is_stem = events_.has_stem_txes();
+        EXPECT_EQ(txs, events_.take_relayed(is_stem ? cryptonote::relay_method::stem : cryptonote::relay_method::fluff));
+
+        if (!is_stem)
+        {
+            notifier.run_fluff();
+            ASSERT_LT(0u, io_service_.poll());
+        }
+
+        std::size_t send_count = 0;
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent && is_stem)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(is_stem ? 1u : 9u, send_count);
+        ASSERT_EQ(is_stem ? 1u : 9u, receiver_.notified_size());
+        for (unsigned count = 0; count < (is_stem ? 1u : 9u); ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            if (is_stem)
+              EXPECT_EQ(txs, notification.txs);
+            else
+              EXPECT_EQ(sorted_txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_EQ(!is_stem, notification.dandelionpp_fluff);
+        }
+
+        has_stemmed |= is_stem;
+        has_fluffed |= !is_stem;
+        notifier.run_epoch();
+    }
+}
+
+TEST_F(levin_notify, local_without_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'f');
+    txs[1].resize(200, 'e');
+
+    std::vector<cryptonote::blobdata> sorted_txs = txs;
+    std::sort(sorted_txs.begin(), sorted_txs.end());
+
+    ASSERT_EQ(10u, contexts_.size());
+    bool has_stemmed = false;
+    bool has_fluffed = false;
+    while (!has_stemmed || !has_fluffed)
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::local));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        const bool is_stem = events_.has_stem_txes();
+        EXPECT_EQ(txs, events_.take_relayed(is_stem ? cryptonote::relay_method::stem : cryptonote::relay_method::fluff));
+
+        if (!is_stem)
+        {
+            notifier.run_fluff();
+            ASSERT_LT(0u, io_service_.poll());
+        }
+
+        std::size_t send_count = 0;
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent && is_stem)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(is_stem ? 1u : 9u, send_count);
+        ASSERT_EQ(is_stem ? 1u : 9u, receiver_.notified_size());
+        for (unsigned count = 0; count < (is_stem ? 1u : 9u); ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+	    if (is_stem)
+	      EXPECT_EQ(txs, notification.txs);
+	    else
+	      EXPECT_EQ(sorted_txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_EQ(!is_stem, notification.dandelionpp_fluff);
+        }
+
+        has_stemmed |= is_stem;
+        has_fluffed |= !is_stem;
+        notifier.run_epoch();
+    }
+}
+
+TEST_F(levin_notify, block_without_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::block));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
+    }
+}
+
+TEST_F(levin_notify, none_without_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::none));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
     }
 }
 
@@ -504,11 +752,6 @@ TEST_F(levin_notify, fluff_with_padding)
     }
     notifier.new_out_connection();
     io_service_.poll();
-    {
-        const auto status = notifier.get_status();
-        EXPECT_FALSE(status.has_noise);
-        EXPECT_FALSE(status.connections_filled); // not tracked
-    }
 
     std::vector<cryptonote::blobdata> txs(2);
     txs[0].resize(100, 'f');
@@ -517,25 +760,219 @@ TEST_F(levin_notify, fluff_with_padding)
     ASSERT_EQ(10u, contexts_.size());
     {
         auto context = contexts_.begin();
-        EXPECT_TRUE(notifier.send_txs(txs, context->get_id()));
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::fluff));
 
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
         notifier.run_fluff();
         ASSERT_LT(0u, io_service_.poll());
 
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+        std::sort(txs.begin(), txs.end());
         EXPECT_EQ(0u, context->process_send_queue());
         for (++context; context != contexts_.end(); ++context)
             EXPECT_EQ(1u, context->process_send_queue());
 
-        std::sort(txs.begin(), txs.end());
         ASSERT_EQ(9u, receiver_.notified_size());
         for (unsigned count = 0; count < 9; ++count)
         {
             auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
             EXPECT_EQ(txs, notification.txs);
             EXPECT_FALSE(notification._.empty());
+            EXPECT_TRUE(notification.dandelionpp_fluff);
         }
+    }
+}
+
+TEST_F(levin_notify, stem_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    bool has_stemmed = false;
+    bool has_fluffed = false;
+    while (!has_stemmed || !has_fluffed)
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        const bool is_stem = events_.has_stem_txes();
+        EXPECT_EQ(txs, events_.take_relayed(is_stem ? cryptonote::relay_method::stem : cryptonote::relay_method::fluff));
+
+        if (!is_stem)
+        {
+            notifier.run_fluff();
+            ASSERT_LT(0u, io_service_.poll());
+        }
+
+        std::size_t send_count = 0;
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent && is_stem)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+                EXPECT_FALSE(context->is_incoming());
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(is_stem ? 1u : 9u, send_count);
+        ASSERT_EQ(is_stem ? 1u : 9u, receiver_.notified_size());
+        for (unsigned count = 0; count < (is_stem ? 1u : 9u); ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_FALSE(notification._.empty());
+            EXPECT_EQ(!is_stem, notification.dandelionpp_fluff);
+        }
+
+        has_stemmed |= is_stem;
+        has_fluffed |= !is_stem;
+        notifier.run_epoch();
+    }
+}
+
+TEST_F(levin_notify, local_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    bool has_stemmed = false;
+    bool has_fluffed = false;
+    while (!has_stemmed || !has_fluffed)
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::local));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        const bool is_stem = events_.has_stem_txes();
+        EXPECT_EQ(txs, events_.take_relayed(is_stem ? cryptonote::relay_method::stem : cryptonote::relay_method::fluff));
+
+        if (!is_stem)
+        {
+            notifier.run_fluff();
+            ASSERT_LT(0u, io_service_.poll());
+        }
+
+        std::size_t send_count = 0;
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent && is_stem)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+                EXPECT_FALSE(context->is_incoming());
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(is_stem ? 1u : 9u, send_count);
+        ASSERT_EQ(is_stem ? 1u : 9u, receiver_.notified_size());
+        for (unsigned count = 0; count < (is_stem ? 1u : 9u); ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_FALSE(notification._.empty());
+            EXPECT_EQ(!is_stem, notification.dandelionpp_fluff);
+        }
+
+        has_stemmed |= is_stem;
+        has_fluffed |= !is_stem;
+        notifier.run_epoch();
+    }
+}
+
+TEST_F(levin_notify, block_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::block));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
+    }
+}
+
+TEST_F(levin_notify, none_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, true, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::none));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
     }
 }
 
@@ -553,20 +990,15 @@ TEST_F(levin_notify, private_fluff_without_padding)
     }
     notifier.new_out_connection();
     io_service_.poll();
-    {
-        const auto status = notifier.get_status();
-        EXPECT_FALSE(status.has_noise);
-        EXPECT_FALSE(status.connections_filled); // not tracked
-    }
 
     std::vector<cryptonote::blobdata> txs(2);
-    txs[0].resize(100, 'f');
-    txs[1].resize(200, 'e');
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
 
     ASSERT_EQ(10u, contexts_.size());
     {
         auto context = contexts_.begin();
-        EXPECT_TRUE(notifier.send_txs(txs, context->get_id()));
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::fluff));
 
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
@@ -574,7 +1006,8 @@ TEST_F(levin_notify, private_fluff_without_padding)
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
 
-        std::sort(txs.begin(), txs.end());
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+
         EXPECT_EQ(0u, context->process_send_queue());
         for (++context; context != contexts_.end(); ++context)
         {
@@ -588,7 +1021,170 @@ TEST_F(levin_notify, private_fluff_without_padding)
             auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
             EXPECT_EQ(txs, notification.txs);
             EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
         }
+    }
+}
+
+TEST_F(levin_notify, private_stem_without_padding)
+{
+    // private mode always uses fluff but marked as stem
+    cryptonote::levin::notify notifier = make_notifier(0, false, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        notifier.run_fluff();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const bool is_incoming = ((context - contexts_.begin()) % 2 == 0);
+            EXPECT_EQ(is_incoming ? 0u : 1u, context->process_send_queue());
+        }
+
+        ASSERT_EQ(5u, receiver_.notified_size());
+        for (unsigned count = 0; count < 5; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+}
+
+TEST_F(levin_notify, private_local_without_padding)
+{
+    // private mode always uses fluff but marked as stem
+    cryptonote::levin::notify notifier = make_notifier(0, false, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::local));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        notifier.run_fluff();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::local));
+
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const bool is_incoming = ((context - contexts_.begin()) % 2 == 0);
+            EXPECT_EQ(is_incoming ? 0u : 1u, context->process_send_queue());
+        }
+
+        ASSERT_EQ(5u, receiver_.notified_size());
+        for (unsigned count = 0; count < 5; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+}
+
+TEST_F(levin_notify, private_block_without_padding)
+{
+    // private mode always uses fluff but marked as stem
+    cryptonote::levin::notify notifier = make_notifier(0, false, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::block));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
+    }
+}
+
+TEST_F(levin_notify, private_none_without_padding)
+{
+    // private mode always uses fluff but marked as stem
+    cryptonote::levin::notify notifier = make_notifier(0, false, false);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::none));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
     }
 }
 
@@ -606,28 +1202,24 @@ TEST_F(levin_notify, private_fluff_with_padding)
     }
     notifier.new_out_connection();
     io_service_.poll();
-    {
-        const auto status = notifier.get_status();
-        EXPECT_FALSE(status.has_noise);
-        EXPECT_FALSE(status.connections_filled); // not tracked
-    }
 
     std::vector<cryptonote::blobdata> txs(2);
-    txs[0].resize(100, 'f');
-    txs[1].resize(200, 'e');
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
 
     ASSERT_EQ(10u, contexts_.size());
     {
         auto context = contexts_.begin();
-        EXPECT_TRUE(notifier.send_txs(txs, context->get_id()));
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::fluff));
 
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
         notifier.run_fluff();
         io_service_.reset();
         ASSERT_LT(0u, io_service_.poll());
-        
-        std::sort(txs.begin(), txs.end());
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+
         EXPECT_EQ(0u, context->process_send_queue());
         for (++context; context != contexts_.end(); ++context)
         {
@@ -641,6 +1233,401 @@ TEST_F(levin_notify, private_fluff_with_padding)
             auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
             EXPECT_EQ(txs, notification.txs);
             EXPECT_FALSE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+}
+
+TEST_F(levin_notify, private_stem_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, false, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        notifier.run_fluff();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const bool is_incoming = ((context - contexts_.begin()) % 2 == 0);
+            EXPECT_EQ(is_incoming ? 0u : 1u, context->process_send_queue());
+        }
+
+        ASSERT_EQ(5u, receiver_.notified_size());
+        for (unsigned count = 0; count < 5; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_FALSE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+}
+
+TEST_F(levin_notify, private_local_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, false, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::local));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        notifier.run_fluff();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::local));
+
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const bool is_incoming = ((context - contexts_.begin()) % 2 == 0);
+            EXPECT_EQ(is_incoming ? 0u : 1u, context->process_send_queue());
+        }
+
+        ASSERT_EQ(5u, receiver_.notified_size());
+        for (unsigned count = 0; count < 5; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_FALSE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+}
+
+TEST_F(levin_notify, private_block_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, false, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::block));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
+    }
+}
+
+TEST_F(levin_notify, private_none_with_padding)
+{
+    cryptonote::levin::notify notifier = make_notifier(0, false, true);
+
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(10u, contexts_.size());
+    {
+        auto context = contexts_.begin();
+        EXPECT_FALSE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::none));
+
+        io_service_.reset();
+        ASSERT_EQ(0u, io_service_.poll());
+    }
+}
+
+TEST_F(levin_notify, stem_mappings)
+{
+    static constexpr const unsigned test_connections_count = (CRYPTONOTE_DANDELIONPP_STEMS + 1) * 2;
+
+    cryptonote::levin::notify notifier = make_notifier(0, true, false);
+
+    for (unsigned count = 0; count < test_connections_count; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(test_connections_count, contexts_.size());
+    for (;;)
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        if (events_.has_stem_txes())
+            break;
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+        notifier.run_fluff();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+            EXPECT_EQ(1u, context->process_send_queue());
+
+        ASSERT_EQ(test_connections_count - 1, receiver_.notified_size());
+        for (unsigned count = 0; count < test_connections_count - 1; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_TRUE(notification.dandelionpp_fluff);
+        }
+
+        notifier.run_epoch();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+    }
+    EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::stem));
+
+    std::set<boost::uuids::uuid> used;
+    std::map<boost::uuids::uuid, boost::uuids::uuid> mappings;
+    {
+        std::size_t send_count = 0;
+        for (auto context = contexts_.begin(); context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+                EXPECT_FALSE(context->is_incoming());
+                used.insert(context->get_id());
+                mappings[contexts_.front().get_id()] = context->get_id();
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(1u, send_count);
+        ASSERT_EQ(1u, receiver_.notified_size());
+        for (unsigned count = 0; count < 1u; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+
+    for (unsigned i = 0; i < contexts_.size() * 2; i += 2)
+    {
+        auto& incoming = contexts_[i % contexts_.size()];
+        EXPECT_TRUE(notifier.send_txs(txs, incoming.get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::stem));
+
+        std::size_t send_count = 0;
+        for (auto context = contexts_.begin(); context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+                EXPECT_FALSE(context->is_incoming());
+                used.insert(context->get_id());
+
+                auto inserted = mappings.emplace(incoming.get_id(), context->get_id()).first;
+                EXPECT_EQ(inserted->second, context->get_id()) << "incoming index " << i;
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(1u, send_count);
+        ASSERT_EQ(1u, receiver_.notified_size());
+        for (unsigned count = 0; count < 1u; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+
+    EXPECT_EQ(CRYPTONOTE_DANDELIONPP_STEMS, used.size());
+}
+
+TEST_F(levin_notify, fluff_multiple)
+{
+    static constexpr const unsigned test_connections_count = (CRYPTONOTE_DANDELIONPP_STEMS + 1) * 2;
+
+    cryptonote::levin::notify notifier = make_notifier(0, true, false);
+
+    for (unsigned count = 0; count < test_connections_count; ++count)
+        add_connection(count % 2 == 0);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_FALSE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    notifier.new_out_connection();
+    io_service_.poll();
+
+    std::vector<cryptonote::blobdata> txs(2);
+    txs[0].resize(100, 'e');
+    txs[1].resize(200, 'f');
+
+    ASSERT_EQ(test_connections_count, contexts_.size());
+    for (;;)
+    {
+        auto context = contexts_.begin();
+        EXPECT_TRUE(notifier.send_txs(txs, context->get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        if (!events_.has_stem_txes())
+            break;
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::stem));
+
+        std::size_t send_count = 0;
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+        {
+            const std::size_t sent = context->process_send_queue();
+            if (sent)
+            {
+                EXPECT_EQ(1u, (context - contexts_.begin()) % 2);
+                EXPECT_FALSE(context->is_incoming());
+            }
+            send_count += sent;
+        }
+
+        EXPECT_EQ(1u, send_count);
+        ASSERT_EQ(1u, receiver_.notified_size());
+        for (unsigned count = 0; count < 1; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+
+        notifier.run_epoch();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+    }
+    EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+    notifier.run_fluff();
+    io_service_.reset();
+    ASSERT_LT(0u, io_service_.poll());
+    {
+        auto context = contexts_.begin();
+        EXPECT_EQ(0u, context->process_send_queue());
+        for (++context; context != contexts_.end(); ++context)
+            EXPECT_EQ(1u, context->process_send_queue());
+
+        ASSERT_EQ(contexts_.size() - 1, receiver_.notified_size());
+        for (unsigned count = 0; count < contexts_.size() - 1; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_TRUE(notification.dandelionpp_fluff);
+        }
+    }
+
+    for (unsigned i = 0; i < contexts_.size() * 2; i += 2)
+    {
+        auto& incoming = contexts_[i % contexts_.size()];
+        EXPECT_TRUE(notifier.send_txs(txs, incoming.get_id(), events_, cryptonote::relay_method::stem));
+
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+        notifier.run_fluff();
+        io_service_.reset();
+        ASSERT_LT(0u, io_service_.poll());
+
+        EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
+
+        for (auto& context : contexts_)
+        {
+            if (std::addressof(incoming) == std::addressof(context))
+                EXPECT_EQ(0u, context.process_send_queue());
+            else
+                EXPECT_EQ(1u, context.process_send_queue());
+        }
+
+        ASSERT_EQ(contexts_.size() - 1, receiver_.notified_size());
+        for (unsigned count = 0; count < contexts_.size() - 1; ++count)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_TRUE(notification.dandelionpp_fluff);
         }
     }
 }
@@ -680,10 +1667,12 @@ TEST_F(levin_notify, noise)
         EXPECT_EQ(0u, receiver_.notified_size());
     }
 
-    EXPECT_TRUE(notifier.send_txs(txs, incoming_id));
+    EXPECT_TRUE(notifier.send_txs(txs, incoming_id, events_, cryptonote::relay_method::local));
     notifier.run_stems();
     io_service_.reset();
     ASSERT_LT(0u, io_service_.poll());
+
+    EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::local));
     {
         std::size_t sent = 0;
         for (auto& context : contexts_)
@@ -695,14 +1684,17 @@ TEST_F(levin_notify, noise)
             auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
             EXPECT_EQ(txs, notification.txs);
             EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
         }
     }
 
     txs[0].resize(3000, 'r');
-    EXPECT_TRUE(notifier.send_txs(txs, incoming_id));
+    EXPECT_TRUE(notifier.send_txs(txs, incoming_id, events_, cryptonote::relay_method::fluff));
     notifier.run_stems();
     io_service_.reset();
     ASSERT_LT(0u, io_service_.poll());
+
+    EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::fluff));
     {
         std::size_t sent = 0;
         for (auto& context : contexts_)
@@ -726,6 +1718,65 @@ TEST_F(levin_notify, noise)
             auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
             EXPECT_EQ(txs, notification.txs);
             EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
+        }
+    }
+}
+
+TEST_F(levin_notify, noise_stem)
+{
+    for (unsigned count = 0; count < 10; ++count)
+        add_connection(count % 2 == 0);
+
+    std::vector<cryptonote::blobdata> txs(1);
+    txs[0].resize(1900, 'h');
+
+    const boost::uuids::uuid incoming_id = random_generator_();
+    cryptonote::levin::notify notifier = make_notifier(2048, false, true);
+
+    {
+        const auto status = notifier.get_status();
+        EXPECT_TRUE(status.has_noise);
+        EXPECT_FALSE(status.connections_filled);
+    }
+    ASSERT_LT(0u, io_service_.poll());
+    {
+        const auto status = notifier.get_status();
+        EXPECT_TRUE(status.has_noise);
+        EXPECT_TRUE(status.connections_filled);
+    }
+
+    notifier.run_stems();
+    io_service_.reset();
+    ASSERT_LT(0u, io_service_.poll());
+    {
+        std::size_t sent = 0;
+        for (auto& context : contexts_)
+            sent += context.process_send_queue();
+
+        EXPECT_EQ(2u, sent);
+        EXPECT_EQ(0u, receiver_.notified_size());
+    }
+
+    EXPECT_TRUE(notifier.send_txs(txs, incoming_id, events_, cryptonote::relay_method::stem));
+    notifier.run_stems();
+    io_service_.reset();
+    ASSERT_LT(0u, io_service_.poll());
+
+    // downgraded to local when being notified
+    EXPECT_EQ(txs, events_.take_relayed(cryptonote::relay_method::local));
+    {
+        std::size_t sent = 0;
+        for (auto& context : contexts_)
+            sent += context.process_send_queue();
+
+        ASSERT_EQ(2u, sent);
+        while (sent--)
+        {
+            auto notification = receiver_.get_notification<cryptonote::NOTIFY_NEW_TRANSACTIONS>().second;
+            EXPECT_EQ(txs, notification.txs);
+            EXPECT_TRUE(notification._.empty());
+            EXPECT_FALSE(notification.dandelionpp_fluff);
         }
     }
 }


### PR DESCRIPTION
Fully enable dandelion++ support to sumokoin public networks (many many thanks to vtnerd)
Dandelion++ is a brilliant tx origin obfuscation method proposed by Cornell University in 2017-2018 as described here https://arxiv.org/abs/1805.11060
Full papers here
original paper: https://arxiv.org/pdf/1701.04439.pdf
final paper: https://arxiv.org/pdf/1805.11060v1.pdf  

It is fully backwards compatible, it does not need an HF and it defaults to true however the more "honest" nodes running it, the greater and more secure the obfuscation which means next release should be marked as mandatory.

To test if dandelion is functional on your sumo node just type on your daemon 
`set_log +net.p2p.tx:debug`

Ref: https://github.com/monero-project/monero/pull/6314