### PR TITLE
[rpc] temporary fix expected_reward

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1435,7 +1435,24 @@ namespace cryptonote
     }
     lock.commit();
 
-    expected_reward = best_coinbase;
+//this need updating before block 657450 is reached
+    if (height < 460215)
+    {
+     expected_reward = 42930000000 + best_coinbase;
+    }
+    if (height >= 460215 && height < 525960)
+    {
+     expected_reward = 53890000000 + best_coinbase;
+    }
+    if (height >= 525960 && height < 591705)
+    {
+     expected_reward = 65920000000 + best_coinbase;
+    }
+    if (height >= 591705 && height < 657450)
+    {
+     expected_reward = 53150000000 + best_coinbase;
+    }
+
     LOG_PRINT_L2("Block template filled with " << bl.tx_hashes.size() << " txes, weight "
         << total_weight << "/" << max_total_weight << ", coinbase " << print_money(best_coinbase)
         << " (including " << print_money(fee) << " in fees)");

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1435,6 +1435,16 @@ namespace cryptonote
     }
     lock.commit();
 
+#if (__GNUC__ && defined( __has_warning ))
+#if __has_warning( "-Wtautological-constant-out-of-range-compare" )
+#define SUPPRESS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+
 //this need updating before block 657450 is reached
     if (height < 460215)
     {
@@ -1452,6 +1462,12 @@ namespace cryptonote
     {
      expected_reward = 53150000000 + best_coinbase;
     }
+
+#pragma GCC diagnostic pop
+#ifdef SUPPRESS
+#undef SUPPRESS
+#pragma GCC diagnostic pop
+#endif
 
     LOG_PRINT_L2("Block template filled with " << bl.tx_hashes.size() << " txes, weight "
         << total_weight << "/" << max_total_weight << ", coinbase " << print_money(best_coinbase)


### PR DESCRIPTION
miner tx construction is ok which is why are getting fine coinbase txs but the template creation is such a mess after all dandelion additions from Monero plus our complicated emission scheme. This sloppily fixes the `estimated_reward` variable used only for rpc's `on_get_block_template`. It doesnt actually fix the coinbase reward on the template which isnt a big problem since block weight calculation is ok and txs + fees are included properly, the rest are taken care of by miner tx construction
If we keep this solution we have to update every couple of years (its ok for the next 200k blocks for now)
I ll try to fix it properly in the future (the issue seems to be there from day 1)
(I suppressed locally on the second commit a warning cause by a gcc bug in some versions https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51712)

Reported by ivan bormotov from hashvault pool