### PR TITLE
[block_sync_size] revert the default to 10 blocks per batch

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -102,10 +102,7 @@
 #define DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN             DIFFICULTY_TARGET //just alias; used by tests
 
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              50     //by default, blocks count in blocks downloading
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_END          1      //by default, blocks count in blocks downloading at the end of the chain
-
-#define LAST_CHECKPOINT                                 446000
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              10     //by default, blocks count in blocks downloading
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                  (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME   604800 //seconds, one week

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1151,10 +1151,8 @@ namespace cryptonote
   {
     if (block_sync_size > 0)
       return block_sync_size;
-    if (get_current_blockchain_height() <= LAST_CHECKPOINT)
+
     return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT;
-    else
-    return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_END;
   }
   //-----------------------------------------------------------------------------------------------
   bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const


### PR DESCRIPTION
revert it to 10 from 50  (the gain in time is almost zero) and revert the end of chain decrease to 1 (which was buggy) for the same reason