### PR TITLE
[epee] add clear method to byte_stream

### DIFF
--- a/contrib/epee/include/byte_stream.h
+++ b/contrib/epee/include/byte_stream.h
@@ -117,6 +117,9 @@ namespace epee
       check(more);
     }
 
+    //! Reset write position, but do not release internal memory. \post `size() == 0`.
+    void clear() noexcept { next_write_ = buffer_.get(); }    
+
     /*! Copy `length` bytes starting at `ptr` to end of stream.
         \throw std::range_error If exceeding max size_t value.
         \throw std::bad_alloc If allocation fails. */
@@ -221,4 +224,3 @@ namespace epee
     dest.put_n(ch, count);
   }
 } // epee
-

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -706,7 +706,7 @@ TEST(ByteSlice, TakeSlice)
 
   EXPECT_FALSE(slice.empty());
   EXPECT_EQ(slice.cbegin(), slice.data());
-  
+
   const epee::byte_slice slice2 = slice.take_slice(remove_size);
 
   EXPECT_EQ(original.begin() + remove_size, slice.begin());
@@ -1115,6 +1115,47 @@ TEST(ByteStream, ToByteSlice)
   EXPECT_EQ(nullptr, empty_slice.end());
   EXPECT_EQ(nullptr, empty_slice.cend());
   EXPECT_EQ(nullptr, empty_slice.data());
+}
+
+TEST(ByteStream, Clear)
+{
+  static constexpr const std::uint8_t source[] =
+    {0xde, 0xad, 0xbe, 0xef, 0xef};
+
+  epee::byte_stream stream{4};
+
+  EXPECT_EQ(4u, stream.increase_size());
+
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.capacity());
+
+  stream.clear();
+
+  EXPECT_EQ(nullptr, stream.data());
+  EXPECT_EQ(nullptr, stream.tellp());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(0u, stream.available());
+  EXPECT_EQ(0u, stream.capacity());
+
+  stream.write({source, 3});
+  std::uint8_t const* const loc = stream.data();
+
+  EXPECT_EQ(loc, stream.data());
+  EXPECT_EQ(loc + 3, stream.tellp());
+  EXPECT_EQ(3u, stream.size());
+  EXPECT_EQ(1u, stream.available());
+  EXPECT_EQ(4u, stream.capacity());
+
+  stream.clear();
+
+  EXPECT_EQ(loc, stream.data());
+  EXPECT_EQ(loc, stream.tellp());
+  EXPECT_EQ(0u, stream.size());
+  EXPECT_EQ(4u, stream.available());
+  EXPECT_EQ(4u, stream.capacity());
 }
 
 TEST(ToHex, String)


### PR DESCRIPTION
Monero Ref # 6769