### PR TITLE
[zmq] use byte_slice for sending zmq messages - removes data copy within zmq

### DIFF
--- a/contrib/epee/include/byte_slice.h
+++ b/contrib/epee/include/byte_slice.h
@@ -42,7 +42,12 @@ namespace epee
 
   struct release_byte_slice
   {
-    void operator()(byte_slice_data*) const noexcept;
+    //! For use with `zmq_message_init_data`, use second arg for buffer pointer.
+    static void call(void*, void* ptr) noexcept;
+    void operator()(byte_slice_data* ptr) const noexcept
+    {
+      call(nullptr, ptr);
+    }
   };
 
   /*! Inspired by slices in golang. Storage is thread-safe reference counted,
@@ -140,6 +145,9 @@ namespace epee
         \throw std::out_of_range If `size() < end`.
         \return Slice starting at `data() + begin` of size `end - begin`. */
     byte_slice get_slice(std::size_t begin, std::size_t end) const;
+
+    //! \post `empty()` \return Ownership of ref-counted buffer.
+    std::unique_ptr<byte_slice_data, release_byte_slice> take_buffer() noexcept;
   };
 } // epee
 

--- a/src/net/zmq.cpp
+++ b/src/net/zmq.cpp
@@ -33,6 +33,8 @@
 #include <limits>
 #include <utility>
 
+#include "byte_slice.h"
+
 namespace net
 {
 namespace zmq
@@ -182,6 +184,22 @@ namespace zmq
     expect<void> send(const epee::span<const std::uint8_t> payload, void* const socket, const int flags) noexcept
     {
         return retry_op(zmq_send, socket, payload.data(), payload.size(), flags);
+    }
+
+    expect<void> send(epee::byte_slice&& payload, void* socket, int flags) noexcept
+    {
+        void* const data = const_cast<std::uint8_t*>(payload.data());
+        const std::size_t size = payload.size();
+        auto buffer = payload.take_buffer(); // clears `payload` from callee
+
+        zmq_msg_t msg{};
+        MONERO_ZMQ_CHECK(zmq_msg_init_data(std::addressof(msg), data, size, epee::release_byte_slice::call, buffer.get()));
+        buffer.release(); // zmq will now decrement byte_slice ref-count
+
+        expect<void> sent = retry_op(zmq_msg_send, std::addressof(msg), socket, flags);
+        if (!sent) // beware if removing `noexcept` from this function - possible leak here
+            zmq_msg_close(std::addressof(msg));
+        return sent;
     }
 } // zmq
 } // net

--- a/src/net/zmq.h
+++ b/src/net/zmq.h
@@ -53,6 +53,11 @@
 #define MONERO_ZMQ_THROW(msg)                         \
     MONERO_THROW( ::net::zmq::get_error_code(), msg )
 
+namespace epee
+{
+    class byte_slice;
+}
+
 namespace net
 {
 namespace zmq
@@ -132,5 +137,24 @@ namespace zmq
         \param flags See `zmq_send` for possible flags.
         \return `success()` if sent, otherwise ZMQ error. */
     expect<void> send(epee::span<const std::uint8_t> payload, void* socket, int flags = 0) noexcept;
+
+    /*! Sends `payload` on `socket`. Blocks until the entire message is queued
+        for sending, or until `zmq_term` is called on the `zmq_context`
+        associated with `socket`. If the context is terminated,
+        `make_error_code(ETERM)` is returned.
+
+        \note This will automatically retry on `EINTR`, so exiting on
+            interrupts requires context termination.
+        \note If non-blocking behavior is requested on `socket` or by `flags`,
+            then `net::zmq::make_error_code(EAGAIN)` will be returned if this
+            would block.
+
+        \param payload sent as one message on `socket`.
+        \param socket Handle created with `zmq_socket`.
+        \param flags See `zmq_msg_send` for possible flags.
+
+        \post `payload.emtpy()` - ownership is transferred to zmq.
+        \return `success()` if sent, otherwise ZMQ error. */
+    expect<void> send(epee::byte_slice&& payload, void* socket, int flags = 0) noexcept;
 } // zmq
 } // net

--- a/src/rpc/daemon_handler.h
+++ b/src/rpc/daemon_handler.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include "byte_slice.h"
 #include "daemon_messages.h"
 #include "daemon_rpc_version.h"
 #include "rpc_handler.h"
@@ -132,7 +133,7 @@ class DaemonHandler : public RpcHandler
 
     void handle(const GetOutputDistribution::Request& req, GetOutputDistribution::Response& res);
 
-    std::string handle(const std::string& request);
+    epee::byte_slice handle(const std::string& request) override final;
 
   private:
 

--- a/src/rpc/message.cpp
+++ b/src/rpc/message.cpp
@@ -149,7 +149,7 @@ cryptonote::rpc::error FullMessage::getError()
   return err;
 }
 
