### PR TITLE
[wallet2] bring subaddress lookahead major and minor definition on config

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -179,6 +179,9 @@
 #define MAX_MIXIN                                       240
 #define DEFAULT_MIXIN_V2                                48
 
+#define SUBADDRESS_LOOKAHEAD_MAJOR                      50
+#define SUBADDRESS_LOOKAHEAD_MINOR                      200
+
 #define TRANSACTION_WEIGHT_LIMIT                        ((uint64_t) ((CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 110 / 100) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE))
 #define BLOCK_SIZE_GROWTH_FAVORED_ZONE                  ((uint64_t) (CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4))
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -116,9 +116,6 @@ using namespace cryptonote;
 
 #define SECOND_OUTPUT_RELATEDNESS_THRESHOLD 0.0f
 
-#define SUBADDRESS_LOOKAHEAD_MAJOR 50
-#define SUBADDRESS_LOOKAHEAD_MINOR 200
-
 #define KEY_IMAGE_EXPORT_FILE_MAGIC "Sumokoin key image export\002"
 
 #define MULTISIG_EXPORT_FILE_MAGIC "Sumokoin multisig export\001"


### PR DESCRIPTION
I want to restrict even further the subaddress one-off command monero introduced cause someone can choose a minor way off the lookahead then rescan the chain or restore his wallet without changing the minor lookahead number to include that index and he will be wondering for ever where his money has gone ...
Also that's a better position to find them incase someone wants to increase the numbers