### PR TITLE
[epee] fix comment + backslash

### DIFF
--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -344,8 +344,8 @@ namespace epee
   } \
   catch (const std::exception &e) { \
     MERROR("Error in handle_invoke_map: " << e.what()); \
-    return LEVIN_ERROR_CONNECTION_TIMEDOUT; /* seems kinda appropriate */ \
-  } \ 
+    return LEVIN_ERROR_CONNECTION_TIMEDOUT; \
+  } \
   }
   
   }


### PR DESCRIPTION
Fixed a whitespace after a backslash and also removed a comment cause it scares clang away thinking that the line below maybe included to the line above giving a `backslash and newline separated by space [-Wbackslash-newline-escape]` warning

