### PR TITLE
[rpc] remove obsolete comments

### DIFF
--- a/src/rpc/daemon_messages.h
+++ b/src/rpc/daemon_messages.h
@@ -66,11 +66,7 @@ class classname \
 #define END_RPC_MESSAGE_RESPONSE };
 #define END_RPC_MESSAGE_CLASS };
 
-// NOTE: when using a type with multiple template parameters,
-// replace any comma in the template specifier with the macro
-// above, or the preprocessor will eat the comma in a bad way.
 #define RPC_MESSAGE_MEMBER(type, name) type name = {}
-
 
 namespace cryptonote
 {


### PR DESCRIPTION
there used to be a `#define COMMA ,` there