### PR TITLE
[gcc] fix a warning for latest gcc versions

### DIFF
--- a/src/common/utf8.h
+++ b/src/common/utf8.h
@@ -43,6 +43,8 @@ namespace tools
     wint_t cp = 0;
     int bytes = 1;
     char wbuf[8], *wptr;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
     while (avail--)
     {
       if ((*ptr & 0x80) == 0)
@@ -109,6 +111,7 @@ namespace tools
       cp = 0;
       bytes = 1;
     }
+#pragma GCC diagnostic pop
     return sc;
   }
 }


### PR DESCRIPTION
```
C:/msys64/home/.../sumokoin/src/common/utf8.h:91:19: warning: comparison is always true due to limited range of data type [-Wtype-limits]
   91 |       else if (cp <= 0xffff)
      |                ~~~^~~~~~~~~
C:/msys64/home/.../sumokoin/src/common/utf8.h:93:19: warning: comparison is always true due to limited range of data type [-Wtype-limits]
   93 |       else if (cp <= 0x10ffff)
```
Its a variadic template and the code is checked twice, once when parsing and once when instantiated.
GCC doesnot understand that this warning isn't always true for all instantiations
So suppress it at this location only rather than globally in cmake. Its a useful warning and we need it otherwise