### PR TITLE
[core] suppress gcc+clang  Wimplicit-fallthrough warnings

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2018, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -220,7 +220,7 @@ bool create_ec_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert, int type)
   }
   openssl_group group_deleter{group};
 
-  EC_GROUP_set_asn1_flag(group, OPENSSL_EC_NAMED_CURVE); 
+  EC_GROUP_set_asn1_flag(group, OPENSSL_EC_NAMED_CURVE);
   EC_GROUP_set_point_conversion_form(group, POINT_CONVERSION_UNCOMPRESSED);
 
   if (!EC_GROUP_check(group, NULL))
@@ -285,6 +285,13 @@ ssl_options_t::ssl_options_t(std::vector<std::vector<std::uint8_t>> fingerprints
   std::sort(fingerprints_.begin(), fingerprints_.end());
 }
 
+#if __GNUC__ && defined( __has_warning )
+#if __has_warning( "-Wimplicit-fallthrough=" )
+#define SUPPRESS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough="
+#endif
+#endif
 boost::asio::ssl::context ssl_options_t::create_context() const
 {
   boost::asio::ssl::context ssl_context{boost::asio::ssl::context::sslv23};
@@ -383,6 +390,10 @@ boost::asio::ssl::context ssl_options_t::create_context() const
   return ssl_context;
 }
 
+#ifdef SUPPRESS
+#undef SUPPRESS
+#pragma GCC diagnostic pop
+#endif
 void ssl_authentication_t::use_ssl_certificate(boost::asio::ssl::context &ssl_context) const
 {
   ssl_context.use_private_key_file(private_key_path, boost::asio::ssl::context::pem);

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -747,6 +747,14 @@ namespace levin
     zone_->flush_txs.cancel();
   }
 
+// suppress "this statement may fall through" warning on gcc (>7.0) and clang, dandelion cases below are supposed to fallthrough
+#if __GNUC__ && defined( __has_warning )
+#if __has_warning( "-Wimplicit-fallthrough=" )
+#define SUPPRESS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough="
+#endif
+#endif
   bool notify::send_txs(std::vector<blobdata> txs, const boost::uuids::uuid& source, i_core_events& core, relay_method tx_relay)
   {
     if (txs.empty())
@@ -828,5 +836,9 @@ namespace levin
     }
     return true;
   }
+  #ifdef SUPPRESS
+  #undef SUPPRESS
+  #pragma GCC diagnostic pop
+  #endif
 } // levin
 } // net

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2929,7 +2929,7 @@ bool simple_wallet::set_inactivity_lock_timeout(const std::vector<std::string> &
 bool simple_wallet::disable_lock(const std::vector<std::string> &args)
 {
 #ifdef _WIN32
-  tools::fail_msg_writer() << tr("Automatic wallet lock due to inactivity is disabled on Windows"); 
+  tools::fail_msg_writer() << tr("Automatic wallet lock due to inactivity is disabled on Windows");
   return true;
 #endif
   m_wallet->inactivity_lock_timeout(-1);
@@ -6517,6 +6517,13 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
 
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
+  #if __GNUC__ && defined( __has_warning )
+  #if __has_warning( "-Wimplicit-fallthrough=" )
+  #define SUPPRESS
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wimplicit-fallthrough="
+  #endif
+  #endif
   try
   {
     // figure out what tx will be necessary
@@ -6548,6 +6555,10 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
       fail_msg_writer() << tr("No outputs found, or daemon is not ready");
       return false;
     }
+    #ifdef SUPPRESS
+    #undef SUPPRESS
+    #pragma GCC diagnostic pop
+    #endif
 
     // if we need to check for backlog, check the worst case tx
     if (m_wallet->confirm_backlog())


### PR DESCRIPTION
suppress `warning: this statement may fall through [-Wimplicit-fallthrough=]` 
In all three specific switch statements, cases are supposed to fallthrough (as commented)  which is why there is no `break`
(warning occurs on gcc 7 upwards, dont know from which version onwards it gets picked up by clang but 11.03 surely picks it up)