### PR TITLE
[mnemonics] replace const char* with C++17's std::string_view

### DIFF
--- a/src/mnemonics/chinese_simplified.h
+++ b/src/mnemonics/chinese_simplified.h
@@ -74,7 +74,7 @@ namespace Language
   public:
     Chinese_Simplified(): Base("简体中文 (中国)", "Chinese (simplified)", {}, 1)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
       "的",
       "一",

--- a/src/mnemonics/dutch.h
+++ b/src/mnemonics/dutch.h
@@ -51,7 +51,7 @@ namespace Language
   public:
     Dutch(): Base("Nederlands", "Dutch", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "aalglad",
         "aalscholver",

--- a/src/mnemonics/english.h
+++ b/src/mnemonics/english.h
@@ -51,7 +51,7 @@ namespace Language
   public:
     English(): Base("English", "English", {}, 3)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "abbey",
         "abducts",

--- a/src/mnemonics/english_old.h
+++ b/src/mnemonics/english_old.h
@@ -53,7 +53,7 @@ namespace Language
   public:
     EnglishOld(): Base("EnglishOld", "English (old)", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "like",
         "just",

--- a/src/mnemonics/esperanto.h
+++ b/src/mnemonics/esperanto.h
@@ -60,7 +60,7 @@ namespace Language
   public:
     Esperanto(): Base("Esperanto", "Esperanto", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
       "abako",
       "abdiki",

--- a/src/mnemonics/french.h
+++ b/src/mnemonics/french.h
@@ -51,7 +51,7 @@ namespace Language
   public:
     French(): Base("Français", "French", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "abandon",
         "abattre",

--- a/src/mnemonics/german.h
+++ b/src/mnemonics/german.h
@@ -53,7 +53,7 @@ namespace Language
   public:
     German(): Base("Deutsch", "German", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "Abakus",
         "Abart",

--- a/src/mnemonics/italian.h
+++ b/src/mnemonics/italian.h
@@ -53,7 +53,7 @@ namespace Language
   public:
     Italian(): Base("Italiano", "Italian", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "abbinare",
         "abbonato",

--- a/src/mnemonics/japanese.h
+++ b/src/mnemonics/japanese.h
@@ -73,7 +73,7 @@ namespace Language
   public:
     Japanese(): Base("日本語", "Japanese", {}, 3)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "あいこくしん",
         "あいさつ",

--- a/src/mnemonics/language_base.h
+++ b/src/mnemonics/language_base.h
@@ -163,7 +163,7 @@ namespace Language
     virtual ~Base()
     {
     }
-    void set_words(const char * const words[])
+    void set_words(std::string_view const words[])
     {
       word_list.resize(NWORDS);
       for (size_t i = 0; i < NWORDS; ++i)

--- a/src/mnemonics/lojban.h
+++ b/src/mnemonics/lojban.h
@@ -58,7 +58,7 @@ namespace Language
   public:
     Lojban(): Base("Lojban", "Lojban", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
       "backi",
       "bacru",

--- a/src/mnemonics/portuguese.h
+++ b/src/mnemonics/portuguese.h
@@ -74,7 +74,7 @@ namespace Language
   public:
     Portuguese(): Base("Português", "Portuguese", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "abaular",
         "abdominal",

--- a/src/mnemonics/russian.h
+++ b/src/mnemonics/russian.h
@@ -53,7 +53,7 @@ namespace Language
   public:
     Russian(): Base("русский язык", "Russian", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "абажур",
         "абзац",

--- a/src/mnemonics/spanish.h
+++ b/src/mnemonics/spanish.h
@@ -74,7 +74,7 @@ namespace Language
   public:
     Spanish(): Base("Español", "Spanish", {}, 4)
     {
-      static constexpr const char * const words[NWORDS] =
+      static constexpr std::string_view const words[NWORDS] =
       {
         "ábaco",
         "abdomen",


### PR DESCRIPTION
Some of the benefits of C++17...
Make seed words list creation much faster by replacing `const char *` with `std::string_view`