### PR TITLE
[p2p] decrease the time we start checking for incoming connections

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -462,7 +462,7 @@ namespace nodetool
     epee::math_helper::once_a_time_seconds<1> m_connections_maker_interval;
     epee::math_helper::once_a_time_seconds<60*10, false> m_peerlist_store_interval;
     epee::math_helper::once_a_time_seconds<10> m_gray_peerlist_housekeeping_interval;
-    epee::math_helper::once_a_time_seconds<3600, false> m_incoming_connections_interval;
+    epee::math_helper::once_a_time_seconds<600, false> m_incoming_connections_interval;
 
     std::list<epee::net_utils::network_address>   m_priority_peers;
     std::vector<epee::net_utils::network_address> m_exclusive_peers;


### PR DESCRIPTION
It was checking in one hour intervals for incoming connections so setting up of IGD port mapping was kicking in late.
decreased to 10 min intervals