### PR TITLE
[workflows] dont use more than one thread for openssl on xenial

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,8 @@ jobs:
         sudo tar -xf OpenSSL_1_0_2g.tar.gz
         cd openssl-OpenSSL_1_0_2g
         sudo ./config 
-        sudo make -j 3
-        sudo make install -j 3
+        sudo make
+        sudo make install
         sudo ldconfig 
         cd /home/runner/work/sumokoin/sumokoin
     - name: build sumokoin


### PR DESCRIPTION
it is very often stopping mid-building or installing most likely due to -j 3 overstretching the remote