### PR TITLE
[unit_tests] string_ref test

### DIFF
--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -841,6 +841,9 @@ TEST(HexLocale, String)
     // decoding it this way also, ignoring spaces and colons between the numbers
     hex.assign("00:ff 0f:f0");
     EXPECT_EQ(source, epee::from_hex_locale::to_vector(hex));
+
+    hex.append("f0");
+    EXPECT_EQ(source, epee::from_hex_locale::to_vector(boost::string_ref{hex.data(), hex.size() - 2}));
 }
 
 TEST(ToHex, Array)


### PR DESCRIPTION
This is partial from https://github.com/monero-project/monero/pull/6359
_Fixed string_ref usage bug in epee::from_hex::vector_

The bug was fixed in our code in a past commit, add the unit_tests part now as well

Of course boost::string_ref (and many of the epee tools) could have been replaced with C++17 STL , in this case std::string_view