### PR TITLE
[clang] fix -pie linker flag for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,9 +643,12 @@ else()
   endif()
 
   # linker
-  if (NOT WIN32 AND NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
+  if (NOT WIN32 AND NOT (CMAKE_C_COMPILER_ID STREQUAL "Clang") AND NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
     # Windows binaries die on startup with PIE when compiled with GCC <9.x
     add_linker_flag_if_supported(-pie LD_SECURITY_FLAGS)
+  endif()
+  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    add_linker_flag_if_supported(-Wl, -pie LD_SECURITY_FLAGS)
   endif()
   add_linker_flag_if_supported(-Wl,-z,relro LD_SECURITY_FLAGS)
   add_linker_flag_if_supported(-Wl,-z,now LD_SECURITY_FLAGS)


### PR DESCRIPTION
fixes `clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]` (present in monero as well) since gcc is ok with `-pie` but clang needs `-Wl, -pie`