### PR TITLE
[difficulty] fix old 128 bit version_2

### DIFF
--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -451,7 +451,7 @@ namespace cryptonote {
     difficulty_type total_work = cumulative_difficulties[cut_end - 1] - cumulative_difficulties[cut_begin];
     assert(total_work > 0);
 
-    boost::multiprecision::uint256_t res = (boost::multiprecision::uint256_t(total_work) + adjusted_total_timespan - 1) / adjusted_total_timespan;
+    boost::multiprecision::uint256_t res = (boost::multiprecision::uint256_t(total_work) * target_seconds + adjusted_total_timespan - 1) / adjusted_total_timespan;
     if (res > max128bit)
       return 0; // to behave like previous implementation, may be better return max128bit?
     return res.convert_to<difficulty_type>();


### PR DESCRIPTION
Bug introduced on converting difficulty from 64bit to 128bit causing recently synced daemons to display a smaller cumulative difficulty than old ones