### PR TITLE
[workflows] add an ubuntu 20.04 make release run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,26 @@ jobs:
     - name: build sumokoin
       run: make -j3
 
+  build-ubuntu-focal-fossa:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: remove bundled boost
+      run: sudo rm -rf /usr/local/share/boost
+    - name: set apt conf
+      run: |
+        echo "Acquire::Retries \"3\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+        echo "Acquire::ftp::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
+    - name: update apt
+      run: sudo apt update
+    - name: install sumokoin dependencies
+      run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev ccache
+    - name: build sumokoin
+      run: make -j3
+
   build-ubuntu-bionic-static:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
add a build to the recently added ubuntu 20 (focal fossa) environment to check compatibility with whatever latest it carries (gcc, boost and so on...)
Think that's enough with workflows for the time being