### PR TITLE
[crypto] fix warnings on obscure old c code in jh.c

### DIFF
--- a/src/crypto/jh.c
+++ b/src/crypto/jh.c
@@ -216,13 +216,13 @@ static void F8(hashState *state)
       uint64  i;
 
       /*xor the 512-bit message with the fist half of the 1024-bit hash state*/
-      for (i = 0; i < 8; i++)  state->x[i >> 1][i & 1] ^= ((uint64*)state->buffer)[i];
+      for (i = 0; i < 8; i++)  ((uint64*)state->x)[i] ^= ((uint64*)state->buffer)[i];
 
       /*the bijective function E8 */
       E8(state);
 
       /*xor the 512-bit message with the second half of the 1024-bit hash state*/
-      for (i = 0; i < 8; i++)  state->x[(8+i) >> 1][(8+i) & 1] ^= ((uint64*)state->buffer)[i];
+      for (i = 0; i < 8; i++)  ((uint64*)state->x)[8+i] ^= ((uint64*)state->buffer)[i];
 }
 
 /*before hashing a message, initialize the hash state as H0 */


### PR DESCRIPTION
stole this workaround from another coin (loki) which was getting a stuck blockchain caused by inability to hash beyond a certain block due to the way this pointer part was optimized when compiled with gcc 10.
We were just getting uninitialized warnings which are now gone.
Synced from scratch all the way, it is fine.
