### PR TITLE
[gen ssl certificate] fix winsocks2 for mingw (windows) building

### DIFF
--- a/src/gen_ssl_cert/gen_ssl_cert.cpp
+++ b/src/gen_ssl_cert/gen_ssl_cert.cpp
@@ -26,6 +26,11 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if defined(__MINGW32__)
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>


### PR DESCRIPTION
Cross compiling on mingw caught it otherwise noone would have spot it. 
```
/usr/share/mingw-w64/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
 #warning Please include winsock2.h before windows.h
```
In `gen_ssl_cert.cpp`
`include_base_utils.h` drags in `easylogging++.h`  which is **ANCIENT** and it has a shitty construction here 
```
#if ELPP_OS_UNIX
#   include <sys/stat.h>
#   include <sys/time.h>
#elif ELPP_OS_WINDOWS
#   include <direct.h>
#   include <windows.h>
#  if defined(WIN32_LEAN_AND_MEAN)
#      if defined(ELPP_WINSOCK2)
#         include <winsock2.h>
#      else
#         include <winsock.h>
#      endif // defined(ELPP_WINSOCK2)
#  endif // defined(WIN32_LEAN_AND_MEAN)
#endif  // ELPP_OS_UNIX
```
windows.h includes winsock.h by default. winsock.h and winsock2.h do not coexist. If winsock2.h is included first, it disables winsock.h, and all is good. But if winsock.h is included first, winsock2.h fails to compile, because it redeclares a lot of things that winsock.h already declares. Thus why you need to include winsock2.h first. 
**SO IF YOU ARE NOT LIVING IN THE EARLY 90'S AND STILL USING WINDOWS 3.11 winsocks2 IS ALL YOU NEED**