### PR TITLE
[crypto] ftime is deprecated use gettimeofday

### DIFF
--- a/src/crypto/oaes_lib.c
+++ b/src/crypto/oaes_lib.c
@@ -28,7 +28,9 @@
  * ---------------------------------------------------------------------------
  */
 #include <stddef.h>
-#include <time.h> 
+#include <time.h>
+#include <sys/time.h>
+#include <sys/timeb.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -37,14 +39,6 @@
 #if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) \
   && !defined(__DragonFly__) && !defined(__NetBSD__)
  #include <malloc.h>
-#endif
-
-// ANDROID, FreeBSD, OpenBSD and NetBSD also don't need timeb.h
-#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__ANDROID__) \
-  && !defined(__NetBSD__)
- #include <sys/timeb.h>
-#else
- #include <sys/time.h>
 #endif
 
 #ifdef WIN32
@@ -474,19 +468,6 @@ OAES_RET oaes_sprintf(
 #ifdef OAES_HAVE_ISAAC
 static void oaes_get_seed( char buf[RANDSIZ + 1] )
 {
-        #if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
-	struct timeb timer;
-	struct tm *gmTimer;
-	char * _test = NULL;
-	
-	ftime (&timer);
-	gmTimer = gmtime( &timer.time );
-	_test = (char *) calloc( sizeof( char ), timer.millitm );
-	sprintf( buf, "%04d%02d%02d%02d%02d%02d%03d%p%d",
-		gmTimer->tm_year + 1900, gmTimer->tm_mon + 1, gmTimer->tm_mday,
-		gmTimer->tm_hour, gmTimer->tm_min, gmTimer->tm_sec, timer.millitm,
-		_test + timer.millitm, GETPID() );
-	#else
 	struct timeval timer;
 	struct tm *gmTimer;
 	char * _test = NULL;
@@ -498,7 +479,6 @@ static void oaes_get_seed( char buf[RANDSIZ + 1] )
 		gmTimer->tm_year + 1900, gmTimer->tm_mon + 1, gmTimer->tm_mday,
 		gmTimer->tm_hour, gmTimer->tm_min, gmTimer->tm_sec, timer.tv_usec/1000,
 		_test + timer.tv_usec/1000, GETPID() );
-	#endif
 		
 	if( _test )
 		free( _test );
@@ -506,19 +486,6 @@ static void oaes_get_seed( char buf[RANDSIZ + 1] )
 #else
 static uint32_t oaes_get_seed(void)
 {
-        #if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__ANDROID__) && !defined(__NetBSD__)
-	struct timeb timer;
-	struct tm *gmTimer;
-	char * _test = NULL;
-	uint32_t _ret = 0;
-	
-	ftime (&timer);
-	gmTimer = gmtime( &timer.time );
-	_test = (char *) calloc( sizeof( char ), timer.millitm );
-	_ret = gmTimer->tm_year + 1900 + gmTimer->tm_mon + 1 + gmTimer->tm_mday +
-			gmTimer->tm_hour + gmTimer->tm_min + gmTimer->tm_sec + timer.millitm +
-			(uintptr_t) ( _test + timer.millitm ) + GETPID();
-	#else
 	struct timeval timer;
 	struct tm *gmTimer;
 	char * _test = NULL;
@@ -530,8 +497,6 @@ static uint32_t oaes_get_seed(void)
 	_ret = gmTimer->tm_year + 1900 + gmTimer->tm_mon + 1 + gmTimer->tm_mday +
 			gmTimer->tm_hour + gmTimer->tm_min + gmTimer->tm_sec + timer.tv_usec/1000 +
 			(uintptr_t) ( _test + timer.tv_usec/1000 ) + GETPID();
-	#endif
-
 	if( _test )
 		free( _test );
 	


### PR DESCRIPTION
ftime is deprecated and will be removed from c's gnu library soon, latest ubuntu versions emit warnings about it (20.04)
http://man7.org/linux/man-pages/man3/ftime.3.html
replace it at oaes_lib.c with `gettimeofday` for all os (was used for freebsd only)