### PR TITLE
[std] replace std::this_thread::sleep instances with its boost equivalent

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 #include <boost/asio/ssl.hpp>
 #include <boost/lambda/lambda.hpp>
+#include <boost/thread/thread.hpp>
 #include <openssl/ssl.h>
 #include <openssl/pem.h>
 #include "misc_log_ex.h"
@@ -538,7 +539,7 @@ bool ssl_options_t::handshake(
     // should poll_one(), can't run_one() because it can block if there is
     // another worker thread executing io_service's tasks
     // TODO: once we get Boost 1.66+, replace with run_one_for/run_until
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(30));
     io_service.poll_one();
   }
 
@@ -599,4 +600,3 @@ static void add_windows_root_certs(SSL_CTX *ctx) noexcept
     SSL_CTX_set_cert_store(ctx, store);
 }
 #endif
-

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -48,6 +48,7 @@
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/thread/thread.hpp>
 #include "include_base_utils.h"
 #include "console_handler.h"
 #include "common/i18n.h"
@@ -6273,7 +6274,7 @@ void simple_wallet::check_for_inactivity_lock(bool user)
       std::cout << setw(18) << "";
       for (const auto msg : s) {
       std::cout << msg << std::flush;
-      std::this_thread::sleep_for(std::chrono::milliseconds(130));
+      boost::this_thread::sleep_for(boost::chrono::milliseconds(130));
     }
 
     tools::msg_writer() << "" << std::endl;


### PR DESCRIPTION
Since we are removing protobuf with #888 , change the only other reason cross compiling for mingw needed posix implementation and required updating and turning into g++ and gcc posix alternatives on the system. This is not required any more. Happy times