### PR TITLE
[tx pool] Used legacy category to match insert_key_images behavior

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1126,7 +1126,7 @@ namespace cryptonote
       // See `insert_key_images`.
       if (1 < found->second.size() || *(found->second.cbegin()) != txid)
         return true;
-      return m_blockchain.txpool_tx_matches_category(txid, relay_category::broadcasted);
+      return m_blockchain.txpool_tx_matches_category(txid, relay_category::legacy);
     }
     return false;
   }


### PR DESCRIPTION
Monero #6478
Fixes dandelion tx double spend detection