-std::string FullMessage::getRequest(const std::string& request, const Message& message, const unsigned id)
+epee::byte_slice FullMessage::getRequest(const std::string& request, const Message& message, const unsigned id)
 {
   rapidjson::StringBuffer buffer;
   {
@@ -172,11 +172,11 @@ std::string FullMessage::getRequest(const std::string& request, const Message& m
     if (!dest.IsComplete())
       throw std::logic_error{"Invalid JSON tree generated"};
   }
-  return std::string{buffer.GetString(), buffer.GetSize()};
+  return epee::byte_slice{{buffer.GetString(), buffer.GetSize()}};
 }
 
 
-std::string FullMessage::getResponse(const Message& message, const rapidjson::Value& id)
+epee::byte_slice FullMessage::getResponse(const Message& message, const rapidjson::Value& id)
 {
   rapidjson::StringBuffer buffer;
   {
@@ -207,17 +207,17 @@ std::string FullMessage::getResponse(const Message& message, const rapidjson::Va
     if (!dest.IsComplete())
       throw std::logic_error{"Invalid JSON tree generated"};
   }
-  return std::string{buffer.GetString(), buffer.GetSize()};
+  return epee::byte_slice{{buffer.GetString(), buffer.GetSize()}};
 }
 
 // convenience functions for bad input
-std::string BAD_REQUEST(const std::string& request)
+epee::byte_slice BAD_REQUEST(const std::string& request)
 {
   rapidjson::Value invalid;
   return BAD_REQUEST(request, invalid);
 }
 
-std::string BAD_REQUEST(const std::string& request, const rapidjson::Value& id)
+epee::byte_slice BAD_REQUEST(const std::string& request, const rapidjson::Value& id)
 {
   Message fail;
   fail.status = Message::STATUS_BAD_REQUEST;
@@ -225,7 +225,7 @@ std::string BAD_REQUEST(const std::string& request, const rapidjson::Value& id)
   return FullMessage::getResponse(fail, id);
 }
 
-std::string BAD_JSON(const std::string& error_details)
+epee::byte_slice BAD_JSON(const std::string& error_details)
 {
   rapidjson::Value invalid;
   Message fail;

--- a/src/rpc/message.h
+++ b/src/rpc/message.h
@@ -33,6 +33,7 @@
 #include <rapidjson/writer.h>
 #include <string>
 
+#include "byte_slice.h"
 #include "rpc/message_data_structs.h"
 
 namespace cryptonote
@@ -85,8 +86,8 @@ namespace rpc
 
       cryptonote::rpc::error getError();
 
-      static std::string getRequest(const std::string& request, const Message& message, unsigned id);
-      static std::string getResponse(const Message& message, const rapidjson::Value& id);
+      static epee::byte_slice getRequest(const std::string& request, const Message& message, unsigned id);
+      static epee::byte_slice getResponse(const Message& message, const rapidjson::Value& id);
     private:
 
       FullMessage() = default;
@@ -99,10 +100,10 @@ namespace rpc
 
 
   // convenience functions for bad input
-  std::string BAD_REQUEST(const std::string& request);
-  std::string BAD_REQUEST(const std::string& request, const rapidjson::Value& id);
+  epee::byte_slice BAD_REQUEST(const std::string& request);
+  epee::byte_slice BAD_REQUEST(const std::string& request, const rapidjson::Value& id);
 
-  std::string BAD_JSON(const std::string& error_details);
+  epee::byte_slice BAD_JSON(const std::string& error_details);
 
 
 }  // namespace rpc

--- a/src/rpc/rpc_handler.h
+++ b/src/rpc/rpc_handler.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "byte_slice.h"
 #include "crypto/hash.h"
 
 namespace cryptonote
@@ -54,7 +55,7 @@ class RpcHandler
     RpcHandler() { }
     virtual ~RpcHandler() { }
 
-    virtual std::string handle(const std::string& request) = 0;
+    virtual epee::byte_slice handle(const std::string& request) = 0;
 
     static boost::optional<output_distribution_data>
       get_output_distribution(const std::function<bool(uint64_t, uint64_t, uint64_t, uint64_t&, std::vector<uint64_t>&, uint64_t&)> &f, uint64_t amount, uint64_t from_height, uint64_t to_height, const std::function<crypto::hash(uint64_t)> &get_hash, bool cumulative, uint64_t blockchain_height);


### PR DESCRIPTION
Ref: https://github.com/monero-project/monero/pull/6350

**Quote**
_Sending JSON response on the ZMQ RPC server has two allocations + copies - one into a std::string and a second internally within ZMQ. This removes that second copy (but ZMQ still allocates internally!), which is an obvious performance gain.
Its possible to remove the allocation+copy into `bye_slice` by getting `rapidjson` to write directly into a `byte_slice` compatible buffer. I am "saving" that for a future commit because its a bit more code.
I ran with this with clang ASAN mode, no memory leaks detected in the unit tests or in the ZMQ JSON-RPC server usage._
**Unquote**