### PR TITLE
[mms] turn error to message if "no message store file is found"

### DIFF
--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -724,7 +724,7 @@ void message_store::read_from_file(const multisig_wallet_state &state, const std
   {
     // Simply do nothing if the file is not there; allows e.g. easy recovery
     // from problems with the MMS by deleting the file
-    MERROR("No message store file found: " << filename);
+    MINFO("No message store file found: " << filename);
     return;
   }
 


### PR DESCRIPTION
it scares people who dont know what it is when they run rpc wallet and it's more of a message than an error

https://github.com/monero-project/monero/pull/6484