### PR TITLE
Upgrade to C++17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         restore-keys: ccache-windows-build-
     - name: update pacman
       run: msys2do pacman -Syu --noconfirm
-    - name: install monero dependencies
+    - name: install sumokoin dependencies
       run: msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git mingw-w64-x86_64-ccache
     - name: build
       run: |
@@ -69,10 +69,14 @@ jobs:
           ccache-ubuntu-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
+    - name: add latest repo
+      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - name: update apt
       run: sudo apt update
-    - name: install monero dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: install sumokoin dependencies
+      run: sudo apt -y install build-essential cmake gcc-9 g++-9 libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: switch to gcc 9
+      run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 20 --slave /usr/bin/g++ g++ /usr/bin/g++-9
     - name: build
       run: |
         ccache --max-size=100M
@@ -97,10 +101,14 @@ jobs:
           ccache-ubuntu-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
+    - name: add latest repo
+      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - name: update apt
       run: sudo apt update
-    - name: install monero dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: install sumokoin dependencies
+      run: sudo apt -y install build-essential cmake gcc-9 g++-9 libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: switch to gcc 9
+      run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 20 --slave /usr/bin/g++ g++ /usr/bin/g++-9
     - name: build
       run: |
         ccache --max-size=100M
@@ -127,10 +135,14 @@ jobs:
           ccache-ubuntu-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
+    - name: add latest repo
+      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - name: update apt
       run: sudo apt update
-    - name: install monero dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: install sumokoin dependencies
+      run: sudo apt -y install build-essential cmake gcc-9 g++-9 libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: switch to gcc 9
+      run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 20 --slave /usr/bin/g++ g++ /usr/bin/g++-9
     - name: install requests
       run: pip install requests
     - name: tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,91 +5,137 @@ on: [push, pull_request]
 jobs:
   build-macos:
     runs-on: macOS-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: ccache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-macos-build-${{ github.sha }}
+        restore-keys: ccache-macos-build-
     - name: update brew and install dependencies
-      run: brew update && brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf
+      run: brew update && brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf ccache
     - name: build
-      run: make -j3
+      run: |
+        ccache --max-size=100M
+        make -j3
 
   build-windows:
     runs-on: windows-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
     - uses: numworks/setup-msys2@v1
+    - name: ccache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-windows-build-${{ github.sha }}
+        restore-keys: ccache-windows-build-
     - name: update pacman
       run: msys2do pacman -Syu --noconfirm
-    - name: install sumokoin dependencies
-      run: msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
+    - name: install monero dependencies
+      run: msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git mingw-w64-x86_64-ccache
     - name: build
-      run: msys2do make release-static-win64 -j2
+      run: |
+        msys2do ccache --max-size=100M
+        msys2do make release-static-win64 -j2
 
   build-ubuntu:
     runs-on: ubuntu-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: ccache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-ubuntu-build-${{ github.sha }}
+        restore-keys: |
+          ccache-ubuntu-build-
+          ccache-ubuntu-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
-    - name: set apt conf
-      run: |
-        echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::ftp::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom      
     - name: update apt
       run: sudo apt update
-    - name: install sumokoin dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev
+    - name: install monero dependencies
+      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
     - name: build
-      run: make -j3
+      run: |
+        ccache --max-size=100M
+        make -j3
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: ccache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-ubuntu-libwallet-${{ github.sha }}
+        restore-keys: |
+          ccache-ubuntu-libwallet-
+          ccache-ubuntu-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
-    - name: set apt conf
-      run: |
-        echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::ftp::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom      
     - name: update apt
       run: sudo apt update
-    - name: install sumokoin dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev
+    - name: install monero dependencies
+      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
     - name: build
-      run: cmake -DBUILD_GUI_DEPS=ON && make -j3
+      run: |
+        ccache --max-size=100M
+        cmake -DBUILD_GUI_DEPS=ON
+        make -j3
 
   test-ubuntu:
     needs: build-ubuntu
     runs-on: ubuntu-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: /tmp/.ccache-temp
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: ccache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-ubuntu-test-${{ github.sha }}
+        restore-keys: |
+          ccache-ubuntu-test-
+          ccache-ubuntu-
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
-    - name: set apt conf
-      run: |
-        echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
-        echo "Acquire::ftp::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom      
     - name: update apt
       run: sudo apt update
