### PR TITLE
[epee] change error to warning

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -771,7 +771,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     }
     if (m_was_shutdown)
     {
-      MERROR("Setting timer on a shut down object");
+      MWARNING("Setting timer on a shut down object");
       return;
     }
     if (add)


### PR DESCRIPTION
On daemon p2p shut down (especially when abruptly with `Ctrl^C` than `exit`) timers are being reset on various p2p objects while they are shutting down hence the red error on logs ` E Setting timer on a shut down object`
Its not an error though its a warning so change it as such