### PR TITLE
[miniupnp] grab latest from official repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = monero
 [submodule "external/miniupnp"]
 	path = external/miniupnp
-	url = https://github.com/monero-project/miniupnp
-	branch = monero
+	url = https://github.com/miniupnp/miniupnp
+	branch = master
 [submodule "external/rapidjson"]
 	path = external/rapidjson
 	url = https://github.com/Tencent/rapidjson

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -37,13 +37,17 @@
 
 find_package(Miniupnpc REQUIRED)
 
+if (NOT FREEBSD)
+  set(CMAKE_C_FLAGS "-Wno-format-truncation")
+endif()
+
 message(STATUS "Using in-tree miniupnpc")
 add_subdirectory(miniupnp/miniupnpc)
 set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
 if(MSVC)
   set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
 elseif(NOT MSVC)
-  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
+  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result")
 endif()
 if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
 	set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -D_NETBSD_SOURCE")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -41,6 +41,12 @@ if (NOT FREEBSD)
   set(CMAKE_C_FLAGS "-Wno-format-truncation")
 endif()
 
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fPIC")
+set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fPIC")
+set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fPIC")
+set (CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -fPIC")
+
 message(STATUS "Using in-tree miniupnpc")
 add_subdirectory(miniupnp/miniupnpc)
 set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")


### PR DESCRIPTION
unbound is a passive networking element but the same cannot be said for miniupnp.

Since monero people rarely update their repo (from where the submodule was pulling from), it is lagging many commits from the official current master and there has been numerous bugs and critical exploits reports forcing miniupnp devs to update their code in a regular rate
https://www.vdoo.com/blog/security-issues-discovered-in-miniupnp

So point the submodule to the official miniupnp repo (master branch)

Tested in every possible environment (linux bionic xenial, freebsd, windows mingw native etc. i had access to) and building method existing (release, release-static, cross)
Seems fine