### PR TITLE
[simplewallet] print system's timestamp when generating seeds

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4759,7 +4759,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
 
   // convert rng value to electrum-style word list
   epee::wipeable_string electrum_words;
-
+  auto timenow =  chrono::system_clock::to_time_t(chrono::system_clock::now());
   crypto::ElectrumWords::bytes_to_words(recovery_val, electrum_words, mnemonic_language);
   const std::string vkey = epee::string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key);
   message_writer(console_color_cyan, true) <<
@@ -4779,10 +4779,14 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
     show_seed(electrum_words);
   }
   message_writer(console_color_red, true) << "\n" << tr("NOTE: the above 26 words can be used to recover access to your wallet. "
-    "Write them down and store them somewhere safe and secure. Please do not store them in "
+    "Write them down and store them somewhere safe and secure.\nPlease do not store them in "
     "your email or on file storage services outside of your immediate control.");
-
-   message_writer(console_color_green, true) << "Press ENTER to Continue";
+  if (!m_restoring)
+    {
+      message_writer(console_color_green, true) << "\n" << "Seed words generated at: " << ctime(&timenow);
+      message_writer(console_color_yellow, true) << tr("When restoring from seed words you may use the date above to avoid needlessly scanning the entire blockchain.") << "\n";
+    }
+  message_writer(console_color_green, true) << "Press ENTER to Continue";
    cin.ignore();
 
   return password;


### PR DESCRIPTION
There is an ongoing debate at the moment at Monero to include a 26th seed word that will contain the height and/or the timestamp of the moment the wallet was generated so that users wont scan the entire chain "by mistake" and waste time. 
I strongly disagree cause it creates legacy seed words, it will be difficult to communicate and explain and finally if a user wants to use the cli instead of the gui or the web wallet or the android then he should be acquainted with its "features" and particulars. Also Sumo has already 26 seed words with its double checksum so a 27th will be an excess that will complicate things with our webwallet, android and so on. Anyway i added a print of the system's timestamp to facilitate users so they can mark the date down along with their seed words so as they remember where to restore from
![image](https://user-images.githubusercontent.com/34991117/84534804-44d40f00-acf3-11ea-868a-2432a372ad49.png)
