### PR TITLE
[daemon+p2p] add option to ban nodes permanently

### DIFF
--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -29,6 +29,7 @@
 #include "common/dns_utils.h"
 #include "common/command_line.h"
 #include "daemon/command_parser_executor.h"
+#include <fstream>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "daemon"
@@ -596,6 +597,15 @@ bool t_command_parser_executor::ban(const std::vector<std::string>& args)
     if (seconds == 0)
     {
       return false;
+    }
+    if (seconds == -1)
+    {
+      seconds = 999999999;
+      std::ofstream permanently_banned_ips;
+      MCLOG_CYAN(el::Level::Info, "global", "Exporting host " << args[0] << " to permanently banned IPs list");
+      permanently_banned_ips.open("bannedips", std::ios_base::app);
+      permanently_banned_ips << args[0] << "\n";
+      permanently_banned_ips.close();
     }
   }
   return m_executor.ban(ip, seconds);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -253,8 +253,8 @@ t_command_server::t_command_server(
     m_command_lookup.set_handler(
       "ban"
     , std::bind(&t_command_parser_executor::ban, &m_parser, p::_1)
-    , "ban <IP> [<seconds>]"
-    , "Ban a given <IP> for a given amount of <seconds>."
+    , "ban <IP> [<seconds> (-1 for permanent ban)]"
+    , "Ban a given <IP> for a given amount of <seconds>. Permanently ban the IP if seconds = -1"
     );
     m_command_lookup.set_handler(
       "unban"


### PR DESCRIPTION
Added the ability to permanent ban an IP by typing on daemon `ban <IP> -1`
This besides banning the IP permanently, on that daemon instance, exports the permanently banned IPs on a file called "bannedips" which is read every time a new daemon instance starts and all the IPs contained in that file are autobanned indefinitely.
(permanently banned ips can be removed by editing that file)