### PR TITLE
[daemon] mention when we leave the compiled block hashes area and syncing is dealyed

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1540,8 +1540,18 @@ namespace cryptonote
               }
               return true;
             });
-            MGINFO_YELLOW("Synced " << current_blockchain_height << "/" << target_blockchain_height
+
+            if (m_core.is_within_compiled_block_hash_area(current_blockchain_height))
+            {
+              MGINFO_YELLOW("Synced " << current_blockchain_height << "/" << target_blockchain_height
                                     << progress_message << timing_message << " syncing with " << n_syncing << " remote nodes" << std::flush);
+            }
+            else
+            {
+              MGINFO_YELLOW("Synced " << current_blockchain_height << "/" << target_blockchain_height
+                                    << progress_message << timing_message << " syncing with " << n_syncing << " remote nodes (no compiled block hashes - syncing will be slow)" << std::flush);
+            }
+
             if (previous_stripe != current_stripe)
               notify_new_stripe(context, current_stripe);
           }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/34991117/94370060-4684df80-00f6-11eb-8f71-a19c2e4b8e48.png)

it displays the same from 0 block when we are in not fast sync mode `--fast-block-sync=0`
