### PR TITLE
[daemon] add a ' --same-version ' option flag 

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -143,6 +143,7 @@ namespace nodetool
 
     const command_line::arg_descriptor<bool>        arg_no_igd  = {"no-igd", "Disable UPnP port mapping"};
     const command_line::arg_descriptor<std::string> arg_igd = {"igd", "UPnP port mapping (disabled, enabled, delayed)", "delayed"};
+    const command_line::arg_descriptor<bool>        arg_same_version  = {"same-version", "Connect exclusively to nodes of the same version"};
     const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6  = {"p2p-use-ipv6", "Enable IPv6 for p2p", false};
     const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4  = {"p2p-ignore-ipv4", "Ignore unsuccessful IPv4 bind for p2p", false};
     const command_line::arg_descriptor<int64_t>     arg_out_peers = {"out-peers", "set max number of out peers", -1};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -246,6 +246,7 @@ namespace nodetool
         m_allow_local_ip(false),
         m_hide_my_port(false),
         m_igd(no_igd),
+        m_same_version(false),
         m_offline(false),
         is_closing(false),
         m_network_id()
@@ -447,6 +448,7 @@ namespace nodetool
     bool m_allow_local_ip;
     bool m_hide_my_port;
     igd_t m_igd;
+    bool m_same_version;
     bool m_offline;
     bool m_use_ipv6;
     bool m_require_ipv4;
@@ -525,6 +527,7 @@ namespace nodetool
 
     extern const command_line::arg_descriptor<bool>        arg_no_igd;
     extern const command_line::arg_descriptor<std::string> arg_igd;
+    extern const command_line::arg_descriptor<bool>        arg_same_version;
     extern const command_line::arg_descriptor<bool>        arg_offline;
     extern const command_line::arg_descriptor<int64_t>     arg_out_peers;
     extern const command_line::arg_descriptor<int64_t>     arg_in_peers;
@@ -534,6 +537,7 @@ namespace nodetool
     extern const command_line::arg_descriptor<int64_t> arg_limit_rate_down;
     extern const command_line::arg_descriptor<int64_t> arg_limit_rate;
     extern const command_line::arg_descriptor<bool> arg_pad_transactions;
+
 }
 
 POP_WARNINGS

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -116,6 +116,7 @@ namespace nodetool
     command_line::add_arg(desc, arg_no_sync);
     command_line::add_arg(desc, arg_no_igd);
     command_line::add_arg(desc, arg_igd);
+    command_line::add_arg(desc, arg_same_version);
     command_line::add_arg(desc, arg_out_peers);
     command_line::add_arg(desc, arg_in_peers);
     command_line::add_arg(desc, arg_tos_flag);
@@ -361,6 +362,7 @@ namespace nodetool
     m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
     const bool has_no_igd = command_line::get_arg(vm, arg_no_igd);
     const std::string sigd = command_line::get_arg(vm, arg_igd);
+
     if (sigd == "enabled")
     {
       if (has_no_igd)
@@ -447,6 +449,9 @@ namespace nodetool
 
     if(command_line::has_arg(vm, arg_p2p_hide_my_port))
       m_hide_my_port = true;
+
+    if(command_line::has_arg(vm, arg_same_version))
+      m_same_version = true;
 
     if (command_line::has_arg(vm, arg_no_sync))
       m_payload_handler.set_no_sync(true);
@@ -2259,14 +2264,31 @@ namespace nodetool
   int node_server<t_payload_net_handler>::handle_handshake(int command, typename COMMAND_HANDSHAKE::request& arg, typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
   {
     std::string r_version = arg.node_data.version.substr(0,12);
-    if (arg.node_data.version.size() == 0)
+    if(!m_same_version)
     {
-      MINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
-    }
+      if (arg.node_data.version.size() == 0)
+      {
+        MINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier");
+      }
 
-    if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
+      if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
+      {
+        MINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << r_version);
+      }
+    }
+    else
     {
-      MINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << r_version);
+      if (arg.node_data.version.size() == 0)
+      {
+        MGINFO("Peer " << context.m_remote_address.str() << " did not provide version information it must be Morioka 0.5.1.1 or earlier. Blocking!");
+        block_host(context.m_remote_address);
+      }
+
+      if (arg.node_data.version.size() != 0 && arg.node_data.version != SUMOKOIN_VERSION)
+      {
+        MGINFO("Peer " << context.m_remote_address.str() << " has a different version than ours: " << r_version << " Blocking!");
+        block_host(context.m_remote_address);
+      }
     }
 
     if(arg.node_data.network_id != m_network_id)


### PR DESCRIPTION
**adds a ' --same-version ' option flag to chose whether we want to connect exclusively to remote nodes of the same version as ours**


![Capture3](https://user-images.githubusercontent.com/34991117/88523637-ec39a680-d000-11ea-865e-85ab54c4c4f3.JPG)
![Capture1](https://user-images.githubusercontent.com/34991117/88523694-01163a00-d001-11ea-88e6-7d8244b78826.JPG)

