### PR TITLE
[zmq] justify system error on exiting

### DIFF
--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -167,9 +167,17 @@ void log_stack_trace(const char *msg)
   ss << el::base::debug::StackTrace();
   std::vector<std::string> lines;
   std::string s = ss.str();
+  std::string s1 = "9ZmqServer5serveEv";
+  if (s.find(s1) != std::string::npos)
+  {
+   ST_LOG("Exiting and severing ZMQ thread, system error logged is due to that and can be ignored");
+  }
+  else
+  {
   boost::split(lines, s, boost::is_any_of("\n"));
   for (const auto &line: lines)
     ST_LOG(line);
+  }
 #endif
 }
 


### PR DESCRIPTION
ZMQ thread management is a bitch. 
On exiting daemon and killing ZMQ, on linux, below system error is logged 
```
2020-06-17 13:16:43.969	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:133	Exception: std::system_error
2020-06-17 13:16:43.969	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:134	Unwound call stack:
2020-06-17 13:16:43.973	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:172	    [1]  0x10d) [0x5560b16f00cd]:__cxa_throw+0x10d) [0x5560b16f00cd]
2020-06-17 13:16:43.973	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:172	    [2]  0x556) [0x5560b1874a16]:_ZN6detail6expect6throw_ESt10error_codePKcS3_j+0x556) [0x5560b1874a16]
2020-06-17 13:16:43.973	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:172	    [3]  0x53a) [0x5560b1735e0a]:_ZN10cryptonote3rpc9ZmqServer5serveEv+0x53a) [0x5560b1735e0a]
2020-06-17 13:16:43.973	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:172	    [4]  0x11bcd) [0x7f2d69ba0bcd]:_64-linux-gnu/libboost_thread.so.1.65.1(+0x11bcd) [0x7f2d69ba0bcd]
2020-06-17 13:16:43.973	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:172	    [5]  0x76db) [0x7f2d688e06db]:_64-linux-gnu/libpthread.so.0(+0x76db) [0x7f2d688e06db]
2020-06-17 13:16:43.973	    7f2ad19a9700	INFO	stacktrace	src/common/stack_trace.cpp:172	    [6]  0x3f) [0x7f2d6860988f]:_64-linux-gnu/libc.so.6(clone+0x3f) [0x7f2d6860988f]
```
That's from severing the zmq thread even though on zmq_server.cpp file, zmqserver stop void tries to end the thread properly. (on windows though this system error is not logged, i dont know if it does work there or unwind logs it and elpp does not, i guess its a thing that should be checked as well).
I tried using volatile bools, reset the linger to 0, close the socket before exiting, tried context shutdown instead of reset, the lot, i guess its a zmq thing as i see many git issues on zmq being created on that matter.
Anyhow this explains the error (see below) so that users are not confused by the daemon log 
```
2020-06-17 18:44:51.231	[SRV_MAIN]	INFO	global	src/daemon/p2p.h:80	p2p net loop stopped
2020-06-17 18:44:51.311	    7f70825ea700	INFO	stacktrace	src/common/stack_trace.cpp:133	Exception: std::system_error
2020-06-17 18:44:51.311	    7f70825ea700	INFO	stacktrace	src/common/stack_trace.cpp:134	Unwound call stack:
2020-06-17 18:44:51.313	    7f70825ea700	INFO	stacktrace	src/common/stack_trace.cpp:173	Exiting and severing ZMQ thread, system error logged is due to that and can be ignored
```
