### PR TITLE
[ZMQ JSON-RPC] fix ZMQ JSON-RPC endpoint names for raw tx

### DIFF
--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -100,7 +100,8 @@ namespace rpc
       {u8"key_images_spent", handle_message<KeyImagesSpent>},
       {u8"mining_status", handle_message<MiningStatus>},
       {u8"save_bc", handle_message<SaveBC>},
-      {u8"send_raw_tx", handle_message<SendRawTxHex>},
+      {u8"send_raw_tx", handle_message<SendRawTx>},
+      {u8"send_raw_tx_hex", handle_message<SendRawTxHex>},
       {u8"set_log_level", handle_message<SetLogLevel>},
       {u8"start_mining", handle_message<StartMining>},
       {u8"stop_mining", handle_message<StopMining>}


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6486
Accidentally deleted by vtnerd when restructuring zmq json-rpc