### PR TITLE
[unbound] fix CMAKE 3.12.0 and newer policy warning

### DIFF
--- a/external/unbound/CMakeLists.txt
+++ b/external/unbound/CMakeLists.txt
@@ -28,6 +28,10 @@
 
 cmake_minimum_required(VERSION 2.8.7)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+  cmake_policy(SET CMP0075 NEW) # cmake >= 3.12
+endif()
+
 project(unbound C)
 
 find_package(Threads)


### PR DESCRIPTION
fixes below policy warning on cmake 3.12 and beyond

```
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.
```