### PR TITLE
[depends] update cdrkit link

### DIFF
--- a/contrib/depends/packages/native_cdrkit.mk
+++ b/contrib/depends/packages/native_cdrkit.mk
@@ -1,8 +1,8 @@
 package=native_cdrkit
 $(package)_version=1.1.11
-$(package)_download_path=https://distro.ibiblio.org/fatdog/source/600/c
-$(package)_file_name=cdrkit-$($(package)_version).tar.bz2
-$(package)_sha256_hash=b50d64c214a65b1a79afe3a964c691931a4233e2ba605d793eb85d0ac3652564
+$(package)_download_path=https://src.fedoraproject.org/repo/pkgs/cdrkit/cdrkit-$($(package)_version).tar.gz/efe08e2f3ca478486037b053acd512e9/
+$(package)_file_name=cdrkit-$($(package)_version).tar.gz
+$(package)_sha256_hash=d1c030756ecc182defee9fe885638c1785d35a2c2a297b4604c0e0dcc78e47da
 $(package)_patches=cdrkit-deterministic.patch
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
the currently link was failing on and off get it from fedora project repo which is consistent