### PR TITLE
[dandelion++] dandelion++ functional tests

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -429,9 +429,9 @@ namespace cryptonote
     return m_blockchain_storage.get_split_transactions_blobs(txs_ids, txs, missed_txs);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_txpool_backlog(std::vector<tx_backlog_entry>& backlog) const
+  bool core::get_txpool_backlog(std::vector<tx_backlog_entry>& backlog, bool include_sensitive_txes) const
   {
-    m_mempool.get_transaction_backlog(backlog);
+    m_mempool.get_transaction_backlog(backlog, include_sensitive_txes);
     return true;
   }
   //-----------------------------------------------------------------------------------------------
@@ -1145,8 +1145,8 @@ namespace cryptonote
       return block_sync_size;
     if (get_current_blockchain_height() <= LAST_CHECKPOINT)
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
-    else 
-    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;    
+    else
+    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const
@@ -1168,18 +1168,18 @@ namespace cryptonote
       std::vector<transaction> txs;
       std::vector<crypto::hash> missed_txs;
       uint64_t coinbase_amount = get_outs_money_amount(b.miner_tx);
-      this->get_transactions(b.tx_hashes, txs, missed_txs);      
+      this->get_transactions(b.tx_hashes, txs, missed_txs);
       uint64_t tx_fee_amount = 0;
       for(const auto& tx: txs)
       {
         tx_fee_amount += get_tx_fee(tx);
       }
-      
+
       emission_amount += coinbase_amount - tx_fee_amount;
       total_fee_amount += tx_fee_amount;
       return true;
       });
-      
+
       // subtract burned coins
       if (start_offset <= config::EXCHANGE_FUND_RELEASE_HEIGHT && end >= config::EXCHANGE_FUND_RELEASE_HEIGHT)
         emission_amount -= config::EXCHANGE_BURNED_AMOUNT;
@@ -1535,9 +1535,9 @@ namespace cryptonote
     return m_blockchain_storage.get_db().get_block_cumulative_difficulty(height);
   }
   //-----------------------------------------------------------------------------------------------
