### PR TITLE
[workflows] reduce threads on windows debug build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
          Invoke-Expression ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/sumogr/PageFile/master/SetPageFileSize.ps1'))
       shell: powershell
     - name: build sumokoin
-      run: make debug-static-win64 -j3
+      run: make debug-static-win64
 
   build-ubuntu-bionic:
     runs-on: ubuntu-latest


### PR DESCRIPTION
cause the pagefile is not providing enough virtual memory for 3 threads and if i increase it there is not enough space to build the huge debug binaries