### PR TITLE
[simplewallet + daemon] Add new 'search_command' command

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -548,6 +548,31 @@ eof:
       return it->second.second;
     }
 
+    std::vector<std::string> get_command_list(const std::vector<std::string>& keywords = std::vector<std::string>())
+    {
+      std::vector<std::string> list;
+      list.reserve(m_command_handlers.size());
+      for(auto const& x:m_command_handlers)
+      {
+        bool take = true;
+        for(auto const& y:keywords)
+        {
+          bool in_usage = x.second.second.first.find(y) != std::string::npos;
+          bool in_description = x.second.second.second.find(y) != std::string::npos;
+          if (!(in_usage || in_description))
+          {
+            take = false;
+            break;
+          }
+        }
+        if (take)
+        {
+          list.push_back(x.first);
+        }
+      }
+      return list;
+    }
+        
     void set_handler(const std::string& cmd, const callback& hndlr, const std::string& usage = "", const std::string& description = "")
     {
       lookup::mapped_type & vt = m_command_handlers[cmd];
@@ -621,7 +646,7 @@ eof:
       }
       catch (const std::exception &e) { /* ignore */ }
     }
-    
+
     bool start_handling(std::function<std::string(void)> prompt, const std::string& usage_string = "", std::function<void(void)> exit_handler = NULL)
     {
       m_console_thread.reset(new boost::thread(boost::bind(&console_handlers_binder::run_handling, this, prompt, usage_string, exit_handler)));

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -58,6 +58,12 @@ t_command_server::t_command_server(
     , "Show the help section or the documentation about a <command>."
     );
   m_command_lookup.set_handler(
+      "search_command"
+    , std::bind(&t_command_server::search_command, this, p::_1)
+    , "search_command <keyword> [<keyword> ...]"
+    , "Search all command descriptions for keyword(s)."
+    );
+  m_command_lookup.set_handler(
       "print_height"
     , std::bind(&t_command_parser_executor::print_height, &m_parser, p::_1)
     , "Print the local blockchain height."
@@ -371,7 +377,7 @@ bool t_command_server::start_handling(std::function<void(void)> exit_handler)
 {
   if (m_is_rpc) return false;
 
-  m_command_lookup.start_handling("", get_commands_str(), exit_handler);
+  m_command_lookup.start_handling("", "Use \"help\" to list all commands and their usage\n", exit_handler);
 
   return true;
 }
@@ -396,6 +402,33 @@ bool t_command_server::help(const std::vector<std::string>& args)
   return true;
 }
 
+bool t_command_server::search_command(const std::vector<std::string>& args)
+{
+  if (args.empty())
+  {
+    std::cout << "Missing keyword" << std::endl;
+    return true;
+  }
+  const std::vector<std::string>& command_list = m_command_lookup.get_command_list(args);
+  if (command_list.empty())
+  {
+    std::cout << "Nothing found" << std::endl;
+    return true;
+  }
+
+  std::cout << std::endl;
+  for(auto const& command:command_list)
+  {
+    std::vector<std::string> cmd;
+    cmd.push_back(command);
+    std::pair<std::string, std::string> documentation = m_command_lookup.get_documentation(cmd);
+    std::cout << "  " << documentation.first << std::endl;
+  }
+  std::cout << std::endl;
+
+  return true;
+}
+
 std::string t_command_server::get_commands_str()
 {
   std::stringstream ss;
@@ -404,7 +437,7 @@ std::string t_command_server::get_commands_str()
   std::string usage = m_command_lookup.get_usage();
   boost::replace_all(usage, "\n", "\n  ");
   usage.insert(0, "  ");
-  ss << usage << std::endl;
+  ss << usage;
   return ss.str();
 }
 

--- a/src/daemon/command_server.h
+++ b/src/daemon/command_server.h
@@ -10,23 +10,23 @@ Passing RPC commands:
 */
 
 // Copyright (c) 2014-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -73,6 +73,7 @@ public:
 
 private:
   bool help(const std::vector<std::string>& args);
+  bool search_command(const std::vector<std::string>& args);
 
   std::string get_commands_str();
   std::string get_command_usage(const std::vector<std::string> &args);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -269,7 +269,8 @@ namespace
   const char* USAGE_STOP_MINING_FOR_RPC("stop_mining_for_rpc");
   const char* USAGE_SHOW_QR_CODE("show_qr_code [<subaddress_index>]");
   const char* USAGE_VERSION("version");
-  const char* USAGE_HELP("help [<command>]");
+  const char* USAGE_HELP("help [<command>] | all");
+  const char* USAGE_SEARCH_COMMAND("search_command <keyword> [<keyword> ...]");
 
   std::string input_line(const std::string& prompt, bool yesno = false)
   {
@@ -3056,10 +3057,36 @@ bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<st
 {
   if(args.empty())
   {
+    message_writer() << "";
+    message_writer() << tr("Important commands:");
+    message_writer() << "";
+    message_writer() << tr("\"welcome\" - Show welcome message.");
+    message_writer() << tr("\"help all\" - Show the list of all available commands.");
+    message_writer() << tr("\"help <command>\" - Show a command's documentation.");
+    message_writer() << tr("\"search_command <keyword>\" - Show commands related to a keyword.");
+    message_writer() << "";
+    message_writer() << tr("\"wallet_info\" - Show wallet main address and other info.");
+    message_writer() << tr("\"balance\" - Show balance.");
+    message_writer() << tr("\"address all\" - Show all addresses.");
+    message_writer() << tr("\"address new\" - Create new subaddress.");
+    message_writer() << tr("\"transfer <address> <amount>\" - Send XMR to an address.");
+    message_writer() << tr("\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.");
+    message_writer() << tr("\"sweep_all <address>\" - Send whole balance to another wallet.");
+    message_writer() << tr("\"seed\" - Show secret 25 words that can be used to recover this wallet.");
+    message_writer() << tr("\"refresh\" - Synchronize wallet with the Monero network.");
+    message_writer() << tr("\"status\" - Check current status of wallet.");
+    message_writer() << tr("\"version\" - Check software version.");
+    message_writer() << tr("\"exit\" - Exit wallet.");
+    message_writer() << "";
+    message_writer() << tr("\"donate <amount>\" - Donate XMR to the development team.");
+    message_writer() << "";
+ }
+ else if ((args.size() == 1) && (args.front() == "all"))
+ {
     success_msg_writer() << get_commands_str();
-  }
-  else if ((args.size() == 2) && (args.front() == "mms"))
-  {
+ }
+ else if ((args.size() == 2) && (args.front() == "mms"))
+ {
     // Little hack to be able to do "help mms <subcommand>"
     std::vector<std::string> mms_args(1, args.front() + " " + args.back());
     success_msg_writer() << get_command_usage(mms_args);
@@ -3068,6 +3095,33 @@ bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<st
   {
     success_msg_writer() << get_command_usage(args);
   }
+  return true;
+}
+
+bool simple_wallet::search_command(const std::vector<std::string> &args)
+{
+  if (args.empty())
+  {
+    PRINT_USAGE(USAGE_SEARCH_COMMAND);
+    return true;
+  }
+  const std::vector<std::string>& command_list = m_cmd_binder.get_command_list(args);
+  if (command_list.empty())
+  {
+    fail_msg_writer() << tr("No commands found mentioning keyword(s)");
+    return true;
+  }
+
+  success_msg_writer() << "";
+  for(auto const& command:command_list)
+  {
+    std::vector<std::string> cmd;
+    cmd.push_back(command);
+    std::pair<std::string, std::string> documentation = m_cmd_binder.get_documentation(cmd);
+    success_msg_writer() << "  " << documentation.first;
+  }
+  success_msg_writer() << "";
+
   return true;
 }
 
@@ -3451,7 +3505,7 @@ simple_wallet::simple_wallet()
                               "<subcommand> is one of:\n"
                               "  init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help\n"
                               "  send_signer_config, start_auto_config, stop_auto_config, auto_config, config_checksum\n"
-                              "Get help about a subcommand with: help_advanced mms <subcommand>"));
+                              "Get help about a subcommand with: help mms <subcommand>"));
   m_cmd_binder.set_handler("mms init",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
                            tr(USAGE_MMS_INIT),
@@ -3617,6 +3671,10 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::help, BOOST_PLACEHOLDERS::_1),
                            tr(USAGE_HELP),
                            tr("Show the help section or the documentation about a <command>."));