-  size_t core::get_pool_transactions_count() const
+  size_t core::get_pool_transactions_count(bool include_sensitive_txes) const
   {
-    return m_mempool.get_transactions_count();
+    return m_mempool.get_transactions_count(include_sensitive_txes);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::have_block(const crypto::hash& id) const
@@ -1576,7 +1576,7 @@ namespace cryptonote
   bool core::get_pool_transaction(const crypto::hash &id, cryptonote::blobdata& tx, relay_category tx_category) const
   {
     return m_mempool.get_transaction(id, tx, tx_category);
-  }  
+  }
   //-----------------------------------------------------------------------------------------------
   bool core::pool_has_tx(const crypto::hash &id) const
   {
@@ -1667,13 +1667,13 @@ namespace cryptonote
     hours = minutes / 60;
     if((get_blockchain_storage().get_current_blockchain_height() >= m_target_blockchain_height) && (m_target_blockchain_height > 0))
     {
-     MGINFO_GREEN(ENDL << "Sumokoin node is on idle and fully synchronized | Height: " << get_blockchain_storage().get_current_blockchain_height() 
-       << " | Uptime: " << int(hours) << " hours " << int(minutes%60) << " minutes " 
+     MGINFO_GREEN(ENDL << "Sumokoin node is on idle and fully synchronized | Height: " << get_blockchain_storage().get_current_blockchain_height()
+       << " | Uptime: " << int(hours) << " hours " << int(minutes%60) << " minutes "
        << int(seconds%60) << " seconds" << ENDL);
     }
    return true;
   }
-  //----------------------------------------------------------------------------------------------- 
+  //-----------------------------------------------------------------------------------------------
   bool core::check_fork_time()
   {
     if (m_nettype == FAKECHAIN)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -190,7 +190,7 @@ namespace cryptonote
       * @note see Blockchain::cleanup_handle_incoming_blocks
       */
      bool cleanup_handle_incoming_blocks(bool force_sync = false);
-     	     	
+
      /**
       * @brief check the size of a block against the current maximum
       *
@@ -469,11 +469,12 @@ namespace cryptonote
 
      /**
       * @copydoc tx_memory_pool::get_txpool_backlog
+      * @param include_sensitive_txes include private transactions
       *
       * @note see tx_memory_pool::get_txpool_backlog
       */
-     bool get_txpool_backlog(std::vector<tx_backlog_entry>& backlog) const;
-     
+     bool get_txpool_backlog(std::vector<tx_backlog_entry>& backlog, bool include_sensitive_txes = false) const;
+
      /**
       * @copydoc tx_memory_pool::get_transactions
       * @param include_sensitive_txes include private transactions
@@ -514,10 +515,11 @@ namespace cryptonote
 
      /**
       * @copydoc tx_memory_pool::get_transactions_count
+      * @param include_sensitive_txes include private transactions
       *
       * @note see tx_memory_pool::get_transactions_count
       */
-     size_t get_pool_transactions_count() const;
+     size_t get_pool_transactions_count(bool include_sensitive_txes = false) const;
 
      /**
       * @copydoc Blockchain::get_total_transactions
@@ -756,12 +758,12 @@ namespace cryptonote
       * @return the number of blocks to sync in one go
       */
      std::pair<uint64_t, uint64_t> get_coinbase_tx_sum(const uint64_t start_offset, const size_t count);
-     
+
      /**
       * @brief get the network type we're on
       *
       * @return which network are we on?
-      */     
+      */
      network_type get_nettype() const { return m_nettype; };
 
      /**
@@ -1028,9 +1030,9 @@ namespace cryptonote
       * @return true on success, false otherwise
       */
      bool check_block_rate();
-     
+
      /**
-      * @brief checks sync status 
+      * @brief checks sync status
       *
       * @return true on synchronized, false otherwise
       */

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -189,7 +189,7 @@ namespace cryptonote
     // TODO: Investigate why not?
     if(!kept_by_block)
     {
-      if(have_tx_keyimges_as_spent(tx))
+      if(have_tx_keyimges_as_spent(tx, id))
       {
         mark_double_spend(tx);
         LOG_PRINT_L1("Transaction with id= "<< id << " used already spent key images");
@@ -232,7 +232,7 @@ namespace cryptonote
         meta.last_relayed_time = time(NULL);
         meta.relayed = relayed;
         meta.set_relay_method(tx_relay);
-        meta.double_spend_seen = have_tx_keyimges_as_spent(tx);
+        meta.double_spend_seen = have_tx_keyimges_as_spent(tx, id);
         meta.pruned = tx.pruned;
         meta.bf_padding = 0;
         memset(meta.padding, 0, sizeof(meta.padding));
@@ -1050,30 +1050,32 @@ namespace cryptonote
     return m_blockchain.get_db().txpool_has_tx(id, tx_category);
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::have_tx_keyimges_as_spent(const transaction& tx) const
+  bool tx_memory_pool::have_tx_keyimges_as_spent(const transaction& tx, const crypto::hash& txid) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, tokey_in, true);//should never fail
-      if(have_tx_keyimg_as_spent(tokey_in.k_image))
+      if(have_tx_keyimg_as_spent(tokey_in.k_image, txid))
          return true;
     }
     return false;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::have_tx_keyimg_as_spent(const crypto::key_image& key_im) const
+  bool tx_memory_pool::have_tx_keyimg_as_spent(const crypto::key_image& key_im, const crypto::hash& txid) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
-    bool spent = false;
     const auto found = m_spent_key_images.find(key_im);
-    if (found != m_spent_key_images.end())
+    if (found != m_spent_key_images.end() && !found->second.empty())
     {
-      for (const crypto::hash& tx_hash : found->second)
-        spent |= m_blockchain.txpool_tx_matches_category(tx_hash, relay_category::broadcasted);
+      // If another tx is using the key image, always return as spent.
+      // See `insert_key_images`.
+      if (1 < found->second.size() || *(found->second.cbegin()) != txid)
+        return true;
+      return m_blockchain.txpool_tx_matches_category(txid, relay_category::broadcasted);
     }
-    return spent;
+    return false;
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::lock() const

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -411,14 +411,14 @@ namespace cryptonote
       /*! if the transaction was returned to the pool from the blockchain
        *  due to a reorg, then this will be true
        */
-      bool kept_by_block;  
+      bool kept_by_block;
 
       //! the highest block the transaction referenced when last checking it failed
       /*! if verifying a transaction's inputs fails, it's possible this is due
        *  to a reorg since it was created (if it used recently created outputs
        *  as inputs).
        */
-      uint64_t last_failed_height;  
+      uint64_t last_failed_height;
 
       //! the hash of the highest block the transaction referenced when last checking it failed
       /*! if verifying a transaction's inputs fails, it's possible this is due
@@ -470,10 +470,11 @@ namespace cryptonote
      * @brief check if a transaction in the pool has a given spent key image
      *
      * @param key_im the spent key image to look for
+     * @param txid hash of the new transaction where `key_im` was seen.
      *
      * @return true if the spent key image is present, otherwise false
      */
-    bool have_tx_keyimg_as_spent(const crypto::key_image& key_im) const;
+    bool have_tx_keyimg_as_spent(const crypto::key_image& key_im, const crypto::hash& txid) const;
 
     /**
      * @brief check if any spent key image in a transaction is in the pool
@@ -484,10 +485,11 @@ namespace cryptonote
      * @note see tx_pool::have_tx_keyimg_as_spent
      *
      * @param tx the transaction to check spent key images of
+     * @param txid hash of `tx`.
      *
      * @return true if any spent key images are present in the pool, otherwise false
      */
-    bool have_tx_keyimges_as_spent(const transaction& tx) const;
+    bool have_tx_keyimges_as_spent(const transaction& tx, const crypto::hash& txid) const;
 
     /**
      * @brief forget a transaction's spent key images
@@ -567,7 +569,7 @@ private:
 #endif
 
     //! container for spent key images from the transactions in the pool
-    key_images_container m_spent_key_images;  
+    key_images_container m_spent_key_images;
 
     //TODO: this time should be a named constant somewhere, not hard-coded
     //! interval on which to check for stale/"stuck" transactions
@@ -639,6 +641,3 @@ namespace boost
 }
 BOOST_CLASS_VERSION(cryptonote::tx_memory_pool, CURRENT_MEMPOOL_ARCHIVE_VER)
 BOOST_CLASS_VERSION(cryptonote::tx_memory_pool::tx_details, CURRENT_MEMPOOL_TX_DETAILS_ARCHIVE_VER)
-
-
-

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -433,7 +433,7 @@ namespace cryptonote
     store_difficulty(m_core.get_blockchain_storage().get_difficulty_for_next_block(), res.difficulty, res.wide_difficulty, res.difficulty_top64);
     res.target = m_core.get_blockchain_storage().get_difficulty_target();
     res.tx_count = m_core.get_blockchain_storage().get_total_transactions() - res.height; //without coinbase
-    res.tx_pool_size = m_core.get_pool_transactions_count();
+    res.tx_pool_size = m_core.get_pool_transactions_count(!restricted);
     res.alt_blocks_count = restricted ? 0 : m_core.get_blockchain_storage().get_alternative_blocks_count();
     uint64_t total_conn = restricted ? 0 : m_p2p.get_public_connections_count();
     res.outgoing_connections_count = restricted ? 0 : m_p2p.get_public_outgoing_connections_count();
@@ -1297,6 +1297,8 @@ namespace cryptonote
     }
     res.sanity_check_failed = false;
 
+    const bool restricted = m_restricted && ctx;
+
     tx_verification_context tvc{};
     if(!m_core.handle_incoming_tx({tx_blob, crypto::null_hash}, tvc, (req.do_not_relay ? relay_method::none : relay_method::local), false) || tvc.m_verifivation_failed)
     {
@@ -1600,12 +1602,13 @@ namespace cryptonote
 
     const bool restricted = m_restricted && ctx;
     const bool request_has_rpc_origin = ctx != NULL;
+    const bool allow_sensitive = !request_has_rpc_origin || !restricted;
 
-    size_t n_txes = m_core.get_pool_transactions_count();
+    size_t n_txes = m_core.get_pool_transactions_count(allow_sensitive);
     if (n_txes > 0)
     {
       CHECK_PAYMENT_SAME_TS(req, res, n_txes * COST_PER_TX);
-      m_core.get_pool_transactions_and_spent_keys_info(res.transactions, res.spent_key_images, !request_has_rpc_origin || !restricted);
+      m_core.get_pool_transactions_and_spent_keys_info(res.transactions, res.spent_key_images, allow_sensitive);
       for (tx_info& txi : res.transactions)
         txi.tx_blob = epee::string_tools::buff_to_hex_nodelimer(txi.tx_blob);
     }
@@ -1625,12 +1628,13 @@ namespace cryptonote
 
     const bool restricted = m_restricted && ctx;
     const bool request_has_rpc_origin = ctx != NULL;
+    const bool allow_sensitive = !request_has_rpc_origin || !restricted;
 
-    size_t n_txes = m_core.get_pool_transactions_count();
+    size_t n_txes = m_core.get_pool_transactions_count(allow_sensitive);
     if (n_txes > 0)
     {
       CHECK_PAYMENT_SAME_TS(req, res, n_txes * COST_PER_POOL_HASH);
-      m_core.get_pool_transaction_hashes(res.tx_hashes, !request_has_rpc_origin || !restricted);
+      m_core.get_pool_transaction_hashes(res.tx_hashes, allow_sensitive);
     }
 
     res.status = CORE_RPC_STATUS_OK;
@@ -1648,13 +1652,14 @@ namespace cryptonote
 
     const bool restricted = m_restricted && ctx;
     const bool request_has_rpc_origin = ctx != NULL;
+    const bool allow_sensitive = !request_has_rpc_origin || !restricted;
 
-    size_t n_txes = m_core.get_pool_transactions_count();
+    size_t n_txes = m_core.get_pool_transactions_count(allow_sensitive);
     if (n_txes > 0)
     {
       CHECK_PAYMENT_SAME_TS(req, res, n_txes * COST_PER_POOL_HASH);
       std::vector<crypto::hash> tx_hashes;
-      m_core.get_pool_transaction_hashes(tx_hashes, !request_has_rpc_origin || !restricted);
+      m_core.get_pool_transaction_hashes(tx_hashes, allow_sensitive);
       res.tx_hashes.reserve(tx_hashes.size());
       for (const crypto::hash &tx_hash: tx_hashes)
         res.tx_hashes.push_back(epee::string_tools::pod_to_hex(tx_hash));

--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -34,18 +34,26 @@ try:
 except:
   tests = DEFAULT_TESTS
 
-N_MONERODS = 2
-N_WALLETS = 4
+N_sumokoinDS = 3
+N_WALLETS = 7
 WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 DIFFICULTY = 10
 
-monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--offline", "--no-igd", "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--log-level", "1"]
-monerod_extra = [
+sumokoind_base = [builddir + "/bin/sumokoind", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--offline", "--no-igd", "--p2p-bind-port", "sumokoind_p2p_port", "--rpc-bind-port", "sumokoind_rpc_port", "--zmq-rpc-bind-port", "sumokoind_zmq_port", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--log-level", "1"]
+sumokoind_extra = [
   [],
-  ["--rpc-payment-address", "44SKxxLQw929wRF6BA9paQ1EWFshNnKhXM3qz6Mo3JGDE2YG3xyzVutMStEicxbQGRfrYvAAYxH6Fe8rnD56EaNwUiqhcwR", "--rpc-payment-difficulty", str(DIFFICULTY), "--rpc-payment-credits", "5000", "--data-dir", builddir + "/functional-tests-directory/monerod1"],
+  ["--rpc-payment-address", "Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq", "--rpc-payment-difficulty", str(DIFFICULTY), "--rpc-payment-credits", "5000", "--data-dir", builddir + "/functional-tests-directory/sumokoind1"],
+  ["--rpc-restricted-bind-port", "18482", "--data-dir", builddir + "/functional-tests-directory/sumokoind2"]
 ]
-wallet_base = [builddir + "/bin/monero-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--disable-rpc-login", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--daemon-port", "18180", "--log-level", "1"]
+wallet_base = [builddir + "/bin/sumo-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--disable-rpc-login", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--log-level", "1"]
 wallet_extra = [
+  ["--daemon-port", "19733"],
+  ["--daemon-port", "19733"],
+  ["--daemon-port", "19733"],
+  ["--daemon-port", "19733"],
+  ["--daemon-port", "19735"],
+  ["--daemon-port", "19735"],
+  ["--daemon-port", "19735"]
 ]
 
 command_lines = []
@@ -53,12 +61,12 @@ processes = []
 outputs = []
 ports = []
 
-for i in range(N_MONERODS):
-  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else x for x in monerod_base])
-  if i < len(monerod_extra):
-    command_lines[-1] += monerod_extra[i]
-  outputs.append(open(builddir + '/tests/functional_tests/monerod' + str(i) + '.log', 'a+'))
-  ports.append(18180+i)
+for i in range(N_sumokoinDS):
+  command_lines.append([str(19733+i) if x == "sumokoind_rpc_port" else str(18280+i) if x == "sumokoind_p2p_port" else str(18380+i) if x == "sumokoind_zmq_port" else x for x in sumokoind_base])
+  if i < len(sumokoind_extra):
+    command_lines[-1] += sumokoind_extra[i]
+  outputs.append(open(builddir + '/tests/functional_tests/sumokoind' + str(i) + '.log', 'a+'))
+  ports.append(19733+i)
 
 for i in range(N_WALLETS):
   command_lines.append([str(18090+i) if x == "wallet_port" else x for x in wallet_base])

--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -34,8 +34,8 @@ try:
 except:
   tests = DEFAULT_TESTS
 
-N_sumokoinDS = 3
-N_WALLETS = 7
+N_sumokoinDS = 2
+N_WALLETS = 4
 WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 DIFFICULTY = 10
 
@@ -43,17 +43,9 @@ sumokoind_base = [builddir + "/bin/sumokoind", "--regtest", "--fixed-difficulty"
 sumokoind_extra = [
   [],
   ["--rpc-payment-address", "Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq", "--rpc-payment-difficulty", str(DIFFICULTY), "--rpc-payment-credits", "5000", "--data-dir", builddir + "/functional-tests-directory/sumokoind1"],
-  ["--rpc-restricted-bind-port", "18482", "--data-dir", builddir + "/functional-tests-directory/sumokoind2"]
 ]
-wallet_base = [builddir + "/bin/sumo-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--disable-rpc-login", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--log-level", "1"]
+wallet_base = [builddir + "/bin/sumo-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--disable-rpc-login", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--daemon-port", "19733", "--log-level", "1"]
 wallet_extra = [
-  ["--daemon-port", "19733"],
-  ["--daemon-port", "19733"],
-  ["--daemon-port", "19733"],
-  ["--daemon-port", "19733"],
-  ["--daemon-port", "19735"],
-  ["--daemon-port", "19735"],
-  ["--daemon-port", "19735"]
 ]
 
 command_lines = []

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2019 The Monero Project
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-# 
+#
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -55,7 +55,7 @@ class TransferTest():
 
     def reset(self):
         print('Resetting blockchain')
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
         res = daemon.get_height()
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
@@ -63,13 +63,13 @@ class TransferTest():
     def create(self):
         print('Creating wallets')
         seeds = [
-          'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted',
-          'peeled mixture ionic radar utopia puddle buying illness nuns gadget river spout cavernous bounced paradise drunk looking cottage jump tequila melting went winter adjust spout',
-          'dilute gutter certain antics pamphlet macro enjoy left slid guarded bogeys upload nineteen bomb jubilee enhanced irritate turnip eggs swung jukebox loudly reduce sedan slid',
+          'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification',
+          'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification',
+          'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification',
         ]
         self.wallet = [None] * len(seeds)
         for i in range(len(seeds)):
-            self.wallet[i] = Wallet(idx = i)
+            self.wallet[i] = Wallet(idx = i + 4)
             # close the wallet if any, will throw if none is loaded
             try: self.wallet[i].close_wallet()
             except: pass
@@ -77,23 +77,23 @@ class TransferTest():
 
     def mine(self):
         print("Mining some blocks")
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         res = daemon.get_info()
         height = res.height
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 80)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 80)
         for i in range(len(self.wallet)):
             self.wallet[i].refresh()
             res = self.wallet[i].get_height()
             assert res.height == height + 80
 
     def transfer(self):
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         print("Creating transfer to self")
 
-        dst = {'address': '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 'amount': 1000000000000}
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         payment_id = '1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde'
 
         start_balances = [0] * len(self.wallet)
@@ -126,8 +126,7 @@ class TransferTest():
         except: ok = True
         assert ok
 
-        res = self.wallet[0].transfer([dst], ring_size = 11, payment_id = payment_id, get_tx_key = False, get_tx_hex = True)
-
+        res = self.wallet[0].transfer([dst], ring_size = 11, get_tx_key = False, get_tx_hex = True)
         assert len(res.tx_hash) == 32*2
         txid = res.tx_hash
         assert len(res.tx_key) == 0
@@ -168,7 +167,7 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert not 'confirmations' in e or e.confirmations == 0
 
@@ -179,7 +178,7 @@ class TransferTest():
         assert res.unlocked_balance <= res.balance
         assert res.blocks_to_unlock == 59
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.getlastblockheader()
         running_balances[0] += res.block_header.reward
         self.wallet[0].refresh()
@@ -201,7 +200,7 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert e.confirmations == 1
 
@@ -219,10 +218,10 @@ class TransferTest():
         assert t.fee == fee
         assert t.note == ''
         assert len(t.destinations) == 1
-        assert t.destinations[0] == {'address': '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 'amount': 1000000000000}
+        assert t.destinations[0] == {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         assert t.type == 'out'
         assert t.unlock_time == 0
-        assert t.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert t.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert t.double_spend_seen == False
         assert t.confirmations == 1
 
@@ -233,7 +232,7 @@ class TransferTest():
 
         print("Creating transfer to another, manual relay")
 
-        dst = {'address': '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', 'amount': 1000000000000}
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         res = self.wallet[0].transfer([dst], ring_size = 11, get_tx_key = True, do_not_relay = True, get_tx_hex = True)
         assert len(res.tx_hash) == 32*2
         txid = res.tx_hash
@@ -280,13 +279,13 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert not 'confirmations' in e or e.confirmations == 0
         assert e.amount == amount
         assert e.fee == fee
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.getlastblockheader()
         running_balances[0] -= 1000000000000 + fee
         running_balances[0] += res.block_header.reward
@@ -306,7 +305,7 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert e.confirmations == 1
         assert e.amount == amount
@@ -321,9 +320,9 @@ class TransferTest():
 
         self.wallet[0].refresh()
 
-        dst0 = {'address': '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 'amount': 1000000000000}
-        dst1 = {'address': '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', 'amount': 1100000000000}
-        dst2 = {'address': '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', 'amount': 1200000000000}
+        dst0 = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        dst1 = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1100000000000}
+        dst2 = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1200000000000}
         res = self.wallet[0].transfer([dst0, dst1, dst2], ring_size = 11, get_tx_key = True)
         assert len(res.tx_hash) == 32*2
         txid = res.tx_hash
@@ -345,7 +344,7 @@ class TransferTest():
         assert res.unlocked_balance <= res.balance
         assert res.blocks_to_unlock == 59
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.getlastblockheader()
         running_balances[0] += res.block_header.reward
         running_balances[0] += 1000000000000
@@ -368,7 +367,7 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert e.confirmations == 1
 
@@ -396,7 +395,7 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert e.confirmations == 1
         assert e.amount == 1100000000000
@@ -423,7 +422,7 @@ class TransferTest():
         assert e.unlock_time == 0
         assert e.subaddr_index.major == 0
         assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
-        assert e.address == '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK'
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
         assert e.double_spend_seen == False
         assert e.confirmations == 1
         assert e.amount == 1200000000000
@@ -438,7 +437,7 @@ class TransferTest():
         self.wallet[0].refresh()
         res = self.wallet[0].get_balance()
         i_pid = '1111111122222222'
-        res = self.wallet[0].make_integrated_address(standard_address = '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', payment_id = i_pid)
+        res = self.wallet[0].make_integrated_address(standard_address = 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', payment_id = i_pid)
         i_address = res.integrated_address
         res = self.wallet[0].transfer([{'address': i_address, 'amount': 200000000}])
         assert len(res.tx_hash) == 32*2
@@ -460,7 +459,7 @@ class TransferTest():
         assert res.unlocked_balance <= res.balance
         assert res.blocks_to_unlock == 59
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.getlastblockheader()
         running_balances[0] += res.block_header.reward
         running_balances[1] += 200000000
@@ -483,7 +482,7 @@ class TransferTest():
         assert res.unlocked_balance <= res.balance
         assert res.blocks_to_unlock == 8
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.getlastblockheader()
         running_balances[0] += res.block_header.reward
 
@@ -509,7 +508,7 @@ class TransferTest():
     def check_get_bulk_payments(self):
         print('Checking get_bulk_payments')
 
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
         res = daemon.get_info()
         height = res.height
 
@@ -545,7 +544,7 @@ class TransferTest():
     def check_get_payments(self):
         print('Checking get_payments')
 
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
         res = daemon.get_info()
         height = res.height
 
@@ -568,11 +567,11 @@ class TransferTest():
         print('Checking double spend detection')
         txes = [[None, None], [None, None]]
         for i in range(2):
-            self.wallet[0].restore_deterministic_wallet(seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted')
+            self.wallet[0].restore_deterministic_wallet(seed = 'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification')
             self.wallet[0].refresh()
             res = self.wallet[0].get_balance()
             unlocked_balance = res.unlocked_balance
-            res = self.wallet[0].sweep_all(address = '44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', do_not_relay = True, get_tx_hex = True)
+            res = self.wallet[0].sweep_all(address = 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', do_not_relay = True, get_tx_hex = True)
             assert len(res.tx_hash_list) == 1
             assert len(res.tx_hash_list[0]) == 32*2
             txes[i][0] = res.tx_hash_list[0]
@@ -588,7 +587,8 @@ class TransferTest():
             assert len(res.tx_blob_list) == 1
             txes[i][1] = res.tx_blob_list[0]
 
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
+        restricted_daemon = Daemon(idx = 2, restricted_rpc = True)
         res = daemon.send_raw_transaction(txes[0][1])
         assert res.not_relayed == False
         assert res.low_mixin == False
@@ -599,6 +599,18 @@ class TransferTest():
         assert res.overspend == False
         assert res.fee_too_low == False
 
+        res = restricted_daemon.send_raw_transaction(txes[0][1])
+        assert res.not_relayed == False
+        assert res.low_mixin == False
+        assert res.double_spend == False
+        assert res.invalid_input == False
+        assert res.invalid_output == False
+        assert res.too_big == False
+        assert res.overspend == False
+        assert res.fee_too_low == False
+
+        res = restricted_daemon.get_transactions([txes[0][0]])
+        assert not 'txs' in res or len(res.txs) == 0
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
         tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
@@ -616,6 +628,19 @@ class TransferTest():
         assert res.fee_too_low == False
         assert res.too_few_outputs == False
 
+        res = restricted_daemon.send_raw_transaction(txes[1][1])
+        assert res.not_relayed == False
+        assert res.low_mixin == False
+        assert res.double_spend == True
+        assert res.invalid_input == False
+        assert res.invalid_output == False
+        assert res.too_big == False
+        assert res.overspend == False
+        assert res.fee_too_low == False
+        assert res.too_few_outputs == False
+
+        res = restricted_daemon.get_transactions([txes[0][0]])
+        assert not 'txs' in res or len(res.txs) == 0
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
         tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
@@ -624,17 +649,17 @@ class TransferTest():
 
     def sweep_dust(self):
         print("Sweeping dust")
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
         self.wallet[0].refresh()
         res = self.wallet[0].sweep_dust()
         assert not 'tx_hash_list' in res or len(res.tx_hash_list) == 0 # there's just one, but it cannot meet the fee
 
     def sweep_single(self):
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         print("Sending single output")
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         self.wallet[0].refresh()
         res = self.wallet[0].incoming_transfers(transfer_type = 'available')
         for t in res.transfers:
@@ -645,20 +670,20 @@ class TransferTest():
         assert res.transfers[index].amount > 0
         ki = res.transfers[index].key_image
         amount = res.transfers[index].amount
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 10) # ensure unlocked
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 10) # ensure unlocked
         self.wallet[0].refresh()
         res = self.wallet[0].get_balance()
         balance = res.balance
         res = daemon.is_key_image_spent([ki])
         assert len(res.spent_status) == 1
         assert res.spent_status[0] == 0
-        res = self.wallet[0].sweep_single('44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', key_image = ki)
+        res = self.wallet[0].sweep_single('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', key_image = ki)
         assert len(res.tx_hash) == 64
         tx_hash = res.tx_hash
         res = daemon.is_key_image_spent([ki])
         assert len(res.spent_status) == 1
         assert res.spent_status[0] == 2
-        daemon.generateblocks('44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.is_key_image_spent([ki])
         assert len(res.spent_status) == 1
         assert res.spent_status[0] == 1
@@ -686,11 +711,11 @@ class TransferTest():
         assert len([t for t in res.transfers if t.key_image == ki]) == 1
 
     def check_destinations(self):
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         print("Checking transaction destinations")
 
-        dst = {'address': '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 'amount': 1000000000000}
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         res = self.wallet[0].transfer([dst])
         assert len(res.tx_hash) == 64
         tx_hash = res.tx_hash
@@ -701,10 +726,10 @@ class TransferTest():
             e = l[0]
             assert len(e.destinations) == 1
             assert e.destinations[0].amount == 1000000000000
-            assert e.destinations[0].address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+            assert e.destinations[0].address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
 
             if i == 0:
-                daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+                daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
                 self.wallet[0].refresh()
 
         dst = {'address': '8AsN91rznfkBGTY8psSNkJBg9SZgxxGGRUhGwRptBhgr5XSQ1XzmA9m8QAnoxydecSh5aLJXdrgXwTDMMZ1AuXsN1EX5Mtm', 'amount': 1000000000000}
@@ -721,7 +746,7 @@ class TransferTest():
             assert e.destinations[0].address == '8AsN91rznfkBGTY8psSNkJBg9SZgxxGGRUhGwRptBhgr5XSQ1XzmA9m8QAnoxydecSh5aLJXdrgXwTDMMZ1AuXsN1EX5Mtm'
 
             if i == 0:
-                daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+                daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
                 self.wallet[0].refresh()
 
         dst = {'address': '4BxSHvcgTwu25WooY4BVmgdcKwZu5EksVZSZkDd6ooxSVVqQ4ubxXkhLF6hEqtw96i9cf3cVfLw8UWe95bdDKfRQeYtPwLm1Jiw7AKt2LY', 'amount': 1000000000000}
@@ -738,11 +763,11 @@ class TransferTest():
             assert e.destinations[0].address == '4BxSHvcgTwu25WooY4BVmgdcKwZu5EksVZSZkDd6ooxSVVqQ4ubxXkhLF6hEqtw96i9cf3cVfLw8UWe95bdDKfRQeYtPwLm1Jiw7AKt2LY'
 
             if i == 0:
-                daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+                daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
                 self.wallet[0].refresh()
 
     def check_tx_notes(self):
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         print('Testing tx notes')
         res = self.wallet[0].get_transfers()
@@ -759,7 +784,7 @@ class TransferTest():
         assert res.notes == ['out txid', 'in txid']
 
     def check_rescan(self):
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         print('Testing rescan_spent')
         res = self.wallet[0].incoming_transfers(transfer_type = 'all')
@@ -799,7 +824,7 @@ class TransferTest():
             assert sorted(old_t_out, key = lambda k: k['txid']) == sorted(new_t_out, key = lambda k: k['txid'])
 
     def check_is_key_image_spent(self):
-        daemon = Daemon()
+        daemon = Daemon(idx = 2)
 
         print('Testing is_key_image_spent')
         res = self.wallet[0].incoming_transfers(transfer_type = 'all')

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2019 The Monero Project
-#
+# 
 # All rights reserved.
-#
+# 
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-#
+# 
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-#
+# 
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-#
+# 
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-#
+# 
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -55,7 +55,7 @@ class TransferTest():
 
     def reset(self):
         print('Resetting blockchain')
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         res = daemon.get_height()
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
@@ -69,7 +69,7 @@ class TransferTest():
         ]
         self.wallet = [None] * len(seeds)
         for i in range(len(seeds)):
-            self.wallet[i] = Wallet(idx = i + 4)
+            self.wallet[i] = Wallet(idx = i)
             # close the wallet if any, will throw if none is loaded
             try: self.wallet[i].close_wallet()
             except: pass
@@ -77,7 +77,7 @@ class TransferTest():
 
     def mine(self):
         print("Mining some blocks")
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         res = daemon.get_info()
         height = res.height
@@ -89,7 +89,7 @@ class TransferTest():
             assert res.height == height + 80
 
     def transfer(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print("Creating transfer to self")
 
@@ -221,7 +221,7 @@ class TransferTest():
         assert t.destinations[0] == {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         assert t.type == 'out'
         assert t.unlock_time == 0
-        assert t.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert t.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
         assert t.double_spend_seen == False
         assert t.confirmations == 1
 
@@ -508,7 +508,7 @@ class TransferTest():
     def check_get_bulk_payments(self):
         print('Checking get_bulk_payments')
 
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         res = daemon.get_info()
         height = res.height
 
@@ -544,7 +544,7 @@ class TransferTest():
     def check_get_payments(self):
         print('Checking get_payments')
 
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         res = daemon.get_info()
         height = res.height
 
@@ -587,8 +587,7 @@ class TransferTest():
             assert len(res.tx_blob_list) == 1
             txes[i][1] = res.tx_blob_list[0]
 
-        daemon = Daemon(idx = 2)
-        restricted_daemon = Daemon(idx = 2, restricted_rpc = True)
+        daemon = Daemon()
         res = daemon.send_raw_transaction(txes[0][1])
         assert res.not_relayed == False
         assert res.low_mixin == False
@@ -599,18 +598,6 @@ class TransferTest():
         assert res.overspend == False
         assert res.fee_too_low == False
 
-        res = restricted_daemon.send_raw_transaction(txes[0][1])
-        assert res.not_relayed == False
-        assert res.low_mixin == False
-        assert res.double_spend == False
-        assert res.invalid_input == False
-        assert res.invalid_output == False
-        assert res.too_big == False
-        assert res.overspend == False
-        assert res.fee_too_low == False
-
-        res = restricted_daemon.get_transactions([txes[0][0]])
-        assert not 'txs' in res or len(res.txs) == 0
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
         tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
@@ -628,19 +615,6 @@ class TransferTest():
         assert res.fee_too_low == False
         assert res.too_few_outputs == False
 
-        res = restricted_daemon.send_raw_transaction(txes[1][1])
-        assert res.not_relayed == False
-        assert res.low_mixin == False
-        assert res.double_spend == True
-        assert res.invalid_input == False
-        assert res.invalid_output == False
-        assert res.too_big == False
-        assert res.overspend == False
-        assert res.fee_too_low == False
-        assert res.too_few_outputs == False
-
-        res = restricted_daemon.get_transactions([txes[0][0]])
-        assert not 'txs' in res or len(res.txs) == 0
         res = daemon.get_transactions([txes[0][0]])
         assert len(res.txs) >= 1
         tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
@@ -649,13 +623,13 @@ class TransferTest():
 
     def sweep_dust(self):
         print("Sweeping dust")
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
         self.wallet[0].refresh()
         res = self.wallet[0].sweep_dust()
         assert not 'tx_hash_list' in res or len(res.tx_hash_list) == 0 # there's just one, but it cannot meet the fee
 
     def sweep_single(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print("Sending single output")
 
@@ -711,7 +685,7 @@ class TransferTest():
         assert len([t for t in res.transfers if t.key_image == ki]) == 1
 
     def check_destinations(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print("Checking transaction destinations")
 
@@ -732,7 +706,7 @@ class TransferTest():
                 daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
                 self.wallet[0].refresh()
 
-        dst = {'address': '8AsN91rznfkBGTY8psSNkJBg9SZgxxGGRUhGwRptBhgr5XSQ1XzmA9m8QAnoxydecSh5aLJXdrgXwTDMMZ1AuXsN1EX5Mtm', 'amount': 1000000000000}
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         res = self.wallet[0].transfer([dst])
         assert len(res.tx_hash) == 64
         tx_hash = res.tx_hash
@@ -743,13 +717,13 @@ class TransferTest():
             e = l[0]
             assert len(e.destinations) == 1
             assert e.destinations[0].amount == 1000000000000
-            assert e.destinations[0].address == '8AsN91rznfkBGTY8psSNkJBg9SZgxxGGRUhGwRptBhgr5XSQ1XzmA9m8QAnoxydecSh5aLJXdrgXwTDMMZ1AuXsN1EX5Mtm'
+            assert e.destinations[0].address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
 
             if i == 0:
                 daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
                 self.wallet[0].refresh()
 
-        dst = {'address': '4BxSHvcgTwu25WooY4BVmgdcKwZu5EksVZSZkDd6ooxSVVqQ4ubxXkhLF6hEqtw96i9cf3cVfLw8UWe95bdDKfRQeYtPwLm1Jiw7AKt2LY', 'amount': 1000000000000}
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
         res = self.wallet[0].transfer([dst])
         assert len(res.tx_hash) == 64
         tx_hash = res.tx_hash
@@ -760,14 +734,14 @@ class TransferTest():
             e = l[0]
             assert len(e.destinations) == 1
             assert e.destinations[0].amount == 1000000000000
-            assert e.destinations[0].address == '4BxSHvcgTwu25WooY4BVmgdcKwZu5EksVZSZkDd6ooxSVVqQ4ubxXkhLF6hEqtw96i9cf3cVfLw8UWe95bdDKfRQeYtPwLm1Jiw7AKt2LY'
+            assert e.destinations[0].address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
 
             if i == 0:
                 daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
                 self.wallet[0].refresh()
 
     def check_tx_notes(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print('Testing tx notes')
         res = self.wallet[0].get_transfers()
@@ -784,7 +758,7 @@ class TransferTest():
         assert res.notes == ['out txid', 'in txid']
 
     def check_rescan(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print('Testing rescan_spent')
         res = self.wallet[0].incoming_transfers(transfer_type = 'all')
@@ -824,7 +798,7 @@ class TransferTest():
             assert sorted(old_t_out, key = lambda k: k['txid']) == sorted(new_t_out, key = lambda k: k['txid'])
 
     def check_is_key_image_spent(self):
-        daemon = Daemon(idx = 2)
+        daemon = Daemon()
 
         print('Testing is_key_image_spent')
         res = self.wallet[0].incoming_transfers(transfer_type = 'all')

--- a/tests/functional_tests/txpool.py
+++ b/tests/functional_tests/txpool.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2019 The Monero Project
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-# 
+#
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -45,33 +45,33 @@ class TransferTest():
 
     def reset(self):
         print('Resetting blockchain')
-        daemon = Daemon()
+        daemon = Daemon(idx=2)
         res = daemon.get_height()
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
 
     def create(self):
         print('Creating wallet')
-        wallet = Wallet()
+        wallet = Wallet(idx = 4)
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
         except: pass
-        seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
+        seed = 'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification'
         res = wallet.restore_deterministic_wallet(seed = seed)
 
     def mine(self):
         print("Mining some blocks")
-        daemon = Daemon()
-        wallet = Wallet()
+        daemon = Daemon(idx = 2)
+        wallet = Wallet(idx = 4)
 
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 80)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 80)
         wallet.refresh()
 
     def create_txes(self, address, ntxes):
         print('Creating ' + str(ntxes) + ' transactions')
 
-        daemon = Daemon()
-        wallet = Wallet()
+        daemon = Daemon(idx = 2)
+        wallet = Wallet(idx = 4)
 
         dst = {'address': address, 'amount': 1000000000000}
 
@@ -83,8 +83,10 @@ class TransferTest():
         return txes
 
     def check_empty_pool(self):
-        daemon = Daemon()
+        self.check_empty_rpc_pool(Daemon(idx = 2))
+        self.check_empty_rpc_pool(Daemon(idx = 2, restricted_rpc = True))
 
+    def check_empty_rpc_pool(self, daemon):
         res = daemon.get_transaction_pool_hashes()
         assert not 'tx_hashes' in res or len(res.tx_hashes) == 0
         res = daemon.get_transaction_pool_stats()
@@ -103,8 +105,9 @@ class TransferTest():
         assert res.pool_stats.num_double_spends == 0
 
     def check_txpool(self):
-        daemon = Daemon()
-        wallet = Wallet()
+        daemon = Daemon(idx = 2)
+        restricted_daemon = Daemon(idx = 2, restricted_rpc = True)
+        wallet = Wallet(idx = 4)
 
         res = daemon.get_info()
         height = res.height
@@ -117,6 +120,7 @@ class TransferTest():
         res = daemon.get_info()
         assert res.tx_pool_size == txpool_size + 5
         txpool_size = res.tx_pool_size
+        self.check_empty_rpc_pool(restricted_daemon)
 
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size
@@ -160,6 +164,7 @@ class TransferTest():
         print('Flushing 2 transactions')
         txes_keys = list(txes.keys())
         daemon.flush_txpool([txes_keys[1], txes_keys[3]])
+        self.check_empty_rpc_pool(restricted_daemon)
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size - 2
         assert len([x for x in res.transactions if x.id_hash == txes_keys[1]]) == 0
@@ -210,11 +215,12 @@ class TransferTest():
         print('Flushing unknown transactions')
         unknown_txids = ['1'*64, '2'*64, '3'*64]
         daemon.flush_txpool(unknown_txids)
+        self.check_empty_rpc_pool(restricted_daemon)
         res = daemon.get_transaction_pool()
         assert len(res.transactions) == txpool_size - 2
 
         print('Mining transactions')
-        daemon.generateblocks('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 1)
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
         res = daemon.get_transaction_pool()
         assert not 'transactions' in res or len(res.transactions) == txpool_size - 5
         res = daemon.get_transaction_pool_hashes()

--- a/tests/functional_tests/txpool.py
+++ b/tests/functional_tests/txpool.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2019 The Monero Project
-#
+# 
 # All rights reserved.
-#
+# 
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-#
+# 
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-#
+# 
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-#
+# 
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-#
+# 
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -29,8 +29,9 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
+import json
 
-"""Test txpool
+"""Test simple transfers
 """
 
 from framework.daemon import Daemon
@@ -41,214 +42,795 @@ class TransferTest():
         self.reset()
         self.create()
         self.mine()
-        self.check_txpool()
+        self.transfer()
+        self.check_get_bulk_payments()
+        self.check_get_payments()
+        self.check_double_spend_detection()
+        self.sweep_dust()
+        self.sweep_single()
+        self.check_destinations()
+        self.check_tx_notes()
+        self.check_rescan()
+        self.check_is_key_image_spent()
 
     def reset(self):
         print('Resetting blockchain')
-        daemon = Daemon(idx=2)
+        daemon = Daemon()
         res = daemon.get_height()
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
 
     def create(self):
-        print('Creating wallet')
-        wallet = Wallet(idx = 4)
-        # close the wallet if any, will throw if none is loaded
-        try: wallet.close_wallet()
-        except: pass
-        seed = 'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification'
-        res = wallet.restore_deterministic_wallet(seed = seed)
+        print('Creating wallets')
+        seeds = [
+          'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification',
+          'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification',
+          'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification',
+        ]
+        self.wallet = [None] * len(seeds)
+        for i in range(len(seeds)):
+            self.wallet[i] = Wallet(idx = i)
+            # close the wallet if any, will throw if none is loaded
+            try: self.wallet[i].close_wallet()
+            except: pass
+            res = self.wallet[i].restore_deterministic_wallet(seed = seeds[i])
 
     def mine(self):
         print("Mining some blocks")
-        daemon = Daemon(idx = 2)
-        wallet = Wallet(idx = 4)
-
-        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 80)
-        wallet.refresh()
-
-    def create_txes(self, address, ntxes):
-        print('Creating ' + str(ntxes) + ' transactions')
-
-        daemon = Daemon(idx = 2)
-        wallet = Wallet(idx = 4)
-
-        dst = {'address': address, 'amount': 1000000000000}
-
-        txes = {}
-        for i in range(ntxes):
-          res = wallet.transfer([dst], get_tx_hex = True)
-          txes[res.tx_hash] = res
-
-        return txes
-
-    def check_empty_pool(self):
-        self.check_empty_rpc_pool(Daemon(idx = 2))
-        self.check_empty_rpc_pool(Daemon(idx = 2, restricted_rpc = True))
-
-    def check_empty_rpc_pool(self, daemon):
-        res = daemon.get_transaction_pool_hashes()
-        assert not 'tx_hashes' in res or len(res.tx_hashes) == 0
-        res = daemon.get_transaction_pool_stats()
-        assert res.pool_stats.bytes_total == 0
-        assert res.pool_stats.bytes_min == 0
-        assert res.pool_stats.bytes_max == 0
-        assert res.pool_stats.bytes_med == 0
-        assert res.pool_stats.fee_total == 0
-        assert res.pool_stats.oldest == 0
-        assert res.pool_stats.txs_total == 0
-        assert res.pool_stats.num_failing == 0
-        assert res.pool_stats.num_10m == 0
-        assert res.pool_stats.num_not_relayed == 0
-        assert res.pool_stats.histo_98pc == 0
-        assert not 'histo' in res.pool_stats or len(res.pool_stats.histo) == 0
-        assert res.pool_stats.num_double_spends == 0
-
-    def check_txpool(self):
-        daemon = Daemon(idx = 2)
-        restricted_daemon = Daemon(idx = 2, restricted_rpc = True)
-        wallet = Wallet(idx = 4)
+        daemon = Daemon()
 
         res = daemon.get_info()
         height = res.height
-        txpool_size = res.tx_pool_size
 
-        self.check_empty_pool()
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 80)
+        for i in range(len(self.wallet)):
+            self.wallet[i].refresh()
+            res = self.wallet[i].get_height()
+            assert res.height == height + 80
 
-        txes = self.create_txes('46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', 5)
+    def transfer(self):
+        daemon = Daemon()
+
+        print("Creating transfer to self")
+
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        payment_id = '1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde'
+
+        start_balances = [0] * len(self.wallet)
+        running_balances = [0] * len(self.wallet)
+        for i in range(len(self.wallet)):
+          res = self.wallet[i].get_balance()
+          start_balances[i] = res.balance
+          running_balances[i] = res.balance
+          assert res.unlocked_balance <= res.balance
+          if i == 0:
+            assert res.blocks_to_unlock == 59 # we've been mining to it
+          else:
+            assert res.blocks_to_unlock == 0
+
+        print ('Checking short payment IDs cannot be used when not in an integrated address')
+        ok = False
+        try: self.wallet[0].transfer([dst], ring_size = 11, payment_id = '1234567812345678', get_tx_key = False)
+        except: ok = True
+        assert ok
+
+        print ('Checking long payment IDs are rejected')
+        ok = False
+        try: self.wallet[0].transfer([dst], ring_size = 11, payment_id = payment_id, get_tx_key = False, get_tx_hex = True)
+        except: ok = True
+        assert ok
+
+        print ('Checking empty destination is rejected')
+        ok = False
+        try: self.wallet[0].transfer([], ring_size = 11, get_tx_key = False)
+        except: ok = True
+        assert ok
+
+        res = self.wallet[0].transfer([dst], ring_size = 11, get_tx_key = False, get_tx_hex = True)
+        assert len(res.tx_hash) == 32*2
+        txid = res.tx_hash
+        assert len(res.tx_key) == 0
+        assert res.amount > 0
+        amount = res.amount
+        assert res.fee > 0
+        fee = res.fee
+        assert len(res.tx_blob) > 0
+        blob_size = len(res.tx_blob) // 2
+        assert len(res.tx_metadata) == 0
+        assert len(res.multisig_txset) == 0
+        assert len(res.unsigned_txset) == 0
+        unsigned_txset = res.unsigned_txset
+
+        res = daemon.get_fee_estimate(10)
+        assert res.fee > 0
+        assert res.quantization_mask > 0
+        expected_fee = (res.fee * 1 * blob_size + res.quantization_mask - 1) // res.quantization_mask * res.quantization_mask
+        assert abs(1 - fee / expected_fee) < 0.01
+
+        self.wallet[0].refresh()
 
         res = daemon.get_info()
-        assert res.tx_pool_size == txpool_size + 5
-        txpool_size = res.tx_pool_size
-        self.check_empty_rpc_pool(restricted_daemon)
+        height = res.height
 
-        res = daemon.get_transaction_pool()
-        assert len(res.transactions) == txpool_size
-        total_bytes = 0
-        total_fee = 0
-        min_bytes = 99999999999999
-        max_bytes = 0
-        for txid in txes.keys():
-            x = [x for x in res.transactions if x.id_hash == txid]
-            assert len(x) == 1
-            x = x[0]
-            assert x.kept_by_block == False
-            assert x.last_failed_id_hash == '0'*64
-            assert x.double_spend_seen == False
-            assert x.weight >= x.blob_size
+        res = self.wallet[0].get_transfers()
+        assert len(res['in']) == height - 1 # coinbases
+        assert not 'out' in res or len(res.out) == 0 # not mined yet
+        assert len(res.pending) == 1
+        assert not 'pool' in res or len(res.pool) == 0
+        assert not 'failed' in res or len(res.failed) == 0
+        for e in res['in']:
+          assert e.type == 'block'
+        e = res.pending[0]
+        assert e.txid == txid
+        assert e.payment_id in ['', '0000000000000000']
+        assert e.type == 'pending'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert not 'confirmations' in e or e.confirmations == 0
 
-            assert x.blob_size * 2 == len(txes[txid].tx_blob)
-            assert x.fee == txes[txid].fee
-            assert x.tx_blob == txes[txid].tx_blob
+        running_balances[0] -= 1000000000000 + fee
 
-            total_bytes += x.blob_size
-            total_fee += x.fee
-            min_bytes = min(min_bytes, x.blob_size)
-            max_bytes = max(max_bytes, x.blob_size)
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
 
-        res = daemon.get_transaction_pool_hashes()
-        assert sorted(res.tx_hashes) == sorted(txes.keys())
-
-        res = daemon.get_transaction_pool_stats()
-        assert res.pool_stats.bytes_total == total_bytes
-        assert res.pool_stats.bytes_min == min_bytes
-        assert res.pool_stats.bytes_max == max_bytes
-        assert res.pool_stats.bytes_med >= min_bytes and res.pool_stats.bytes_med <= max_bytes
-        assert res.pool_stats.fee_total == total_fee
-        assert res.pool_stats.txs_total == len(txes)
-        assert res.pool_stats.num_failing == 0
-        assert res.pool_stats.num_10m == 0
-        assert res.pool_stats.num_not_relayed == 0
-        assert res.pool_stats.num_double_spends == 0
-
-        print('Flushing 2 transactions')
-        txes_keys = list(txes.keys())
-        daemon.flush_txpool([txes_keys[1], txes_keys[3]])
-        self.check_empty_rpc_pool(restricted_daemon)
-        res = daemon.get_transaction_pool()
-        assert len(res.transactions) == txpool_size - 2
-        assert len([x for x in res.transactions if x.id_hash == txes_keys[1]]) == 0
-        assert len([x for x in res.transactions if x.id_hash == txes_keys[3]]) == 0
-
-        new_keys = list(txes.keys())
-        new_keys.remove(txes_keys[1])
-        new_keys.remove(txes_keys[3])
-        res = daemon.get_transaction_pool_hashes()
-        assert sorted(res.tx_hashes) == sorted(new_keys)
-
-        res = daemon.get_transaction_pool()
-        assert len(res.transactions) == len(new_keys)
-        total_bytes = 0
-        total_fee = 0
-        min_bytes = 99999999999999
-        max_bytes = 0
-        for txid in new_keys:
-            x = [x for x in res.transactions if x.id_hash == txid]
-            assert len(x) == 1
-            x = x[0]
-            assert x.kept_by_block == False
-            assert x.last_failed_id_hash == '0'*64
-            assert x.double_spend_seen == False
-            assert x.weight >= x.blob_size
-
-            assert x.blob_size * 2 == len(txes[txid].tx_blob)
-            assert x.fee == txes[txid].fee
-            assert x.tx_blob == txes[txid].tx_blob
-
-            total_bytes += x.blob_size
-            total_fee += x.fee
-            min_bytes = min(min_bytes, x.blob_size)
-            max_bytes = max(max_bytes, x.blob_size)
-
-        res = daemon.get_transaction_pool_stats()
-        assert res.pool_stats.bytes_total == total_bytes
-        assert res.pool_stats.bytes_min == min_bytes
-        assert res.pool_stats.bytes_max == max_bytes
-        assert res.pool_stats.bytes_med >= min_bytes and res.pool_stats.bytes_med <= max_bytes
-        assert res.pool_stats.fee_total == total_fee
-        assert res.pool_stats.txs_total == len(new_keys)
-        assert res.pool_stats.num_failing == 0
-        assert res.pool_stats.num_10m == 0
-        assert res.pool_stats.num_not_relayed == 0
-        assert res.pool_stats.num_double_spends == 0
-
-        print('Flushing unknown transactions')
-        unknown_txids = ['1'*64, '2'*64, '3'*64]
-        daemon.flush_txpool(unknown_txids)
-        self.check_empty_rpc_pool(restricted_daemon)
-        res = daemon.get_transaction_pool()
-        assert len(res.transactions) == txpool_size - 2
-
-        print('Mining transactions')
         daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
-        res = daemon.get_transaction_pool()
-        assert not 'transactions' in res or len(res.transactions) == txpool_size - 5
-        res = daemon.get_transaction_pool_hashes()
-        assert not 'tx_hashes' in res or len(res.tx_hashes) == 0
+        res = daemon.getlastblockheader()
+        running_balances[0] += res.block_header.reward
+        self.wallet[0].refresh()
 
-        self.check_empty_pool()
+        running_balances[0] += 1000000000000
 
-        print('Popping block')
-        daemon.pop_blocks(1)
-        res = daemon.get_transaction_pool_hashes()
-        assert sorted(res.tx_hashes) == sorted(new_keys)
-        res = daemon.get_transaction_pool()
-        assert len(res.transactions) == txpool_size - 2
-        for txid in new_keys:
-            x = [x for x in res.transactions if x.id_hash == txid]
-            assert len(x) == 1
-            x = x[0]
-            assert x.kept_by_block == True
-            assert x.last_failed_id_hash == '0'*64
-            assert x.double_spend_seen == False
-            assert x.weight >= x.blob_size
+        res = self.wallet[0].get_transfers()
+        assert len(res['in']) == height # coinbases
+        assert len(res.out) == 1 # not mined yet
+        assert not 'pending' in res or len(res.pending) == 0
+        assert not 'pool' in res or len(res.pool) == 0
+        assert not 'failed' in res or len(res.failed) == 0
+        for e in res['in']:
+          assert e.type == 'block'
+        e = res.out[0]
+        assert e.txid == txid
+        assert e.payment_id in ['', '0000000000000000']
+        assert e.type == 'out'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert e.confirmations == 1
 
-            assert x.blob_size * 2 == len(txes[txid].tx_blob)
-            assert x.fee == txes[txid].fee
-            assert x.tx_blob == txes[txid].tx_blob
+        res = self.wallet[0].get_height()
+        wallet_height = res.height
+        res = self.wallet[0].get_transfer_by_txid(txid)
+        assert len(res.transfers) == 1
+        assert res.transfers[0] == res.transfer
+        t = res.transfer
+        assert t.txid == txid
+        assert t.payment_id in ['', '0000000000000000']
+        assert t.height == wallet_height - 1
+        assert t.timestamp > 0
+        assert t.amount == 0 # to self, so it's just "pay a fee" really
+        assert t.fee == fee
+        assert t.note == ''
+        assert len(t.destinations) == 1
+        assert t.destinations[0] == {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        assert t.type == 'out'
+        assert t.unlock_time == 0
+        assert t.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert t.double_spend_seen == False
+        assert t.confirmations == 1
 
-        daemon.flush_txpool()
-        self.check_empty_pool()
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        print("Creating transfer to another, manual relay")
+
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        res = self.wallet[0].transfer([dst], ring_size = 11, get_tx_key = True, do_not_relay = True, get_tx_hex = True)
+        assert len(res.tx_hash) == 32*2
+        txid = res.tx_hash
+        assert len(res.tx_key) == 32*2
+        assert res.amount == 1000000000000
+        amount = res.amount
+        assert res.fee > 0
+        fee = res.fee
+        assert len(res.tx_blob) > 0
+        assert len(res.tx_metadata) == 0
+        assert len(res.multisig_txset) == 0
+        assert len(res.unsigned_txset) == 0
+        tx_blob = res.tx_blob
+
+        res = daemon.send_raw_transaction(tx_blob)
+        assert res.not_relayed == False
+        assert res.low_mixin == False
+        assert res.double_spend == False
+        assert res.invalid_input == False
+        assert res.invalid_output == False
+        assert res.too_big == False
+        assert res.overspend == False
+        assert res.fee_too_low == False
+
+        self.wallet[0].refresh()
+
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        self.wallet[1].refresh()
+
+        res = self.wallet[1].get_transfers()
+        assert not 'in' in res or len(res['in']) == 0
+        assert not 'out' in res or len(res.out) == 0
+        assert not 'pending' in res or len(res.pending) == 0
+        assert len(res.pool) == 1
+        assert not 'failed' in res or len(res.failed) == 0
+        e = res.pool[0]
+        assert e.txid == txid
+        assert e.payment_id in ["", "0000000000000000"] # long payment IDs are now ignored
+        assert e.type == 'pool'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert not 'confirmations' in e or e.confirmations == 0
+        assert e.amount == amount
+        assert e.fee == fee
+
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+        res = daemon.getlastblockheader()
+        running_balances[0] -= 1000000000000 + fee
+        running_balances[0] += res.block_header.reward
+        self.wallet[1].refresh()
+        running_balances[1] += 1000000000000
+
+        res = self.wallet[1].get_transfers()
+        assert len(res['in']) == 1
+        assert not 'out' in res or len(res.out) == 0
+        assert not 'pending' in res or len(res.pending) == 0
+        assert not 'pool' in res or len(res.pool) == 0
+        assert not 'failed' in res or len(res.failed) == 0
+        e = res['in'][0]
+        assert e.txid == txid
+        assert e.payment_id in ["", "0000000000000000"] # long payment IDs are now ignored
+        assert e.type == 'in'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert e.confirmations == 1
+        assert e.amount == amount
+        assert e.fee == fee
+
+        res = self.wallet[1].get_balance()
+        assert res.balance == running_balances[1]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 9
+
+        print('Creating multi out transfer')
+
+        self.wallet[0].refresh()
+
+        dst0 = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        dst1 = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1100000000000}
+        dst2 = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1200000000000}
+        res = self.wallet[0].transfer([dst0, dst1, dst2], ring_size = 11, get_tx_key = True)
+        assert len(res.tx_hash) == 32*2
+        txid = res.tx_hash
+        assert len(res.tx_key) == 32*2
+        assert res.amount == 1000000000000 + 1100000000000 + 1200000000000
+        amount = res.amount
+        assert res.fee > 0
+        fee = res.fee
+        assert len(res.tx_blob) == 0
+        assert len(res.tx_metadata) == 0
+        assert len(res.multisig_txset) == 0
+        assert len(res.unsigned_txset) == 0
+        unsigned_txset = res.unsigned_txset
+
+        running_balances[0] -= 1000000000000 + 1100000000000 + 1200000000000 + fee
+
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+        res = daemon.getlastblockheader()
+        running_balances[0] += res.block_header.reward
+        running_balances[0] += 1000000000000
+        running_balances[1] += 1100000000000
+        running_balances[2] += 1200000000000
+        self.wallet[0].refresh()
+
+        res = self.wallet[0].get_transfers()
+        assert len(res['in']) == height + 2
+        assert len(res.out) == 3
+        assert not 'pending' in res or len(res.pending) == 0
+        assert not 'pool' in res or len(res.pool) == 1
+        assert not 'failed' in res or len(res.failed) == 0
+        e = [o for o in res.out if o.txid == txid]
+        assert len(e) == 1
+        e = e[0]
+        assert e.txid == txid
+        assert e.payment_id in ["", "0000000000000000"] # long payment IDs are now ignored
+        assert e.type == 'out'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert e.confirmations == 1
+
+        assert e.amount == amount
+        assert e.fee == fee
+
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        self.wallet[1].refresh()
+        res = self.wallet[1].get_transfers()
+        assert len(res['in']) == 2
+        assert not 'out' in res or len(res.out) == 0
+        assert not 'pending' in res or len(res.pending) == 0
+        assert not 'pool' in res or len(res.pool) == 0
+        assert not 'failed' in res or len(res.failed) == 0
+        e = [o for o in res['in'] if o.txid == txid]
+        assert len(e) == 1
+        e = e[0]
+        assert e.txid == txid
+        assert e.payment_id in ["", "0000000000000000"] # long payment IDs are now ignored
+        assert e.type == 'in'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert e.confirmations == 1
+        assert e.amount == 1100000000000
+        assert e.fee == fee
+
+        res = self.wallet[1].get_balance()
+        assert res.balance == running_balances[1]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 9
+
+        self.wallet[2].refresh()
+        res = self.wallet[2].get_transfers()
+        assert len(res['in']) == 1
+        assert not 'out' in res or len(res.out) == 0
+        assert not 'pending' in res or len(res.pending) == 0
+        assert not 'pool' in res or len(res.pool) == 0
+        assert not 'failed' in res or len(res.failed) == 0
+        e = [o for o in res['in'] if o.txid == txid]
+        assert len(e) == 1
+        e = e[0]
+        assert e.txid == txid
+        assert e.payment_id in ["", "0000000000000000"] # long payment IDs are now ignored
+        assert e.type == 'in'
+        assert e.unlock_time == 0
+        assert e.subaddr_index.major == 0
+        assert e.subaddr_indices == [{'major': 0, 'minor': 0}]
+        assert e.address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+        assert e.double_spend_seen == False
+        assert e.confirmations == 1
+        assert e.amount == 1200000000000
+        assert e.fee == fee
+
+        res = self.wallet[2].get_balance()
+        assert res.balance == running_balances[2]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 9
+
+        print('Sending to integrated address')
+        self.wallet[0].refresh()
+        res = self.wallet[0].get_balance()
+        i_pid = '1111111122222222'
+        res = self.wallet[0].make_integrated_address(standard_address = 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', payment_id = i_pid)
+        i_address = res.integrated_address
+        res = self.wallet[0].transfer([{'address': i_address, 'amount': 200000000}])
+        assert len(res.tx_hash) == 32*2
+        i_txid = res.tx_hash
+        assert len(res.tx_key) == 32*2
+        assert res.amount == 200000000
+        i_amount = res.amount
+        assert res.fee > 0
+        fee = res.fee
+        assert len(res.tx_blob) == 0
+        assert len(res.tx_metadata) == 0
+        assert len(res.multisig_txset) == 0
+        assert len(res.unsigned_txset) == 0
+
+        running_balances[0] -= 200000000 + fee
+
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+        res = daemon.getlastblockheader()
+        running_balances[0] += res.block_header.reward
+        running_balances[1] += 200000000
+
+        self.wallet[0].refresh()
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        self.wallet[1].refresh()
+        res = self.wallet[1].get_balance()
+        assert res.balance == running_balances[1]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 9
+
+        self.wallet[2].refresh()
+        res = self.wallet[2].get_balance()
+        assert res.balance == running_balances[2]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 8
+
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+        res = daemon.getlastblockheader()
+        running_balances[0] += res.block_header.reward
+
+        self.wallet[0].refresh()
+        res = self.wallet[0].get_balance()
+        assert res.balance == running_balances[0]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 59
+
+        self.wallet[1].refresh()
+        res = self.wallet[1].get_balance()
+        assert res.balance == running_balances[1]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 8
+
+        self.wallet[2].refresh()
+        res = self.wallet[2].get_balance()
+        assert res.balance == running_balances[2]
+        assert res.unlocked_balance <= res.balance
+        assert res.blocks_to_unlock == 7
+
+
+    def check_get_bulk_payments(self):
+        print('Checking get_bulk_payments')
+
+        daemon = Daemon()
+        res = daemon.get_info()
+        height = res.height
+
+        self.wallet[0].refresh()
+        res = self.wallet[0].get_bulk_payments()
+        assert len(res.payments) >= 83 # at least 83 coinbases
+        res = self.wallet[0].get_bulk_payments(payment_ids = ['1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde'])
+        assert 'payments' not in res or len(res.payments) == 0
+        res = self.wallet[0].get_bulk_payments(min_block_height = height)
+        assert 'payments' not in res or len(res.payments) == 0
+        res = self.wallet[0].get_bulk_payments(min_block_height = height - 40)
+        assert len(res.payments) >= 39 # coinbases
+
+        self.wallet[1].refresh()
+        res = self.wallet[1].get_bulk_payments()
+        assert len(res.payments) >= 3 # two txes to standard address were sent, plus one to integrated address
+        res = self.wallet[1].get_bulk_payments(payment_ids = ['1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde'])
+        assert not 'payments' in res or len(res.payments) == 0 # long payment IDs are now ignored on receipt
+        res = self.wallet[1].get_bulk_payments(payment_ids = ['ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'])
+        assert 'payments' not in res or len(res.payments) == 0 # none with that payment id
+        res = self.wallet[1].get_bulk_payments(payment_ids = ['1111111122222222' + '0'*48])
+        assert len(res.payments) >= 1 # one tx to integrated address
+
+        self.wallet[2].refresh()
+        res = self.wallet[2].get_bulk_payments()
+        assert len(res.payments) >= 1 # one tx was sent
+        res = self.wallet[2].get_bulk_payments(payment_ids = ['1'*64, '1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde', '2'*64])
+        assert not 'payments' in res or len(res.payments) == 0 # long payment IDs are now ignored
+
+        res = self.wallet[1].get_bulk_payments(["1111111122222222"])
+        assert len(res.payments) >= 1 # we have one of these
+
+    def check_get_payments(self):
+        print('Checking get_payments')
+
+        daemon = Daemon()
+        res = daemon.get_info()
+        height = res.height
+
+        self.wallet[0].refresh()
+        self.wallet[1].refresh()
+
+        res = self.wallet[0].get_payments('1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde')
+        assert 'payments' not in res or len(res.payments) == 0
+
+        res = self.wallet[1].get_payments('1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde')
+        assert 'payments' not in res or len(res.payments) == 0
+
+        res = self.wallet[1].get_payments('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+        assert 'payments' not in res or len(res.payments) == 0
+
+        res = self.wallet[1].get_payments(payment_id = '1111111122222222' + '0'*48)
+        assert len(res.payments) >= 1 # one tx to integrated address
+
+    def check_double_spend_detection(self):
+        print('Checking double spend detection')
+        txes = [[None, None], [None, None]]
+        for i in range(2):
+            self.wallet[0].restore_deterministic_wallet(seed = 'upbeat wade toenail italics maverick anybody eluded altitude tumbling emotion against okay inkling ankle karate stunning doing verification slid zinger cucumber blender dual extra wade verification')
+            self.wallet[0].refresh()
+            res = self.wallet[0].get_balance()
+            unlocked_balance = res.unlocked_balance
+            res = self.wallet[0].sweep_all(address = 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', do_not_relay = True, get_tx_hex = True)
+            assert len(res.tx_hash_list) == 1
+            assert len(res.tx_hash_list[0]) == 32*2
+            txes[i][0] = res.tx_hash_list[0]
+            assert len(res.fee_list) == 1
+            assert res.fee_list[0] > 0
+            assert len(res.amount_list) == 1
+            assert res.amount_list[0] == unlocked_balance - res.fee_list[0]
+            assert len(res.tx_blob_list) > 0
+            assert len(res.tx_blob_list[0]) > 0
+            assert not 'tx_metadata_list' in res or len(res.tx_metadata_list) == 0
+            assert not 'multisig_txset' in res or len(res.multisig_txset) == 0
+            assert not 'unsigned_txset' in res or len(res.unsigned_txset) == 0
+            assert len(res.tx_blob_list) == 1
+            txes[i][1] = res.tx_blob_list[0]
+
+        daemon = Daemon()
+        res = daemon.send_raw_transaction(txes[0][1])
+        assert res.not_relayed == False
+        assert res.low_mixin == False
+        assert res.double_spend == False
+        assert res.invalid_input == False
+        assert res.invalid_output == False
+        assert res.too_big == False
+        assert res.overspend == False
+        assert res.fee_too_low == False
+
+        res = daemon.get_transactions([txes[0][0]])
+        assert len(res.txs) >= 1
+        tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
+        assert tx.in_pool
+        assert not tx.double_spend_seen
+
+        res = daemon.send_raw_transaction(txes[1][1])
+        assert res.not_relayed == False
+        assert res.low_mixin == False
+        assert res.double_spend == True
+        assert res.invalid_input == False
+        assert res.invalid_output == False
+        assert res.too_big == False
+        assert res.overspend == False
+        assert res.fee_too_low == False
+        assert res.too_few_outputs == False
+
+        res = daemon.get_transactions([txes[0][0]])
+        assert len(res.txs) >= 1
+        tx = [tx for tx in res.txs if tx.tx_hash == txes[0][0]][0]
+        assert tx.in_pool
+        assert tx.double_spend_seen
+
+    def sweep_dust(self):
+        print("Sweeping dust")
+        daemon = Daemon()
+        self.wallet[0].refresh()
+        res = self.wallet[0].sweep_dust()
+        assert not 'tx_hash_list' in res or len(res.tx_hash_list) == 0 # there's just one, but it cannot meet the fee
+
+    def sweep_single(self):
+        daemon = Daemon()
+
+        print("Sending single output")
+
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+        self.wallet[0].refresh()
+        res = self.wallet[0].incoming_transfers(transfer_type = 'available')
+        for t in res.transfers:
+            assert not t.spent
+        assert len(res.transfers) > 8 # we mined a lot
+        index = 8
+        assert not res.transfers[index].spent
+        assert res.transfers[index].amount > 0
+        ki = res.transfers[index].key_image
+        amount = res.transfers[index].amount
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 10) # ensure unlocked
+        self.wallet[0].refresh()
+        res = self.wallet[0].get_balance()
+        balance = res.balance
+        res = daemon.is_key_image_spent([ki])
+        assert len(res.spent_status) == 1
+        assert res.spent_status[0] == 0
+        res = self.wallet[0].sweep_single('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', key_image = ki)
+        assert len(res.tx_hash) == 64
+        tx_hash = res.tx_hash
+        res = daemon.is_key_image_spent([ki])
+        assert len(res.spent_status) == 1
+        assert res.spent_status[0] == 2
+        daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+        res = daemon.is_key_image_spent([ki])
+        assert len(res.spent_status) == 1
+        assert res.spent_status[0] == 1
+        self.wallet[0].refresh()
+        res = self.wallet[0].get_balance()
+        new_balance = res.balance
+        res = daemon.get_transactions([tx_hash], decode_as_json = True)
+        assert len(res.txs) == 1
+        tx = res.txs[0]
+        assert tx.tx_hash == tx_hash
+        assert not tx.in_pool
+        assert len(tx.as_json) > 0
+        try:
+            j = json.loads(tx.as_json)
+        except:
+            j = None
+        assert j
+        assert new_balance == balance - amount
+        assert len(j['vin']) == 1
+        assert j['vin'][0]['key']['k_image'] == ki
+        self.wallet[0].refresh()
+        res = self.wallet[0].incoming_transfers(transfer_type = 'available')
+        assert len([t for t in res.transfers if t.key_image == ki]) == 0
+        res = self.wallet[0].incoming_transfers(transfer_type = 'unavailable')
+        assert len([t for t in res.transfers if t.key_image == ki]) == 1
+
+    def check_destinations(self):
+        daemon = Daemon()
+
+        print("Checking transaction destinations")
+
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        res = self.wallet[0].transfer([dst])
+        assert len(res.tx_hash) == 64
+        tx_hash = res.tx_hash
+        for i in range(2):
+            res = self.wallet[0].get_transfers(pending = True, out = True)
+            l = [x for x in (res.pending if i == 0 else res.out) if x.txid == tx_hash]
+            assert len(l) == 1
+            e = l[0]
+            assert len(e.destinations) == 1
+            assert e.destinations[0].amount == 1000000000000
+            assert e.destinations[0].address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+
+            if i == 0:
+                daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+                self.wallet[0].refresh()
+
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        res = self.wallet[0].transfer([dst])
+        assert len(res.tx_hash) == 64
+        tx_hash = res.tx_hash
+        for i in range(2):
+            res = self.wallet[0].get_transfers(pending = True, out = True)
+            l = [x for x in (res.pending if i == 0 else res.out) if x.txid == tx_hash]
+            assert len(l) == 1
+            e = l[0]
+            assert len(e.destinations) == 1
+            assert e.destinations[0].amount == 1000000000000
+            assert e.destinations[0].address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+
+            if i == 0:
+                daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+                self.wallet[0].refresh()
+
+        dst = {'address': 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 'amount': 1000000000000}
+        res = self.wallet[0].transfer([dst])
+        assert len(res.tx_hash) == 64
+        tx_hash = res.tx_hash
+        for i in range(2):
+            res = self.wallet[0].get_transfers(pending = True, out = True)
+            l = [x for x in (res.pending if i == 0 else res.out) if x.txid == tx_hash]
+            assert len(l) == 1
+            e = l[0]
+            assert len(e.destinations) == 1
+            assert e.destinations[0].amount == 1000000000000
+            assert e.destinations[0].address == 'Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq'
+
+            if i == 0:
+                daemon.generateblocks('Sumoo1aLd1yKkerxdjbXggMf3mdy5m9tZeWpYU913LSmZuUdMjJnoa67vp2WB7sV2ZHCBZbh2MekDK2emfWCxZZ997WpRfimvjq', 1)
+                self.wallet[0].refresh()
+
+    def check_tx_notes(self):
+        daemon = Daemon()
+
+        print('Testing tx notes')
+        res = self.wallet[0].get_transfers()
+        assert len(res['in']) > 0
+        in_txid = res['in'][0].txid
+        assert len(res['out']) > 0
+        out_txid = res['out'][0].txid
+        res = self.wallet[0].get_tx_notes([in_txid, out_txid])
+        assert res.notes == ['', '']
+        res = self.wallet[0].set_tx_notes([in_txid, out_txid], ['in txid', 'out txid'])
+        res = self.wallet[0].get_tx_notes([in_txid, out_txid])
+        assert res.notes == ['in txid', 'out txid']
+        res = self.wallet[0].get_tx_notes([out_txid, in_txid])
+        assert res.notes == ['out txid', 'in txid']
+
+    def check_rescan(self):
+        daemon = Daemon()
+
+        print('Testing rescan_spent')
+        res = self.wallet[0].incoming_transfers(transfer_type = 'all')
+        transfers = res.transfers
+        res = self.wallet[0].rescan_spent()
+        res = self.wallet[0].incoming_transfers(transfer_type = 'all')
+        assert transfers == res.transfers
+
+        for hard in [False, True]:
+            print('Testing %s rescan_blockchain' % ('hard' if hard else 'soft'))
+            res = self.wallet[0].incoming_transfers(transfer_type = 'all')
+            transfers = res.transfers
+            res = self.wallet[0].get_transfers()
+            t_in = res['in']
+            t_out = res.out
+            res = self.wallet[0].rescan_blockchain(hard = hard)
+            res = self.wallet[0].incoming_transfers(transfer_type = 'all')
+            assert transfers == res.transfers
+            res = self.wallet[0].get_transfers()
+            assert t_in == res['in']
+            # some information can not be recovered for out txes
+            unrecoverable_fields = ['payment_id', 'destinations', 'note']
+            old_t_out = []
+            for x in t_out:
+                e = {}
+                for k in x.keys():
+                    if not k in unrecoverable_fields:
+                        e[k] = x[k]
+                old_t_out.append(e)
+            new_t_out = []
+            for x in res.out:
+                e = {}
+                for k in x.keys():
+                    if not k in unrecoverable_fields:
+                        e[k] = x[k]
+                new_t_out.append(e)
+            assert sorted(old_t_out, key = lambda k: k['txid']) == sorted(new_t_out, key = lambda k: k['txid'])
+
+    def check_is_key_image_spent(self):
+        daemon = Daemon()
+
+        print('Testing is_key_image_spent')
+        res = self.wallet[0].incoming_transfers(transfer_type = 'all')
+        transfers = res.transfers
+        ki = [x.key_image for x in transfers]
+        expected = [1 if x.spent else 0 for x in transfers]
+        res = daemon.is_key_image_spent(ki)
+        assert res.spent_status == expected
+
+        res = self.wallet[0].incoming_transfers(transfer_type = 'available')
+        transfers = res.transfers
+        ki = [x.key_image for x in transfers]
+        expected = [0 for x in transfers]
+        res = daemon.is_key_image_spent(ki)
+        assert res.spent_status == expected
+
+        res = self.wallet[0].incoming_transfers(transfer_type = 'unavailable')
+        transfers = res.transfers
+        ki = [x.key_image for x in transfers]
+        expected = [1 for x in transfers]
+        res = daemon.is_key_image_spent(ki)
+        assert res.spent_status == expected
+
+        ki = [ki[-1]] * 5
+        expected = [1] * len(ki)
+        res = daemon.is_key_image_spent(ki)
+        assert res.spent_status == expected
+
+        ki = ['2'*64, '1'*64]
+        expected = [0, 0]
+        res = daemon.is_key_image_spent(ki)
+        assert res.spent_status == expected
 
 
 if __name__ == '__main__':

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2019, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "gtest/gtest.h"
@@ -87,8 +87,8 @@ const uint64_t AMOUNT_1XMR  =  1000000000000L;
 
 const std::string PAYMENT_ID_EMPTY = "";
 
-std::string TESTNET_DAEMON_ADDRESS = "localhost:38081";
-std::string MAINNET_DAEMON_ADDRESS = "localhost:18081";
+std::string TESTNET_DAEMON_ADDRESS = "localhost:39734";
+std::string MAINNET_DAEMON_ADDRESS = "localhost:19734";
 
 
 }
@@ -620,7 +620,7 @@ TEST_F(WalletTest1, WalletTransactionWithMixin)
     std::string recepient_address = Utils::get_wallet_address(CURRENT_DST_WALLET, TESTNET_WALLET_PASS);
     for (auto mixin : mixins) {
         std::cerr << "Transaction mixin count: " << mixin << std::endl;
-	
+
         Monero::PendingTransaction * transaction = wallet1->createTransaction(
                     recepient_address, payment_id, AMOUNT_5XMR, mixin, Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
 
@@ -662,7 +662,7 @@ TEST_F(WalletTest1, WalletTransactionWithPriority)
 
     for (auto it = priorities.begin(); it != priorities.end(); ++it) {
         std::cerr << "Transaction priority: " << *it << std::endl;
-	
+
         Monero::PendingTransaction * transaction = wallet1->createTransaction(
                     recepient_address, payment_id, AMOUNT_5XMR, mixin, *it, 0, std::set<uint32_t>{});
         std::cerr << "Transaction status: " << transaction->status() << std::endl;

--- a/tests/unit_tests/bootstrap_node_selector.cpp
+++ b/tests/unit_tests/bootstrap_node_selector.cpp
@@ -44,12 +44,12 @@ protected:
       "white_node_1:18089", true
     },
     {
-      "white_node_2:18081", true
+      "white_node_2:19734", true
     }
   };
   const std::map<std::string, bool> gray_nodes = {
     {
-      "gray_node_1:18081", false
+      "gray_node_1:19734", false
     },
     {
       "gray_node_2:18089", false

--- a/utils/python-rpc/framework/daemon.py
+++ b/utils/python-rpc/framework/daemon.py
@@ -1,21 +1,21 @@
 # Copyright (c) 2018 The Monero Project
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-# 
+#
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -28,14 +28,15 @@
 
 """Daemon class to make rpc calls and store state."""
 
-from .rpc import JSONRPC 
+from .rpc import JSONRPC
 
 class Daemon(object):
 
-    def __init__(self, protocol='http', host='127.0.0.1', port=0, idx=0):
+    def __init__(self, protocol='http', host='127.0.0.1', port=0, idx=0, restricted_rpc = False):
+        base = 18480 if restricted_rpc else 19733
         self.host = host
         self.port = port
-        self.rpc = JSONRPC('{protocol}://{host}:{port}'.format(protocol=protocol, host=host, port=port if port else 18180+idx))
+        self.rpc = JSONRPC('{protocol}://{host}:{port}'.format(protocol=protocol, host=host, port=port if port else base+idx))
 
     def getblocktemplate(self, address, prev_block = "", client = ""):
         getblocktemplate = {
@@ -46,7 +47,7 @@ class Daemon(object):
                 'reserve_size' : 1,
                 'prev_block' : prev_block,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(getblocktemplate)
@@ -65,10 +66,10 @@ class Daemon(object):
     def submitblock(self, block):
         submitblock = {
             'method': 'submitblock',
-            'params': [ block ],    
-            'jsonrpc': '2.0', 
+            'params': [ block ],
+            'jsonrpc': '2.0',
             'id': '0'
-        }    
+        }
         return self.rpc.send_json_rpc_request(submitblock)
     submit_block = submitblock
 
@@ -81,7 +82,7 @@ class Daemon(object):
                 'height': height,
                 'fill_pow_hash': fill_pow_hash,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(getblock)
@@ -93,7 +94,7 @@ class Daemon(object):
             'params': {
                 'client': client,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(getlastblockheader)
@@ -107,7 +108,7 @@ class Daemon(object):
                 'hash': hash,
                 'hashes': hashes,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(getblockheaderbyhash)
@@ -120,7 +121,7 @@ class Daemon(object):
                 'client': client,
                 'height': height,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(getblockheaderbyheight)
@@ -135,7 +136,7 @@ class Daemon(object):
                 'end_height': end_height,
                 'fill_pow_hash': fill_pow_hash,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(getblockheadersrange)
@@ -145,7 +146,7 @@ class Daemon(object):
         get_connections = {
             'client': client,
             'method': 'get_connections',
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(get_connections)
@@ -158,7 +159,7 @@ class Daemon(object):
             },
             'jsonrpc': '2.0',
             'id': '0'
-        }    
+        }
         return self.rpc.send_json_rpc_request(get_info)
     getinfo = get_info
 
@@ -170,7 +171,7 @@ class Daemon(object):
             },
             'jsonrpc': '2.0',
             'id': '0'
-        }    
+        }
         return self.rpc.send_json_rpc_request(hard_fork_info)
 
     def generateblocks(self, address, blocks=1, prev_block = "", starting_nonce = 0):
@@ -183,7 +184,7 @@ class Daemon(object):
                 'prev_block': prev_block,
                 'starting_nonce': starting_nonce,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(generateblocks)
@@ -480,7 +481,7 @@ class Daemon(object):
             'method': 'get_block_count',
             'params': {
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(get_block_count)
@@ -490,7 +491,7 @@ class Daemon(object):
         get_block_hash = {
             'method': 'get_block_hash',
             'params': [height],
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(get_block_hash)
@@ -504,7 +505,7 @@ class Daemon(object):
                 'txids': txids,
                 'client': client,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(relay_tx)
@@ -515,7 +516,7 @@ class Daemon(object):
             'params': {
                 'client': client,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(sync_info)
@@ -526,7 +527,7 @@ class Daemon(object):
             'params': {
                 'client': client,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(get_txpool_backlog)
@@ -537,7 +538,7 @@ class Daemon(object):
             'params': {
                 'check': check,
             },
-            'jsonrpc': '2.0', 
+            'jsonrpc': '2.0',
             'id': '0'
         }
         return self.rpc.send_json_rpc_request(prune_blockchain)


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6445

Mostly brought in for code continuity cause there was a bit of restructuring
(fuctional tests are not fully enabled in sumo)
(fixed a port number on python rpc and on some tests as well while i was at it)
+
Ref: https://github.com/monero-project/monero/pull/6477
Quote
_Testing behavior of Dandelion++ via the restricted port is not possible currently - the stem/fluff mode changes the behavior of the node and is selected randomly._
Unquote