### PR TITLE
[p2p] fix constant's name and delete obsolete constant

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -103,9 +103,8 @@
 #define DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN             DIFFICULTY_TARGET //just alias; used by tests
 
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              50     //by default, blocks count in blocks downloading
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4           1      //by default, blocks count in blocks downloading at the end of the chain
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_END          1      //by default, blocks count in blocks downloading at the end of the chain
 
 #define LAST_CHECKPOINT                                 405000
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1147,7 +1147,7 @@ namespace cryptonote
     if (get_current_blockchain_height() <= LAST_CHECKPOINT)
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
     else
-    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_V4;
+    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_END;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const


### PR DESCRIPTION
`BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4`  has no meaning for Sumo
Also fix the name of end of chain default synchronising block count name to `BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_END` so we know what it is for