### PR TITLE
[unit_tests] fix output selection test #2

### DIFF
--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -177,7 +177,7 @@ TEST(select_outputs, density)
     float chain_ratio = count_chain / (float)n_outs;
     MDEBUG(count_selected << "/" << NPICKS << " outputs selected in blocks of density " << d << ", " << 100.0f * selected_ratio << "%");
     MDEBUG(count_chain << "/" << offsets.size() << " outputs in blocks of density " << d << ", " << 100.0f * chain_ratio << "%");
-    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.028f);
+    ASSERT_LT(fabsf(selected_ratio - chain_ratio), 0.031f);
   }
 }
 


### PR DESCRIPTION
Following https://github.com/sumoprojects/sumokoin/pull/864 comment
Quote
_(Due to the randomness 0.028 is more or less empirical it might need amendement but i think it will cover almost all cases)_
Unquote
It does need amendment after all, edge cases come up to almost 0.031. It covers them all now.