### PR TITLE
[workflows] decrease building threads to 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: update brew and install dependencies
       run: brew update && brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf
     - name: build
-      run: make -j3
+      run: make -j2
 
   build-windows:
     runs-on: windows-latest
@@ -46,7 +46,7 @@ jobs:
     - name: install sumokoin dependencies
       run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev
     - name: build
-      run: make -j3
+      run: make -j2
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest
@@ -66,7 +66,7 @@ jobs:
     - name: install sumokoin dependencies
       run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev
     - name: build
-      run: cmake -DBUILD_GUI_DEPS=ON && make -j3
+      run: cmake -DBUILD_GUI_DEPS=ON && make -j2
 
   test-ubuntu:
     needs: build-ubuntu
@@ -91,5 +91,5 @@ jobs:
     - name: tests
       env:
         CTEST_OUTPUT_ON_FAILURE: ON
-      run: make release-test -j3
+      run: make release-test -j2
 


### PR DESCRIPTION
From github man page
https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners

_Supported runners and hardware resources
Each virtual machine has the same hardware resources available.
2-core CPU
7 GB of RAM memory
14 GB of SSD disk space_