-    - name: install sumokoin dependencies
-      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev
+    - name: install monero dependencies
+      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
     - name: install requests
       run: pip install requests
     - name: tests
       env:
         CTEST_OUTPUT_ON_FAILURE: ON
-      run: make release-test -j3
-
+      run: |
+        ccache --max-size=100M
+        make release-test -j3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "(SunOS|Solaris)")
 endif ()
 
 if (APPLE AND NOT IOS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -fvisibility=default -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -fvisibility=default -std=c++17")
   if (NOT OpenSSL_DIR)
       EXECUTE_PROCESS(COMMAND brew --prefix openssl
         OUTPUT_VARIABLE OPENSSL_ROOT_DIR
@@ -599,7 +599,7 @@ else()
     set(WARNINGS "${WARNINGS} -Wno-delete-abstract-non-virtual-dtor")
   endif()
 
-  try_compile(STATIC_ASSERT_CPP_RES "${CMAKE_CURRENT_BINARY_DIR}/static-assert" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test-static-assert.cpp" COMPILE_DEFINITIONS "-std=c++11")
+  try_compile(STATIC_ASSERT_CPP_RES "${CMAKE_CURRENT_BINARY_DIR}/static-assert" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test-static-assert.cpp" COMPILE_DEFINITIONS "-std=c++17")
   if(STATIC_ASSERT_CPP_RES)
     set(STATIC_ASSERT_CPP_FLAG "")
   else()
@@ -688,7 +688,7 @@ else()
   message(STATUS "Using linker security hardening flags: ${LD_SECURITY_FLAGS}")
 
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -D_GNU_SOURCE ${MINGW_FLAG} ${STATIC_ASSERT_FLAG} ${WARNINGS} ${C_WARNINGS} ${COVERAGE_FLAGS} ${PIC_FLAG} ${C_SECURITY_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D_GNU_SOURCE ${MINGW_FLAG} ${STATIC_ASSERT_CPP_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${COVERAGE_FLAGS} ${PIC_FLAG} ${CXX_SECURITY_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -D_GNU_SOURCE ${MINGW_FLAG} ${STATIC_ASSERT_CPP_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${COVERAGE_FLAGS} ${PIC_FLAG} ${CXX_SECURITY_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LD_SECURITY_FLAGS} ${LD_BACKCOMPAT_FLAGS}")
 
   # With GCC 6.1.1 the compiled binary malfunctions due to aliasing. Until that

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ library archives (`.a`).
 
 | Dep          | Min. version  | Vendored | Debian/Ubuntu pkg    | Arch pkg     | Fedora              | Optional | Purpose         |
 | ------------ | ------------- | -------- | -------------------- | ------------ | ------------------- | -------- | --------------- |
-| GCC          | 4.7.3         | NO       | `build-essential`    | `base-devel` | `gcc`               | NO       |                 |
+| GCC          | 9.3.0         | NO       | `gcc-9 g++-9`        | `base-devel` | `gcc`               | NO       |                 |
 | CMake        | 3.5           | NO       | `cmake`              | `cmake`      | `cmake`             | NO       |                 |
 | pkg-config   | any           | NO       | `pkg-config`         | `base-devel` | `pkgconf`           | NO       |                 |
 | Boost        | 1.58          | NO       | `libboost-all-dev`   | `boost`      | `boost-devel`       | NO       | C++ libraries   |
@@ -100,7 +100,7 @@ build the library binary manually. This can be done with the following command `
 
 Install all dependencies at once on Debian/Ubuntu:
 
-``` sudo apt update && sudo apt install build-essential cmake pkg-config libboost-all-dev libssl-dev libzmq3-dev libunbound-dev libsodium-dev libunwind8-dev liblzma-dev libreadline6-dev libldns-dev libexpat1-dev doxygen graphviz libpgm-dev qttools5-dev-tools libhidapi-dev libusb-dev libprotobuf-dev protobuf-compiler ```
+``` sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt update && sudo apt install cmake build-essential pkg-config libboost-all-dev gcc-9 g++-9 libssl-dev libzmq3-dev libunbound-dev libsodium-dev libunwind8-dev liblzma-dev libreadline6-dev libldns-dev libexpat1-dev doxygen graphviz libpgm-dev qttools5-dev-tools libhidapi-dev libusb-dev libprotobuf-dev protobuf-compiler && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 20 --slave /usr/bin/g++ g++ /usr/bin/g++-9 ```
 
 Install all dependencies at once on macOS with the provided Brewfile:
 ``` brew update && brew bundle --file=contrib/brew/Brewfile ```

--- a/contrib/epee/src/http_auth.cpp
+++ b/contrib/epee/src/http_auth.cpp
@@ -214,7 +214,7 @@ namespace
   >;
 
   template<typename T>
-  quoted_result<T> quoted(const T& arg)
+  quoted_result<T> quotes(const T& arg)
   {
     return boost::range::join(boost::range::join(ceref(u8"\""), arg), ceref(u8"\""));
   }
@@ -242,13 +242,13 @@ namespace
   {
     str.append(u8"Digest ");
     add_first_field(str, u8"algorithm", algorithm);
-    add_field(str, u8"nonce", quoted(user.server.nonce));
-    add_field(str, u8"realm", quoted(user.server.realm));
-    add_field(str, u8"response", quoted(response));
-    add_field(str, u8"uri", quoted(uri));
-    add_field(str, u8"username", quoted(user.credentials.username));
+    add_field(str, u8"nonce", quotes(user.server.nonce));
+    add_field(str, u8"realm", quotes(user.server.realm));
+    add_field(str, u8"response", quotes(response));
+    add_field(str, u8"uri", quotes(uri));
+    add_field(str, u8"username", quotes(user.credentials.username));
     if (!user.server.opaque.empty())
-      add_field(str, u8"opaque", quoted(user.server.opaque));
+      add_field(str, u8"opaque", quotes(user.server.opaque));
   }
 
   //! Implements superseded algorithm specified in RFC 2069
@@ -674,8 +674,8 @@ namespace
           Digest::name, (i == 0 ? boost::string_ref{} : sess_algo)
         );
         add_field(out, u8"algorithm", algorithm);
-        add_field(out, u8"realm", quoted(auth_realm));
-        add_field(out, u8"nonce", quoted(nonce));
+        add_field(out, u8"realm", quotes(auth_realm));
+        add_field(out, u8"nonce", quotes(nonce));
         add_field(out, u8"stale", is_stale ? ceref("true") : ceref("false"));
         
         fields.push_back(std::make_pair(std::string(server_auth_field), std::move(out)));
@@ -782,4 +782,3 @@ namespace epee
     }
   }
 }
-

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -326,7 +326,7 @@ namespace hw {
     //automatic lock one more level on device ensuring the current thread is allowed to use it
     #define AUTO_LOCK_CMD() \
       /* lock both mutexes without deadlock*/ \
-      boost::lock(device_locker, command_locker); \
+      std::lock(device_locker, command_locker); \
       /* make sure both already-locked mutexes are unlocked at the end of scope */ \
       boost::lock_guard<boost::recursive_mutex> lock1(device_locker, boost::adopt_lock); \
       boost::lock_guard<boost::mutex> lock2(command_locker, boost::adopt_lock)

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -49,7 +49,7 @@
 //automatic lock one more level on device ensuring the current thread is allowed to use it
 #define TREZOR_AUTO_LOCK_CMD() \
   /* lock both mutexes without deadlock*/ \
-  boost::lock(device_locker, command_locker); \
+  std::lock(device_locker, command_locker); \
   /* make sure both already-locked mutexes are unlocked at the end of scope */ \
   boost::lock_guard<boost::recursive_mutex> lock1(device_locker, boost::adopt_lock); \
   boost::lock_guard<boost::mutex> lock2(command_locker, boost::adopt_lock)


### PR DESCRIPTION
### This is still a draft, working PR and will include several commits (do not merge)

C++11 is almost a decade old if you step back to consider that C++20 is almost out.... STL has come a long way up to C++17 and we can remove boost dependancy on many constructs improving speed and code robustness as well as using its various new features.

**C++17 is totally and absolutely backwards compatible with C++11** besides some rare cases like the one i fixed on device (ledger & trezor) with mutex overspecification (just used the STL for lock instead of boost) https://cplusplus.github.io/LWG/lwg-unresolved.html#936
1. Clang hates deprecated boost::string_ref changed with std::string_view
2. (clang) fix 'quoted' calls cause they are conflicting with std::quoted() introduced after C++11 (by renaming them)
who would have thought....

Code compiles perfectly on gcc and clang now

started changing boost::filesystem to std::filesystem it either needs a direct link to the library on cmake for current gcc version or welcome gcc 9! Update sumo instructions and workflows to gcc 9
(clang is surprisingly fine with it)

