### PR TITLE
[unit_tests] fix output selection test

### DIFF
--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -177,7 +177,7 @@ TEST(select_outputs, density)
     float chain_ratio = count_chain / (float)n_outs;
     MDEBUG(count_selected << "/" << NPICKS << " outputs selected in blocks of density " << d << ", " << 100.0f * selected_ratio << "%");
     MDEBUG(count_chain << "/" << offsets.size() << " outputs in blocks of density " << d << ", " << 100.0f * chain_ratio << "%");
-    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.025f);
+    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.028f);
   }
 }
 


### PR DESCRIPTION
We increased the range of the end of chain output selection and introduced randomness in picking through that range. That means that for edge cases unit test for output selection fail
`Expected: (fabsf(selected_ratio - chain_ratio)) < (0.025f), actual: 0.0263155 vs 0.025`
Increase the right hand side of the inequality to include almost all edge cases.
(Due to the randomness 0.028 is more or less empirical it might need amendement but i think it will cover almost all cases)