### PR TITLE
[p2p] increase whitelist connections number

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -144,7 +144,7 @@
 #define P2P_DEFAULT_PING_CONNECTION_TIMEOUT             5000       //5 seconds
 #define P2P_DEFAULT_INVOKE_TIMEOUT                      60*2*1000  //2 minutes
 #define P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT            5000       //5 seconds
-#define P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT       70
+#define P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT       75
 #define P2P_DEFAULT_ANCHOR_CONNECTIONS_COUNT            4
 #define P2P_DEFAULT_SYNC_SEARCH_CONNECTIONS_COUNT       2
 #define P2P_DEFAULT_LIMIT_RATE_UP                       2048       // kB/s

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1452,7 +1452,7 @@ namespace nodetool
       }
 
       std::deque<size_t> filtered;
-      const size_t limit = use_white_list ? 20 : std::numeric_limits<size_t>::max();
+      const size_t limit = use_white_list ? 30 : std::numeric_limits<size_t>::max();
       for (int step = 0; step < 2; ++step)
       {
         bool skip_duplicate_class_B = step == 0;


### PR DESCRIPTION
We have increased the number of default connections (doubled it) in the past and made peerlist scanning faster.
However we havent increased respectively the whitelist connection percentage thus stressing the node.