### PR TITLE
[checkpoints] update last checkpoint on config.h

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -106,7 +106,7 @@
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              50     //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_END          1      //by default, blocks count in blocks downloading at the end of the chain
 
-#define LAST_CHECKPOINT                                 435000
+#define LAST_CHECKPOINT                                 446000
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                  (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME   604800 //seconds, one week


### PR DESCRIPTION
it should have been updated in our latest release as well (it uses the last checkpoint height to drop the block sync size to 1 from 50 after the precompiled blocks.dat file is exhausted) it will drop to 1 at 435000 instead of 446000 no big deal