### PR TITLE
[daemon] dont bring ascii logo that dont belong to global logs into them

### DIFF
--- a/src/daemon/core.h
+++ b/src/daemon/core.h
@@ -71,7 +71,7 @@ public:
       throw std::runtime_error("Failed to initialize core");
     }
     MGINFO("Core initialized OK");
-    MGINFO_CYAN(std::endl << "\n \n" 
+    std::cout << std::endl << 
     "\033[1;36m	  ___                        _         _               \033[0m" << std::endl <<
     "\033[1;36m	/ ___| _   _ _ __ ___   ___ | | _____ (_)_ __          \033[0m" << std::endl <<
     "\033[1;36m	\\___ \\| | | | '_ ` _ \\ / _ \\| |/ / _ \\| | '_ \\   \033[0m" << std::endl <<
@@ -79,7 +79,7 @@ public:
     "\033[1;36m	|____/ \\__,_|_| |_| |_|\\___/|_|\\_\\___/|_|_| |_|    \033[0m" << std::endl <<
     std::endl <<
     "\033[1;36m                 PRIVACY WITHOUT COMPROMISE             \033[0m" << std::endl <<
-    std::endl);
+    std::endl;
   }
 
   // TODO - get rid of circular dependencies in internals


### PR DESCRIPTION
Just print them. Logs are oversized already