### PR TITLE
[miniupnpc] fix old clang warning about package name inconsistency

### DIFF
--- a/cmake/FindMiniupnpc.cmake
+++ b/cmake/FindMiniupnpc.cmake
@@ -35,12 +35,21 @@ set(MINIUPNP_INCLUDE_DIRS ${MINIUPNP_INCLUDE_DIR})
 set(MINIUPNP_LIBRARIES ${MINIUPNP_LIBRARY})
 set(MINIUPNP_STATIC_LIBRARIES ${MINIUPNP_STATIC_LIBRARY})
 
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Miniupnpc DEFAULT_MSG
+  MINIUPNP_INCLUDE_DIR
+  MINIUPNP_LIBRARY
+)
+else
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   MiniUPnPc DEFAULT_MSG
   MINIUPNP_INCLUDE_DIR
   MINIUPNP_LIBRARY
 )
+endif()
 
 IF(MINIUPNPC_FOUND)
   file(STRINGS "${MINIUPNP_INCLUDE_DIR}/miniupnpc.h" MINIUPNPC_API_VERSION_STR REGEX "^#define[\t ]+MINIUPNPC_API_VERSION[\t ]+[0-9]+")


### PR DESCRIPTION
that was also the case before we brought the package in 