### PR TITLE
[simplewallet] restrict one off subaddress to lookahead minor index limit

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -179,6 +179,9 @@
 #define MAX_MIXIN                                       240
 #define DEFAULT_MIXIN_V2                                48
 
+#define SUBADDRESS_LOOKAHEAD_MAJOR                      50
+#define SUBADDRESS_LOOKAHEAD_MINOR                      200
+
 #define TRANSACTION_WEIGHT_LIMIT                        ((uint64_t) ((CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 110 / 100) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE))
 #define BLOCK_SIZE_GROWTH_FAVORED_ZONE                  ((uint64_t) (CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4))
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -70,6 +70,7 @@
 #include "multisig/multisig.h"
 #include "wallet/wallet_args.h"
 #include "version.h"
+#include "cryptonote_config.h"
 #include <stdexcept>
 #include "wallet/message_store.h"
 
@@ -9412,6 +9413,11 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
       fail_msg_writer() << tr(" Subaddress index selected (minor index: ") << local_args[1] << (") already exists");
       return true;
     }
+    if (epee::string_tools::get_xtype_from_string(major, local_args[0]) && epee::string_tools::get_xtype_from_string(minor, local_args[1]) && minor > SUBADDRESS_LOOKAHEAD_MINOR)
+    {
+      fail_msg_writer() << tr(" Please select a minor index lower or equal to ") << SUBADDRESS_LOOKAHEAD_MINOR;
+      return true;
+    }	  
     m_wallet->create_one_off_subaddress({major, minor});
     success_msg_writer() << boost::format(tr("Address at %u %u: %s")) % major % minor % m_wallet->get_subaddress_as_str({major, minor});
   }


### PR DESCRIPTION
restrict even further the subaddress one-off command monero introduced cause someone can choose a minor way off the lookahead then rescan the chain or restore his wallet without changing the minor lookahead number to include that index and he will be wondering for ever where his money has gone. 
steps on https://github.com/sumoprojects/sumokoin/pull/871