### PR TITLE
[daemon] alter sync display for windows

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -669,7 +669,11 @@ void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint6
   // size-based check
   if (need_resize(threshold_size))
   {
+#ifdef _WIN32
+    MGINFO("[batch] DB resize needed");
+#else
     MGINFO("\033[K[batch] DB resize needed\033[0m");
+#endif
     do_resize(increase_size);
   }
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1531,10 +1531,15 @@ namespace cryptonote
               }
               return true;
             });
+#ifdef _WIN32
+            MGINFO_YELLOW("Synced " << current_blockchain_height << "/" << target_blockchain_height
+                                    << progress_message << timing_message << " syncing with " << n_syncing << " remote nodes" << std::flush);
+#else
             MGINFO_YELLOW("\033[0K" << "Synced " << current_blockchain_height << "/" << target_blockchain_height << "\033[1;32m"
-              << " [" << std::string(comp_perc / 2, '=') << (comp_perc < 100 ? ">" : "") << std::string(100 / 2 - comp_perc / 2, ' ') << "]" << "\033[1;33m"
-              << progress_message << timing_message << " syncing with " << "\033[1;32m" << n_syncing << "\033[1;33m"
-              << " remote nodes" << "\033[0m" << std::flush << "\033[F");
+                                    << " [" << std::string(comp_perc / 2, '=') << (comp_perc < 100 ? ">" : "") << std::string(100 / 2 - comp_perc / 2, ' ') << "]" << "\033[1;33m"
+                                    << progress_message << timing_message << " syncing with " << "\033[1;32m" << n_syncing << "\033[1;33m"
+                                    << " remote nodes" << "\033[0m" << std::flush << "\033[F");
+#endif
             if (previous_stripe != current_stripe)
               notify_new_stripe(context, current_stripe);
           }


### PR DESCRIPTION
The sync bar and the colors, provided by the ansi escape sequences, are definitely very fancy but for windows it is a gamble cause we dont know if the user's windows system supports ansi colors or if they are enabled. If they are not that beautiful thing turns into a rubbish printout.
So remove the sync bar and the ansi coloring for windows only, keep them for all other OSs