### PR TITLE
[wallet2] Replace std::move with boost::move to avoid prevention of copy elision

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1123,7 +1123,7 @@ void wallet_device_callback::on_progress(const hw::device_progress& event)
 }
 
 wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory):
-  m_http_client(std::move(http_client_factory->create())),
+  m_http_client(boost::move(http_client_factory->create())),
   m_multisig_rescan_info(NULL),
   m_multisig_rescan_k(NULL),
   m_upper_transaction_weight_limit(0),


### PR DESCRIPTION
Latest clang was warning about it and it is absolutely right
```
warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
  m_http_client(std::move(http_client_factory->create())),
```
https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/