+  m_cmd_binder.set_handler("search_command",
+                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::search_command, BOOST_PLACEHOLDERS::_1),
+                            tr(USAGE_SEARCH_COMMAND),
+                            tr("Search all command descriptions for keyword(s)"));
   m_cmd_binder.set_unknown_command_handler(boost::bind(&simple_wallet::on_command, this, &simple_wallet::on_unknown_command, BOOST_PLACEHOLDERS::_1));
   m_cmd_binder.set_empty_command_handler(boost::bind(&simple_wallet::on_empty_command, this));
   m_cmd_binder.set_cancel_handler(boost::bind(&simple_wallet::on_cancelled_command, this));
@@ -5050,7 +5108,8 @@ std::optional<epee::wipeable_string> simple_wallet::open_wallet(const boost::pro
   }
   success_msg_writer() <<
     "**********************************************************************\n" <<
-    tr("Use the \"help\" command to see the list of available commands.\n") <<
+    tr("Use the \"help\" command to see a simplified list of available commands.\n") <<
+    tr("Use \"help all\" command to see the list of all available commands.\n") <<
     tr("Use \"help <command>\" to see a command's documentation.\n") <<
     "**********************************************************************\n" <<
     tr("NOTES:\n") <<
@@ -11232,7 +11291,7 @@ void simple_wallet::mms_help(const std::vector<std::string> &args)
 {
   if (args.size() > 1)
   {
-    fail_msg_writer() << tr("Usage: mms help [<subcommand>]");
+    fail_msg_writer() << tr("Usage: help mms [<subcommand>]");
     return;
   }
   std::vector<std::string> help_args;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -155,6 +155,7 @@ namespace cryptonote
     bool set_auto_mine_for_rpc_payment_threshold(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_credits_target(const std::vector<std::string> &args = std::vector<std::string>());
     bool help(const std::vector<std::string> &args = std::vector<std::string>());
+    bool search_command(const std::vector<std::string> &args);    
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);
     bool set_daemon(const std::vector<std::string> &args);


### PR DESCRIPTION
This is partially based on Monero # 6614 where they reverted the help_advanced configuration (we reverted that ourselves some months ago) and added a command to search wallet's or daemon's command help list by keyword.
They named the command `apropos` (i guess to sound sophisticated) i renamed it to `search_command` and adjusted the code for sumo
Anyhow, it's useful, i ll use that tool to search the address book entries by keyword on description on a next pr 