### PR TITLE
[daemon] remove syncing prgress bar on linux

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -669,11 +669,7 @@ void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint6
   // size-based check
   if (need_resize(threshold_size))
   {
-#ifdef _WIN32
     MGINFO("[batch] DB resize needed");
-#else
-    MGINFO("\033[K[batch] DB resize needed\033[0m");
-#endif
     do_resize(increase_size);
   }
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1531,15 +1531,8 @@ namespace cryptonote
               }
               return true;
             });
-#ifdef _WIN32
             MGINFO_YELLOW("Synced " << current_blockchain_height << "/" << target_blockchain_height
                                     << progress_message << timing_message << " syncing with " << n_syncing << " remote nodes" << std::flush);
-#else
-            MGINFO_YELLOW("\033[0K" << "Synced " << current_blockchain_height << "/" << target_blockchain_height << "\033[1;32m"
-                                    << " [" << std::string(comp_perc / 2, '=') << (comp_perc < 100 ? ">" : "") << std::string(100 / 2 - comp_perc / 2, ' ') << "]" << "\033[1;33m"
-                                    << progress_message << timing_message << " syncing with " << "\033[1;32m" << n_syncing << "\033[1;33m"
-                                    << " remote nodes" << "\033[0m" << std::flush << "\033[F");
-#endif
             if (previous_stripe != current_stripe)
               notify_new_stripe(context, current_stripe);
           }


### PR DESCRIPTION
Much to my disappointment due to the recent Monero epee tool changes VT100 escape seqeunces are not properly handled by Linux (it was not only windows as I hoped for)
There goes my beloved syncing bar :( (i 'd rater lose the bar than changing code just to keep it)