### PR TITLE
[ringsize] increase ring size to 59 and require consistent ring size for mixable txes

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -203,6 +203,7 @@
 #define DEFAULT_MIXIN                                   12     // default & minimum mixin allowed
 #define MAX_MIXIN                                       240
 #define DEFAULT_MIXIN_V2                                48
+#define DEFAULT_MIXIN_V3                                58
 
 #define TRANSACTION_WEIGHT_LIMIT                        ((uint64_t) ((CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 110 / 100) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE))
 #define BLOCK_SIZE_GROWTH_FAVORED_ZONE                  ((uint64_t) (CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4))
@@ -219,6 +220,8 @@
 #define HF_VERSION_EXACT_COINBASE                         10
 #define HF_VERSION_CLSAG                                  10
 #define HF_VERSION_DETERMINISTIC_UNLOCK_TIME              10
+#define HF_VERSION_MIN_MIXIN_58                           10
+#define HF_VERSION_SAME_MIXIN                             10
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS                 6
 #define HASH_OF_HASHES_STEP                              512

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -174,7 +174,7 @@ namespace cryptonote
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, txin, false);
-      if (txin.key_offsets.size() - 1 < (version <  7 ? DEFAULT_MIXIN : DEFAULT_MIXIN_V2)){
+      if (txin.key_offsets.size() - 1 < (version >= HF_VERSION_MIN_MIXIN_58 ? DEFAULT_MIXIN_V3 : version >= 7 ? DEFAULT_MIXIN_V2 : DEFAULT_MIXIN)){
         mixin_too_low = true;
         break;
       }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7454,6 +7454,8 @@ int wallet2::get_fee_algorithm()
 //------------------------------------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_min_ring_size()
 {
+  if (use_fork_rules(10, 10))
+    return DEFAULT_MIXIN_V3 + 1;
   if (use_fork_rules(7, 10))
     return DEFAULT_MIXIN_V2 + 1;
   return DEFAULT_MIXIN + 1;


### PR DESCRIPTION
CLSAG (compact signature scheme) will decrease the tx size by 25% and improve the tx verification performance by 20%.
the current 49 ringsize seems to give reasonable tx sizes and verification speed so we can increase it by almost 20% (to 59) along with the implementation of CLSAG.
Also added a consistent ringsize implementation as per Monero (it was checked by MLSAG (CLSAG) verification anyhow) 
Next ringsize increase will be at "triptych" implementation which is way further up the road