### PR TITLE
[dbdrivers+crypto] fix a couple of allocated buffer overflows

### DIFF
--- a/external/db_drivers/liblmdb/mdb.c
+++ b/external/db_drivers/liblmdb/mdb.c
@@ -1081,7 +1081,7 @@ typedef struct MDB_node {
 /** @} */
 	unsigned short	mn_flags;		/**< @ref mdb_node */
 	unsigned short	mn_ksize;		/**< key size */
-	char		mn_data[1];			/**< key and data are appended here */
+	char		mn_data[8];		/**< key and data are appended here */
 } MDB_node;
 
 	/** Size of the node header, excluding dynamic data at the end */

--- a/src/crypto/tree-hash.c
+++ b/src/crypto/tree-hash.c
@@ -83,7 +83,7 @@ void tree_hash(const char (*hashes)[HASH_SIZE], size_t count, char *root_hash) {
 
     size_t cnt = tree_hash_cnt( count );
 
-    char *ints = calloc(cnt, HASH_SIZE);  // zero out as extra protection for using uninitialized mem
+    char *ints = calloc(cnt, 2 * HASH_SIZE);  // zero out as extra protection for using uninitialized mem
     assert(ints);
 
     memcpy(ints, hashes, (2 * cnt - count) * HASH_SIZE);


### PR DESCRIPTION
First one (external/db_drivers/liblmdb/mdb.c_
`char  mn_data[1];` was given a region of 1 byte and by calling memcpy we are trying to write by copying 8 bytes at the below cases
`memcpy(NODEDATA(ni), &my->mc_next_pgno, sizeof(pgno_t));`
`memcpy(ndata, &ofp->mp_pgno, sizeof(pgno_t));`
`memcpy(ndata, data->mv_data, sizeof(pgno_t));`

Second case (src/crypto/tree-hash.c )
We were allocating 32 bytes here `char *ints = calloc(cnt, HASH_SIZE);` and trying to write on it 64 bytes with memcpy below