### PR TITLE
[python-rpc] add missing sync_txpool python entry point and add missing error when an entry point is missing

### DIFF
--- a/tests/functional_tests/check_missing_rpc_methods.py
+++ b/tests/functional_tests/check_missing_rpc_methods.py
@@ -46,5 +46,6 @@ for module in modules:
         name = name[1:]
       if not hasattr(module['object'], name):
         print('Error: %s API method %s does not have a matching function' % (module['name'], name))
+        error = True
 
 sys.exit(1 if error else 0)

--- a/utils/python-rpc/framework/daemon.py
+++ b/utils/python-rpc/framework/daemon.py
@@ -552,6 +552,16 @@ class Daemon(object):
         }
         return self.rpc.send_json_rpc_request(flush_cache)
 
+  def sync_txpool(self):
+      sync_txpool = {
+           'method': 'sync_txpool',
+           'params': {
+           },
+           'jsonrpc': '2.0',
+           'id': '0'
+       }
+       return self.rpc.send_json_rpc_request(sync_txpool)        
+
     def rpc_access_info(self, client):
         rpc_access_info = {
             'method': 'rpc_access_info',


### PR DESCRIPTION
Ref Monero # 6593