### PR TITLE
[boost->std] replace boost::bind with std::bind where possible

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -464,13 +464,8 @@ eof:
   template<class t_server, class t_handler>
   bool run_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, std::function<std::string(void)> prompt, const std::string& usage = "")
   {
-#if BOOST_VERSION >= 106100
     async_console_handler console_handler;
-    return console_handler.run(ptsrv, boost::bind<bool>(no_srv_param_adapter<t_server, t_handler>, boost::placeholders::_1, boost::placeholders::_2, handlr), prompt, usage);
-#else
-    async_console_handler console_handler;
-    return console_handler.run(ptsrv, boost::bind<bool>(no_srv_param_adapter<t_server, t_handler>, _1, _2, handlr), prompt, usage);
-#endif
+    return console_handler.run(ptsrv, std::bind<bool>(no_srv_param_adapter<t_server, t_handler>, std::placeholders::_1, std::placeholders::_2, handlr), prompt, usage);
   }
 
   template<class t_server, class t_handler>
@@ -482,7 +477,7 @@ eof:
   template<class t_server, class t_handler>
   bool start_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, std::function<std::string(void)> prompt, const std::string& usage = "")
   {
-    boost::thread( boost::bind(run_default_console_handler_no_srv_param<t_server, t_handler>, ptsrv, handlr, prompt, usage) );
+    boost::thread( std::bind(run_default_console_handler_no_srv_param<t_server, t_handler>, ptsrv, handlr, prompt, usage) );
     return true;
   }
 
@@ -507,9 +502,9 @@ eof:
   bool start_default_console2(t_handler handlr, const std::string& usage = "")
   {
     //std::string usage_local = usage;
-    boost::thread( boost::bind(default_console_handler2<t_handler>, handlr, usage) );
-    //boost::function<bool ()> p__ = boost::bind(f<t_handler>, 1, handlr);
-    //boost::function<bool ()> p__ = boost::bind(default_console_handler2<t_handler>, handlr, usage);
+    boost::thread( std::bind(default_console_handler2<t_handler>, handlr, usage) );
+    //boost::function<bool ()> p__ = std::bind(f<t_handler>, 1, handlr);
+    //boost::function<bool ()> p__ = std::bind(default_console_handler2<t_handler>, handlr, usage);
     //boost::thread tr(p__);
     return true;
   }*/
@@ -572,7 +567,7 @@ eof:
       }
       return list;
     }
-        
+
     void set_handler(const std::string& cmd, const callback& hndlr, const std::string& usage = "", const std::string& description = "")
     {
       lookup::mapped_type & vt = m_command_handlers[cmd];
@@ -649,7 +644,7 @@ eof:
 
     bool start_handling(std::function<std::string(void)> prompt, const std::string& usage_string = "", std::function<void(void)> exit_handler = NULL)
     {
-      m_console_thread.reset(new boost::thread(boost::bind(&console_handlers_binder::run_handling, this, prompt, usage_string, exit_handler)));
+      m_console_thread.reset(new boost::thread(std::bind(&console_handlers_binder::run_handling, this, prompt, usage_string, exit_handler)));
       return true;
     }
     bool start_handling(const std::string &prompt, const std::string& usage_string = "", std::function<void(void)> exit_handler = NULL)
@@ -664,11 +659,7 @@ eof:
 
     bool run_handling(std::function<std::string(void)> prompt, const std::string& usage_string, std::function<void(void)> exit_handler = NULL)
     {
-#if BOOST_VERSION >= 106100
-      return m_console_handler.run(boost::bind(&console_handlers_binder::process_command_str, this, boost::placeholders::_1), prompt, usage_string, exit_handler);
-#else
-      return m_console_handler.run(boost::bind(&console_handlers_binder::process_command_str, this, _1), prompt, usage_string, exit_handler);
-#endif
+      return m_console_handler.run(std::bind(&console_handlers_binder::process_command_str, this, std::placeholders::_1), prompt, usage_string, exit_handler);
     }
 
     void print_prompt()
@@ -690,13 +681,13 @@ eof:
   //public:
   //  bool start_handling(t_server* psrv, const std::string& prompt, const std::string& usage_string = "")
   //  {
-  //    boost::thread(boost::bind(&srv_console_handlers_binder<t_server>::run_handling, this, psrv, prompt, usage_string)).detach();
+  //    boost::thread(std::bind(&srv_console_handlers_binder<t_server>::run_handling, this, psrv, prompt, usage_string)).detach();
   //    return true;
   //  }
 
   //  bool run_handling(t_server* psrv, const std::string& prompt, const std::string& usage_string)
   //  {
-  //    return m_console_handler.run(psrv, boost::bind(&srv_console_handlers_binder<t_server>::process_command_str, this, boost::placeholders::_1, boost::placeholders::_2), prompt, usage_string);
+  //    return m_console_handler.run(psrv, std::bind(&srv_console_handlers_binder<t_server>::process_command_str, this, std::placeholders::_1, std::placeholders::_2), prompt, usage_string);
   //  }
 
   //  void stop_handling()

--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -207,7 +207,7 @@ namespace net_utils
   {
     boosted_tcp_server(const boosted_tcp_server&) = delete;
     boosted_tcp_server& operator=(const boosted_tcp_server&) = delete;
-        
+
     enum try_connect_result_t
     {
       CONNECT_SUCCESS,
@@ -325,7 +325,7 @@ namespace net_utils
         std::shared_ptr<idle_callback_conext<t_handler>> ptr(new idle_callback_conext<t_handler>(io_service_, t_callback, timeout_ms));
         //needed call handler here ?...
         ptr->m_timer.expires_from_now(boost::posix_time::milliseconds(ptr->m_period));
-        ptr->m_timer.async_wait(boost::bind(&boosted_tcp_server<t_protocol_handler>::global_timer_handler<t_handler>, this, ptr));
+        ptr->m_timer.async_wait(std::bind(&boosted_tcp_server<t_protocol_handler>::global_timer_handler<t_handler>, this, ptr));
         return true;
       }
 
@@ -336,7 +336,7 @@ namespace net_utils
       if(!ptr->call_handler())
         return true;
       ptr->m_timer.expires_from_now(boost::posix_time::milliseconds(ptr->m_period));
-      ptr->m_timer.async_wait(boost::bind(&boosted_tcp_server<t_protocol_handler>::global_timer_handler<t_handler>, this, ptr));
+      ptr->m_timer.async_wait(std::bind(&boosted_tcp_server<t_protocol_handler>::global_timer_handler<t_handler>, this, ptr));
       return true;
     }
 

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -46,13 +46,6 @@
 #include "net/local_ip.h"
 #include "pragma_comp_defs.h"
 
-#define BOOST_BIND_GLOBAL_PLACEHOLDERS
-#if BOOST_VERSION >= 106100
-#define BOOST_PLACEHOLDERS boost::placeholders
-#else
-#define BOOST_PLACEHOLDERS
-#endif
-
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
@@ -255,7 +248,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     if(!self)
       return false;
 
-    strand_.post(boost::bind(&connection<t_protocol_handler>::call_back_starter, self));
+    strand_.post(std::bind(&connection<t_protocol_handler>::call_back_starter, self));
     CATCH_ENTRY_L0("connection<t_protocol_handler>::request_callback()", false);
     return true;
   }
@@ -696,7 +689,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
         reset_timer(get_default_timeout(), false);
             async_write(boost::asio::buffer(m_send_que.front().data(), size_now ) ,
                                  strand_.wrap(
-                                 boost::bind(&connection<t_protocol_handler>::handle_write, self, BOOST_PLACEHOLDERS::_1, BOOST_PLACEHOLDERS::_2)
+                                 std::bind(&connection<t_protocol_handler>::handle_write, self, std::placeholders::_1, std::placeholders::_2)
                                  )
                                  );
         //_dbg3("(chunk): " << size_now);
@@ -902,7 +895,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 		CHECK_AND_ASSERT_MES( size_now == m_send_que.front().size(), void(), "Unexpected queue size");
 		  async_write(boost::asio::buffer(m_send_que.front().data(), size_now) ,
            strand_.wrap(
-            boost::bind(&connection<t_protocol_handler>::handle_write, connection<t_protocol_handler>::shared_from_this(), BOOST_PLACEHOLDERS::_1, BOOST_PLACEHOLDERS::_2)
+            std::bind(&connection<t_protocol_handler>::handle_write, connection<t_protocol_handler>::shared_from_this(), std::placeholders::_1, std::placeholders::_2)
 			  )
           );
       //_dbg3("(normal)" << size_now);
@@ -1175,7 +1168,7 @@ POP_WARNINGS
       for (std::size_t i = 0; i < threads_count; ++i)
       {
         std::shared_ptr<boost::thread> thread(new boost::thread(
-          attrs, boost::bind(&boosted_tcp_server<t_protocol_handler>::worker_thread, this)));
+          attrs, std::bind(&boosted_tcp_server<t_protocol_handler>::worker_thread, this)));
           _note("Run server thread name: " << m_thread_name_prefix);
         m_threads.push_back(thread);
       }
@@ -1411,11 +1404,7 @@ POP_WARNINGS
     {
       shared_context->connect_mut.lock(); shared_context->ec = ec_; shared_context->cond.notify_one(); shared_context->connect_mut.unlock();
     };
-#if BOOST_VERSION >= 106100
-    sock_.async_connect(remote_endpoint, boost::bind<void>(connect_callback, BOOST_PLACEHOLDERS::_1, local_shared_context));
-#else
-    sock_.async_connect(remote_endpoint, boost::bind<void>(connect_callback, _1, local_shared_context));
-#endif
+    sock_.async_connect(remote_endpoint, std::bind<void>(connect_callback, std::placeholders::_1, local_shared_context));
     while(local_shared_context->ec == boost::asio::error::would_block)
     {
       bool r = local_shared_context->cond.timed_wait(lock, boost::get_system_time() + boost::posix_time::milliseconds(conn_timeout));

--- a/contrib/epee/include/net/abstract_tcp_server_cp.inl
+++ b/contrib/epee/include/net/abstract_tcp_server_cp.inl
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,7 +22,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 #pragma comment(lib, "Ws2_32.lib")
@@ -34,7 +34,7 @@ namespace epee
 {
 namespace net_utils
 {
-template<class TProtocol> 
+template<class TProtocol>
 cp_server_impl<TProtocol>::cp_server_impl():
 									m_port(0), m_stop(false),
 									m_worker_thread_counter(0), m_listen_socket(INVALID_SOCKET)
@@ -47,11 +47,11 @@ cp_server_impl<TProtocol>::~cp_server_impl()
 	deinit_server();
 }
 //-------------------------------------------------------------
-template<class TProtocol> 
+template<class TProtocol>
 bool cp_server_impl<TProtocol>::init_server(int port_no)
 {
 	m_port = port_no;
-	
+
 	WSADATA wsad = {0};
 	int err = ::WSAStartup(MAKEWORD(2,2), &wsad);
 	if ( err != 0  || LOBYTE( wsad.wVersion ) != 2 || HIBYTE( wsad.wVersion ) != 2 )
@@ -59,7 +59,7 @@ bool cp_server_impl<TProtocol>::init_server(int port_no)
 		LOG_ERROR("Could not find a usable WinSock DLL, err = " << err << " \"" << socket_errors::get_socket_error_text(err) <<"\"");
 		return false;
 	}
-	
+
 	m_initialized = true;
 
 	m_listen_socket = ::WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
@@ -133,7 +133,7 @@ static int CALLBACK CPConditionFunc(
 		LOG_PRINT("Maximum connections count overfull.", LOG_LEVEL_2);
 		return CF_REJECT;
 	}*/
-	
+
 	return  CF_ACCEPT;
 }
 //-------------------------------------------------------------
@@ -154,7 +154,7 @@ unsigned CALLBACK cp_server_impl<TProtocol>::worker_thread(void* param)
 	return 1;
 }
 //-------------------------------------------------------------
-template<class TProtocol> 
+template<class TProtocol>
 bool cp_server_impl<TProtocol>::worker_thread_member()
 {
 	LOG_PRINT("Worker thread STARTED", LOG_LEVEL_1);
@@ -165,7 +165,7 @@ bool cp_server_impl<TProtocol>::worker_thread_member()
 		DWORD bytes_transfered = 0;
 		connection<TProtocol>* pconnection = 0;
 		io_data_base* pio_data = 0;
-		
+
 		{
 			PROFILE_FUNC("[worker_thread]GetQueuedCompletionStatus");
 			BOOL res = ::GetQueuedCompletionStatus (m_completion_port, &bytes_transfered ,	(PULONG_PTR)&pconnection, (LPOVERLAPPED *)&pio_data, INFINITE);
@@ -238,7 +238,7 @@ bool cp_server_impl<TProtocol>::worker_thread_member()
 
 		}
 
-		//preparing new request, 
+		//preparing new request,
 
 		{
 			PROFILE_FUNC("[worker_thread]RECV Request small loop");
@@ -291,23 +291,23 @@ bool cp_server_impl<TProtocol>::worker_thread_member()
 		}
 	}
 
-	
+
 	LOG_PRINT("Worker thread STOPED", LOG_LEVEL_1);
 	::InterlockedDecrement(&m_worker_thread_counter);
 	return true;
 }
 //-------------------------------------------------------------
-template<class TProtocol> 
+template<class TProtocol>
 bool cp_server_impl<TProtocol>::shutdown_connection(connection<TProtocol>* pconn)
 {
 	PROFILE_FUNC("[shutdown_connection]");
-	
+
 	if(!pconn)
 	{
 		LOG_ERROR("Attempt to remove null pptr connection!");
 		return false;
 	}
-	else 
+	else
 	{
 		LOG_PRINT("Shutting down connection ("<< pconn << ")", LOG_LEVEL_3);
 	}
@@ -355,7 +355,7 @@ bool cp_server_impl<TProtocol>::shutdown_connection(connection<TProtocol>* pconn
 	return true;
 }
 //-------------------------------------------------------------
-template<class TProtocol> 
+template<class TProtocol>
 bool cp_server_impl<TProtocol>::run_server(int threads_count = 0)
 {
 	int err = listen(m_listen_socket, 100);
@@ -374,7 +374,7 @@ bool cp_server_impl<TProtocol>::run_server(int threads_count = 0)
 	}
 	for(int i = 0; i != threads_count; i++)
 	{
-		boost::thread(boost::bind(&cp_server_impl::worker_thread_member, this));
+		boost::thread(std::bind(&cp_server_impl::worker_thread_member, this));
 		//HANDLE h_thread = threads_helper::create_thread(worker_thread, this);
 		InterlockedIncrement(&m_worker_thread_counter);
 		//::CloseHandle(h_thread);
@@ -397,7 +397,7 @@ bool cp_server_impl<TProtocol>::run_server(int threads_count = 0)
 			PROFILE_FUNC("[run_server] select");
 			select_res = select(0, &sock_set, &sock_set, NULL, &tv);
 		}
-		
+
 		if(SOCKET_ERROR == select_res)
 		{
 			err = ::WSAGetLastError();
@@ -418,7 +418,7 @@ bool cp_server_impl<TProtocol>::run_server(int threads_count = 0)
 				PROFILE_FUNC("[run_server] WSAAccept");
 				new_sock = ::WSAAccept(m_listen_socket, (sockaddr *)&adr_from, &adr_len, CPConditionFunc, (DWORD_PTR)this);
 			}
-			
+
 			if(INVALID_SOCKET == new_sock)
 			{
 				if(m_stop)
@@ -432,7 +432,7 @@ bool cp_server_impl<TProtocol>::run_server(int threads_count = 0)
 				PROFILE_FUNC("[run_server] Add new connection");
 				add_new_connection(new_sock, adr_from.sin_addr.s_addr, adr_from.sin_port);
 			}
-			
+
 		}
 
 	}
@@ -474,7 +474,7 @@ template<class TProtocol>
 bool cp_server_impl<TProtocol>::add_new_connection(SOCKET new_sock, const network_address &address_from)
 {
 	PROFILE_FUNC("[add_new_connection]");
-	
+
 	LOG_PRINT("Add new connection zone: entering lock", LOG_LEVEL_3);
 	m_connections_lock.lock();
 
@@ -535,7 +535,7 @@ bool cp_server_impl<TProtocol>::add_new_connection(SOCKET new_sock, const networ
 				//shutdown_connection(&conn);
 				break;
 			}
-			
+
 
 			break;
 			/*else if(0 == res)
@@ -600,7 +600,7 @@ bool cp_server_impl<TProtocol>::send_stop_signal()
 template<class TProtocol>
 bool cp_server_impl<TProtocol>::is_stop_signal()
 {
-	return m_stop?true:false;	
+	return m_stop?true:false;
 }
 //-------------------------------------------------------------
 }

--- a/contrib/epee/include/net/levin_client_async.h
+++ b/contrib/epee/include/net/levin_client_async.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,7 +22,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 #pragma once
@@ -40,10 +40,10 @@ namespace levin
 {
 
   /************************************************************************
-  *    levin_client_async - probably it is not really fast implementation, 
-  *                each handler thread could make up to 30 ms latency. 
+  *    levin_client_async - probably it is not really fast implementation,
+  *                each handler thread could make up to 30 ms latency.
   *                But, handling events in reader thread will cause dead locks in
-  *                case of recursive call (call invoke() to the same connection 
+  *                case of recursive call (call invoke() to the same connection
   *                on reader thread on remote invoke() handler)
   ***********************************************************************/
 
@@ -76,10 +76,10 @@ namespace levin
 		};
 		std::list<packet_entry> m_recieved_packets;
     /*
-       m_current_connection_index needed when some connection was broken and reconnected - in this 
-                  case we could have some received packets in que, which shoud not be handled 
+       m_current_connection_index needed when some connection was broken and reconnected - in this
+                  case we could have some received packets in que, which shoud not be handled
     */
-		volatile uint32_t m_current_connection_index; 
+		volatile uint32_t m_current_connection_index;
 		::critical_section m_invoke_lock;
 		::critical_section m_reciev_packet_lock;
     ::critical_section m_connection_lock;
@@ -119,15 +119,15 @@ namespace levin
 			CRITICAL_REGION_BEGIN(m_reciev_packet_lock);
 			CRITICAL_REGION_BEGIN(m_send_lock);
 			res = levin_client_impl::connect(ip, port, timeout);
-			boost::interprocess::ipcdetail::atomic_inc32(&m_current_connection_index); 
+			boost::interprocess::ipcdetail::atomic_inc32(&m_current_connection_index);
 			CRITICAL_REGION_END();
 			CRITICAL_REGION_END();
 			if(res && !boost::interprocess::ipcdetail::atomic_read32(&m_threads_count) )
 			{
 				//boost::interprocess::ipcdetail::atomic_write32(&m_is_stop, 0);//m_is_stop = false;
-				boost::thread( boost::bind(&levin_duplex_client::reciever_thread, this) );
-				boost::thread( boost::bind(&levin_duplex_client::handler_thread, this) );
-				boost::thread( boost::bind(&levin_duplex_client::handler_thread, this) );
+				boost::thread( std::bind(&levin_duplex_client::reciever_thread, this) );
+				boost::thread( std::bind(&levin_duplex_client::handler_thread, this) );
+				boost::thread( std::bind(&levin_duplex_client::handler_thread, this) );
 			}
 
 			return res;
@@ -157,7 +157,7 @@ namespace levin
 		}
 
 		//------------------------------------------------------------------------------
-		inline 
+		inline
 			bool recv_n(SOCKET s, char* pbuff, size_t cb)
 		{
 			while(cb)
@@ -191,7 +191,7 @@ namespace levin
 		//------------------------------------------------------------------------------
 		inline
 			bool recv_n(SOCKET s, std::string& buff)
-		{	
+		{
 			size_t cb_remain = buff.size();
 			char*  m_current_ptr = (char*)buff.data();
 			return recv_n(s, m_current_ptr, cb_remain);
@@ -201,7 +201,7 @@ namespace levin
 		{
 			//boost::interprocess::ipcdetail::atomic_write32(&m_is_stop, 1);//m_is_stop = true;
 			loop_call_guard();
-			critical_region cr(m_cs);			
+			critical_region cr(m_cs);
 			levin_client_impl::disconnect();
 
 			CRITICAL_REGION_BEGIN(m_local_invoke_buff_lock);
@@ -230,11 +230,11 @@ namespace levin
 
 			boost::interprocess::ipcdetail::atomic_write32(&m_invoke_is_active, 1);
 			boost::interprocess::ipcdetail::atomic_write32(&m_invoke_data_ready, 0);
-			misc_utils::destr_ptr hdlr = misc_utils::add_exit_scope_handler(boost::bind(&levin_duplex_client::on_leave_invoke, this));
+			misc_utils::destr_ptr hdlr = misc_utils::add_exit_scope_handler(std::bind(&levin_duplex_client::on_leave_invoke, this));
 
 			loop_call_guard();
-			
-			if(!check_connection())				
+
+			if(!check_connection())
 				return LEVIN_ERROR_CONNECTION_DESTROYED;
 
 
@@ -278,19 +278,19 @@ namespace levin
 			size_t timeout_count = 0;
 			boost::unique_lock<boost::mutex> lock(m_invoke_event);
 
-			while(!boost::interprocess::ipcdetail::atomic_read32(&m_invoke_data_ready))    
+			while(!boost::interprocess::ipcdetail::atomic_read32(&m_invoke_data_ready))
 			{
 				if(!m_invoke_cond.timed_wait(lock, timeout))
 				{
 					if(timeout_count < 10)
 					{
-						//workaround to avoid freezing at timed_wait called after notify_all. 
+						//workaround to avoid freezing at timed_wait called after notify_all.
 						timeout = boost::get_system_time()+ boost::posix_time::milliseconds(100);
 						++timeout_count;
 						continue;
 					}else if(timeout_count == 10)
 					{
-						//workaround to avoid freezing at timed_wait called after notify_all. 
+						//workaround to avoid freezing at timed_wait called after notify_all.
 						timeout = boost::get_system_time()+ boost::posix_time::minutes(10);
 						++timeout_count;
 						continue;
@@ -298,18 +298,18 @@ namespace levin
 					{
 						LOG_PRINT("[" << m_socket <<"] Timeout on waiting invoke result. ", LOG_LEVEL_0);
 						//disconnect();
-						return LEVIN_ERROR_CONNECTION_TIMEDOUT;	
+						return LEVIN_ERROR_CONNECTION_TIMEDOUT;
 					}
 				}
 			}
-			
-			
+
+
 			CRITICAL_REGION_BEGIN(m_local_invoke_buff_lock);
 			buff_out.swap(m_local_invoke_buff);
 			m_local_invoke_buff.clear();
 			CRITICAL_REGION_END();
 			return m_invoke_res;
-		}	
+		}
 
 		int notify(const GUID& target, int command, const std::string& in_buff)
 		{
@@ -352,7 +352,7 @@ namespace levin
 			return 1;
 		}
 
-		
+
 	private:
 		bool have_some_data(SOCKET sock, int interval = 1)
 		{
@@ -411,15 +411,15 @@ namespace levin
 
 			conn_index = boost::interprocess::ipcdetail::atomic_read32(&m_current_connection_index);
 
-			if(head.m_signature!=LEVIN_SIGNATURE) 
+			if(head.m_signature!=LEVIN_SIGNATURE)
 			{
 				LOG_ERROR("Signature mismatch in response");
 				return false;
 			}
-			
+
 			is_request = (head.m_protocol_version == LEVIN_PROTOCOL_VER_1 && head.m_flags&LEVIN_PACKET_REQUEST);
-			
-			
+
+
 			local_buff.resize((size_t)head.m_cb);
 			if(!recv_n(m_socket, local_buff))
 			{
@@ -445,14 +445,14 @@ namespace levin
 				*/
 			}else
 			{//this is some response
-				
+
 				CRITICAL_REGION_BEGIN(m_local_invoke_buff_lock);
 				m_local_invoke_buff.swap(local_buff);
 				m_invoke_res = head.m_return_code;
 				CRITICAL_REGION_END();
 				boost::interprocess::ipcdetail::atomic_write32(&m_invoke_data_ready, 1); //m_invoke_data_ready = true;
 				m_invoke_cond.notify_all();
-				
+
 			}
 			return true;
 		}
@@ -487,7 +487,7 @@ namespace levin
 					}
 				}
 			}
-			
+
 			boost::interprocess::ipcdetail::atomic_dec32(&m_threads_count);
 			LOG_PRINT_L3("[" << m_socket <<"] Socket reciever thread stopped.[m_threads_count=" << m_threads_count << "]");
 			return true;
@@ -503,7 +503,7 @@ namespace levin
 				std::string return_buff;
 				if(m_pcommands_handler)
 					head.m_return_code = m_pcommands_handler->invoke(head.m_id, head.m_command, local_buff, return_buff, conn_context);
-				else 
+				else
 					head.m_return_code = LEVIN_ERROR_CONNECTION_HANDLER_NOT_DEFINED;
 
 
@@ -567,7 +567,7 @@ namespace levin
 				if(have_some_work)
 				{
 					process_recieved_packet(bh, local_buff, conn_index);
-				}else 
+				}else
 				{
 					//Idle when no work
 					Sleep(30);

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -376,7 +376,7 @@ public:
   void request_callback()
   {
     misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-      boost::bind(&async_protocol_handler::finish_outer_call, this));
+      std::bind(&async_protocol_handler::finish_outer_call, this));
 
     m_pservice_endpoint->request_callback();
   }
@@ -608,7 +608,7 @@ public:
   bool async_invoke(int command, const epee::span<const uint8_t> in_buff, const callback_t &cb, size_t timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
   {
     misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-      boost::bind(&async_protocol_handler::finish_outer_call, this));
+      std::bind(&async_protocol_handler::finish_outer_call, this));
 
     if(timeout == LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
       timeout = m_config.m_invoke_timeout;
@@ -662,7 +662,7 @@ public:
   int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out)
   {
     misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-                                      boost::bind(&async_protocol_handler::finish_outer_call, this));
+                                      std::bind(&async_protocol_handler::finish_outer_call, this));
 
     if(m_deletion_initiated)
       return LEVIN_ERROR_CONNECTION_DESTROYED;
@@ -714,7 +714,7 @@ public:
   int notify(int command, const epee::span<const uint8_t> in_buff)
   {
     misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-                          boost::bind(&async_protocol_handler::finish_outer_call, this));
+                          std::bind(&async_protocol_handler::finish_outer_call, this));
 
     if(m_deletion_initiated)
       return LEVIN_ERROR_CONNECTION_DESTROYED;
@@ -742,7 +742,7 @@ public:
   int send(byte_slice message)
   {
     const misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-      boost::bind(&async_protocol_handler::finish_outer_call, this)
+      std::bind(&async_protocol_handler::finish_outer_call, this)
     );
 
     if(m_deletion_initiated)

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,7 +22,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 
@@ -77,8 +77,8 @@ namespace net_utils
 			CONNECT_NO_SSL,
 		};
 
-		
-		
+
+
 				struct handler_obj
 				{
 					handler_obj(boost::system::error_code& error,	size_t& bytes_transferred):ref_error(error), ref_bytes_transferred(bytes_transferred)
@@ -252,11 +252,11 @@ namespace net_utils
 			m_connector = std::move(connector);
 		}
 
-		inline 
+		inline
 		bool disconnect()
 		{
 			try
-			{	
+			{
 				if(m_connected)
 				{
 					m_connected = false;
@@ -279,7 +279,7 @@ namespace net_utils
 		}
 
 
-		inline 
+		inline
 		bool send(const std::string& buff, std::chrono::milliseconds timeout)
 		{
 
@@ -297,14 +297,14 @@ namespace net_utils
 				// Start the asynchronous operation itself. The boost::lambda function
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
-				// can use boost::bind rather than boost::lambda.
+				// can use std::bind rather than boost::lambda.
 				async_write(buff.c_str(), buff.size(), ec);
 
 				// Block until the asynchronous operation has completed.
 				while (ec == boost::asio::error::would_block)
 				{
 					m_io_service.reset();
-					m_io_service.run_one(); 
+					m_io_service.run_one();
 				}
 
 				if (ec)
@@ -333,7 +333,7 @@ namespace net_utils
 			return true;
 		}
 
-		inline 
+		inline
 			bool send(const void* data, size_t sz)
 		{
 			try
@@ -351,7 +351,7 @@ namespace net_utils
 				// Start the asynchronous operation itself. The boost::lambda function
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
-				// can use boost::bind rather than boost::lambda.
+				// can use std::bind rather than boost::lambda.
 				boost::asio::async_write(m_socket, boost::asio::buffer(data, sz), boost::lambda::var(ec) = boost::lambda::_1);
 
 				// Block until the asynchronous operation has completed.
@@ -400,7 +400,7 @@ namespace net_utils
 			return true;
 		}
 
-		inline 
+		inline
 		bool recv(std::string& buff, std::chrono::milliseconds timeout)
 		{
 
@@ -421,23 +421,23 @@ namespace net_utils
 				// Start the asynchronous operation itself. The boost::lambda function
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
-				// can use boost::bind rather than boost::lambda.
+				// can use std::bind rather than boost::lambda.
 
 				boost::system::error_code ec = boost::asio::error::would_block;
 				size_t bytes_transfered = 0;
-			
+
 				handler_obj hndlr(ec, bytes_transfered);
 
 				static const size_t max_size = 16384;
 				buff.resize(max_size);
-				
+
 				async_read(&buff[0], max_size, boost::asio::transfer_at_least(1), hndlr);
 
 				// Block until the asynchronous operation has completed.
 				while (ec == boost::asio::error::would_block && !boost::interprocess::ipcdetail::atomic_read32(&m_shutdowned))
 				{
 					m_io_service.reset();
-					m_io_service.run_one(); 
+					m_io_service.run_one();
 				}
 
 
@@ -507,20 +507,20 @@ namespace net_utils
 				// Start the asynchronous operation itself. The boost::lambda function
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
-				// can use boost::bind rather than boost::lambda.
+				// can use std::bind rather than boost::lambda.
 
 				buff.resize(static_cast<size_t>(sz));
 				boost::system::error_code ec = boost::asio::error::would_block;
 				size_t bytes_transfered = 0;
 
-				
+
 				handler_obj hndlr(ec, bytes_transfered);
 				async_read((char*)buff.data(), buff.size(), boost::asio::transfer_at_least(buff.size()), hndlr);
-				
+
 				// Block until the asynchronous operation has completed.
 				while (ec == boost::asio::error::would_block && !boost::interprocess::ipcdetail::atomic_read32(&m_shutdowned))
 				{
-					m_io_service.run_one(); 
+					m_io_service.run_one();
 				}
 
 				if (ec)
@@ -559,7 +559,7 @@ namespace net_utils
 
 			return false;
 		}
-		
+
 		bool shutdown()
 		{
 			m_deadline.cancel();
@@ -579,7 +579,7 @@ namespace net_utils
       m_connected = false;
 			return true;
 		}
-		
+
 		boost::asio::io_service& get_io_service()
 		{
 			return m_io_service;
@@ -622,7 +622,7 @@ namespace net_utils
 			}
 
 			// Put the actor back to sleep.
-			m_deadline.async_wait(boost::bind(&blocked_mode_client::check_deadline, this));
+			m_deadline.async_wait(std::bind(&blocked_mode_client::check_deadline, this));
 		}
 
 		void shutdown_ssl() {
@@ -646,7 +646,7 @@ namespace net_utils
 			    )
 				MDEBUG("Problems at ssl shutdown: " << ec.message());
 		}
-		
+
 	protected:
 		bool write(const void* data, size_t sz, boost::system::error_code& ec)
 		{
@@ -657,24 +657,24 @@ namespace net_utils
 				success = boost::asio::write(m_ssl_socket->next_layer(), boost::asio::buffer(data, sz), ec);
 			return success;
 		}
-		
-		void async_write(const void* data, size_t sz, boost::system::error_code& ec) 
+
+		void async_write(const void* data, size_t sz, boost::system::error_code& ec)
 		{
 			if(m_ssl_options.support != ssl_support_t::e_ssl_support_disabled)
 				boost::asio::async_write(*m_ssl_socket, boost::asio::buffer(data, sz), boost::lambda::var(ec) = boost::lambda::_1);
 			else
 				boost::asio::async_write(m_ssl_socket->next_layer(), boost::asio::buffer(data, sz), boost::lambda::var(ec) = boost::lambda::_1);
 		}
-		
+
 		void async_read(char* buff, size_t sz, boost::asio::detail::transfer_at_least_t transfer_at_least, handler_obj& hndlr)
 		{
 			if(m_ssl_options.support == ssl_support_t::e_ssl_support_disabled)
 				boost::asio::async_read(m_ssl_socket->next_layer(), boost::asio::buffer(buff, sz), transfer_at_least, hndlr);
 			else
 				boost::asio::async_read(*m_ssl_socket, boost::asio::buffer(buff, sz), transfer_at_least, hndlr);
-			
+
 		}
-		
+
 	protected:
 		boost::asio::io_service m_io_service;
 		boost::asio::ssl::context m_ctx;
@@ -711,7 +711,7 @@ namespace net_utils
 		{
 			m_send_deadline.cancel();
 		}
-		
+
 		bool shutdown()
 		{
 			blocked_mode_client::shutdown();
@@ -719,7 +719,7 @@ namespace net_utils
 			return true;
 		}
 
-		inline 
+		inline
 			bool send(const void* data, size_t sz)
 		{
 			try
@@ -737,7 +737,7 @@ namespace net_utils
 				// Start the asynchronous operation itself. The boost::lambda function
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
-				// can use boost::bind rather than boost::lambda.
+				// can use std::bind rather than boost::lambda.
 				boost::asio::async_write(m_socket, boost::asio::buffer(data, sz), boost::lambda::var(ec) = boost::lambda::_1);
 
 				// Block until the asynchronous operation has completed.
@@ -745,11 +745,11 @@ namespace net_utils
 				{
 					m_io_service.run_one();
 				}*/
-				
+
 				boost::system::error_code ec;
 
 				size_t writen = write(data, sz, ec);
-				
+
 				if (!writen || ec)
 				{
 					LOG_PRINT_L3("Problems at write: " << ec.message());
@@ -798,9 +798,8 @@ namespace net_utils
 			}
 
 			// Put the actor back to sleep.
-			m_send_deadline.async_wait(boost::bind(&async_blocked_mode_client::check_send_deadline, this));
+			m_send_deadline.async_wait(std::bind(&async_blocked_mode_client::check_send_deadline, this));
 		}
 	};
 }
 }
-

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,7 +22,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 #pragma once
 
@@ -30,12 +30,6 @@
 #include <boost/utility/value_init.hpp>
 #include "span.h"
 #include "net/levin_base.h"
-
-#if BOOST_VERSION >= 106100
-#define BOOST_PLACEHOLDERS boost::placeholders
-#else
-#define BOOST_PLACEHOLDERS
-#endif
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net"
@@ -145,7 +139,7 @@ namespace epee
       std::string buff_to_send;
       stg.store_to_binary(buff_to_send);
       on_levin_traffic(context, true, true, false, buff_to_send.size(), command);
-      int res = transport.invoke_async(command, epee::strspan<uint8_t>(buff_to_send), conn_id, [cb, command](int code, const epee::span<const uint8_t> buff, typename t_transport::connection_context& context)->bool 
+      int res = transport.invoke_async(command, epee::strspan<uint8_t>(buff_to_send), conn_id, [cb, command](int code, const epee::span<const uint8_t> buff, typename t_transport::connection_context& context)->bool
       {
         t_result result_struct = AUTO_VAL_INIT(result_struct);
         if( code <=0 )
@@ -263,14 +257,14 @@ namespace epee
   { \
   bool handled = false; \
   return handle_invoke_map(false, command, in_buff, buff_out, context, handled); \
-  } 
+  }
 
 #define CHAIN_LEVIN_NOTIFY_MAP2(context_type) \
   int notify(int command, const epee::span<const uint8_t> in_buff, context_type& context) \
   { \
   bool handled = false; std::string fake_str;\
   return handle_invoke_map(true, command, in_buff, fake_str, context, handled); \
-  } 
+  }
 
 
 #define CHAIN_LEVIN_INVOKE_MAP() \
@@ -278,20 +272,20 @@ namespace epee
   { \
   bool handled = false; \
   return handle_invoke_map(false, command, in_buff, buff_out, context, handled); \
-  } 
+  }
 
 #define CHAIN_LEVIN_NOTIFY_MAP() \
   int notify(int command, const epee::span<const uint8_t> in_buff, epee::net_utils::connection_context_base& context) \
   { \
   bool handled = false; std::string fake_str;\
   return handle_invoke_map(true, command, in_buff, fake_str, context, handled); \
-  } 
+  }
 
 #define CHAIN_LEVIN_NOTIFY_STUB() \
   int notify(int command, const epee::span<const uint8_t> in_buff, epee::net_utils::connection_context_base& context) \
   { \
   return -1; \
-  } 
+  }
 
 #define BEGIN_INVOKE_MAP2(owner_type) \
   template <class t_context> int handle_invoke_map(bool is_notify, int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, t_context& context, bool& handled) \
@@ -301,20 +295,20 @@ namespace epee
 
 #define HANDLE_INVOKE2(command_id, func, type_name_in, typename_out) \
   if(!is_notify && command_id == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in, typename_out>(this, command, in_buff, buff_out, boost::bind(func, this, BOOST_PLACEHOLDERS::_1, BOOST_PLACEHOLDERS::_2, BOOST_PLACEHOLDERS::_3, BOOST_PLACEHOLDERS::_4), context);}
+  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in, typename_out>(this, command, in_buff, buff_out, std::bind(func, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), context);}
 
 #define HANDLE_INVOKE_T2(COMMAND, func) \
   if(!is_notify && COMMAND::ID == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename COMMAND::request, typename COMMAND::response>(command, in_buff, buff_out, boost::bind(func, this, BOOST_PLACEHOLDERS::_1, BOOST_PLACEHOLDERS::_2, BOOST_PLACEHOLDERS::_3, BOOST_PLACEHOLDERS::_4), context);}
+  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename COMMAND::request, typename COMMAND::response>(command, in_buff, buff_out, std::bind(func, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), context);}
 
 
 #define HANDLE_NOTIFY2(command_id, func, type_name_in) \
   if(is_notify && command_id == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in>(this, command, in_buff, boost::bind(func, this, BOOST_PLACEHOLDERS::_1, BOOST_PLACEHOLDERS::_2, BOOST_PLACEHOLDERS::_3), context);}
+  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, type_name_in>(this, command, in_buff, std::bind(func, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), context);}
 
 #define HANDLE_NOTIFY_T2(NOTIFY, func) \
   if(is_notify && NOTIFY::ID == command) \
-  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename NOTIFY::request>(this, command, in_buff, boost::bind(func, this, BOOST_PLACEHOLDERS::_1, BOOST_PLACEHOLDERS::_2, BOOST_PLACEHOLDERS::_3), context);}
+  {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename NOTIFY::request>(this, command, in_buff, std::bind(func, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), context);}
 
 #define CHAIN_INVOKE_MAP2(func) \
   { \
@@ -347,7 +341,6 @@ namespace epee
     return LEVIN_ERROR_CONNECTION_TIMEDOUT; \
   } \
   }
-  
+
   }
 }
-

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -84,7 +84,7 @@ void threadpool::create(unsigned int max_threads) {
   size_t i = max ? max - 1 : 0;
   running = true;
   while(i--) {
-    threads.push_back(boost::thread(attrs, boost::bind(&threadpool::run, this, false)));
+    threads.push_back(boost::thread(attrs, std::bind(&threadpool::run, this, false)));
   }
 }
 

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -241,7 +241,7 @@ namespace cryptonote
     boost::interprocess::ipcdetail::atomic_write32(&m_stop, 0);
     boost::interprocess::ipcdetail::atomic_write32(&m_thread_index, 0);
     for(size_t i = 0; i != m_threads_total; i++)
-      m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
+      m_threads.push_back(boost::thread(m_attrs, std::bind(&miner::worker_thread, this)));
   }
   //-----------------------------------------------------------------------------------------------------
   void miner::init_options(boost::program_options::options_description& desc)
@@ -343,7 +343,7 @@ namespace cryptonote
 
     for(size_t i = 0; i != m_threads_total; i++)
     {
-      m_threads.push_back(boost::thread(m_attrs, boost::bind(&miner::worker_thread, this)));
+      m_threads.push_back(boost::thread(m_attrs, std::bind(&miner::worker_thread, this)));
     }
 
     if (threads_count == 0)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3835,7 +3835,7 @@ leave:
     }
   }
 #endif
-  if (!fast_check)  
+  if (!fast_check)
   {
     auto it = m_blocks_longhash_table.find(id);
     if (it != m_blocks_longhash_table.end())
@@ -4428,7 +4428,7 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
       {
         m_sync_counter = 0;
         m_bytes_to_sync = 0;
-        m_async_service.dispatch(boost::bind(&Blockchain::store_blockchain, this));
+        m_async_service.dispatch(std::bind(&Blockchain::store_blockchain, this));
       }
       else if(m_db_sync_mode == db_sync)
       {
@@ -4738,7 +4738,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
         unsigned nblocks = batches;
         if (i < extra)
           ++nblocks;
-        tpool.submit(&waiter, boost::bind(&Blockchain::block_longhash_worker, this, thread_height, epee::span<const block>(&blocks[thread_height - height], nblocks), std::ref(maps[i])), true);
+        tpool.submit(&waiter, std::bind(&Blockchain::block_longhash_worker, this, thread_height, epee::span<const block>(&blocks[thread_height - height], nblocks), std::ref(maps[i])), true);
         thread_height += nblocks;
       }
 
@@ -4881,7 +4881,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
     for (size_t i = 0; i < amounts.size(); i++)
     {
       uint64_t amount = amounts[i];
-      tpool.submit(&waiter, boost::bind(&Blockchain::output_scan_worker, this, amount, std::cref(offset_map[amount]), std::ref(tx_map[amount])), true);
+      tpool.submit(&waiter, std::bind(&Blockchain::output_scan_worker, this, amount, std::cref(offset_map[amount]), std::ref(tx_map[amount])), true);
     }
     if (!waiter.wait())
       return false;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1644,13 +1644,13 @@ namespace cryptonote
       m_starter_message_showed = true;
     }
 
-    m_txpool_auto_relayer.do_call(boost::bind(&core::relay_txpool_transactions, this));
-    m_check_updates_interval.do_call(boost::bind(&core::check_updates, this));
-    m_check_disk_space_interval.do_call(boost::bind(&core::check_disk_space, this));
-    m_block_rate_interval.do_call(boost::bind(&core::check_block_rate, this));
-    m_blockchain_pruning_interval.do_call(boost::bind(&core::update_blockchain_pruning, this));
-    m_ok_status.do_call(boost::bind(&core::check_sync_status, this));
-    m_version_check.do_call(boost::bind(&core::check_version, this));
+    m_txpool_auto_relayer.do_call(std::bind(&core::relay_txpool_transactions, this));
+    m_check_updates_interval.do_call(std::bind(&core::check_updates, this));
+    m_check_disk_space_interval.do_call(std::bind(&core::check_disk_space, this));
+    m_block_rate_interval.do_call(std::bind(&core::check_block_rate, this));
+    m_blockchain_pruning_interval.do_call(std::bind(&core::update_blockchain_pruning, this));
+    m_ok_status.do_call(std::bind(&core::check_sync_status, this));
+    m_version_check.do_call(std::bind(&core::check_version, this));
     m_miner.on_idle();
     m_mempool.on_idle();
     return true;
@@ -1678,11 +1678,11 @@ namespace cryptonote
     bool avail, valid;
     std::vector<std::string> version = tools::DNSResolver::instance().get_txt_record("sumoversion.pw", avail, valid);
     std::string current_version = std::string(SUMOKOIN_VERSION) + " " + std::string(SUMOKOIN_RELEASE_NAME);
-   
+
    for (auto& ver : version)
    {
       if (current_version != ver)
-        MWARNING("Your current version of Sumokoin (" << current_version << ") is obsolete, please upgrade to the lastest version ("<< ver << ")" <<ENDL); 
+        MWARNING("Your current version of Sumokoin (" << current_version << ") is obsolete, please upgrade to the lastest version ("<< ver << ")" <<ENDL);
    }
 
    return true;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -976,7 +976,7 @@ namespace cryptonote
           fluff_txs.push_back(std::move(tx));
           break;
         default:
-        case relay_method::forward: // not supposed to happen here        
+        case relay_method::forward: // not supposed to happen here
         case relay_method::none:
           break;
       }
@@ -1610,9 +1610,9 @@ skip:
   template<class t_core>
   bool t_cryptonote_protocol_handler<t_core>::on_idle()
   {
-    m_idle_peer_kicker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::kick_idle_peers, this));
-    m_standby_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::check_standby_peers, this));
-    m_sync_search_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::update_sync_search, this));
+    m_idle_peer_kicker.do_call(std::bind(&t_cryptonote_protocol_handler<t_core>::kick_idle_peers, this));
+    m_standby_checker.do_call(std::bind(&t_cryptonote_protocol_handler<t_core>::check_standby_peers, this));
+    m_sync_search_checker.do_call(std::bind(&t_cryptonote_protocol_handler<t_core>::update_sync_search, this));
     return m_core.on_idle();
   }
   //------------------------------------------------------------------------------------------------------------------------

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -31,7 +31,6 @@
 // IP blocking adapted from Boolberry
 
 #include <algorithm>
-#include <boost/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <optional>
@@ -875,8 +874,8 @@ namespace nodetool
     })); // lambda
 
     network_zone& public_zone = m_network_zones.at(epee::net_utils::zone::public_);
-    public_zone.m_net_server.add_idle_handler(boost::bind(&node_server<t_payload_net_handler>::idle_worker, this), 1000);
-    public_zone.m_net_server.add_idle_handler(boost::bind(&t_payload_net_handler::on_idle, &m_payload_handler), 1000);
+    public_zone.m_net_server.add_idle_handler(std::bind(&node_server<t_payload_net_handler>::idle_worker, this), 1000);
+    public_zone.m_net_server.add_idle_handler(std::bind(&t_payload_net_handler::on_idle, &m_payload_handler), 1000);
 
     //here you can set worker threads count
     int thrds_count = 10;
@@ -1777,11 +1776,11 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::idle_worker()
   {
-    m_peer_handshake_idle_maker_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::peer_sync_idle_maker, this));
-    m_connections_maker_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::connections_maker, this));
-    m_gray_peerlist_housekeeping_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::gray_peerlist_housekeeping, this));
-    m_peerlist_store_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::store_config, this));
-    m_incoming_connections_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::check_incoming_connections, this));
+    m_peer_handshake_idle_maker_interval.do_call(std::bind(&node_server<t_payload_net_handler>::peer_sync_idle_maker, this));
+    m_connections_maker_interval.do_call(std::bind(&node_server<t_payload_net_handler>::connections_maker, this));
+    m_gray_peerlist_housekeeping_interval.do_call(std::bind(&node_server<t_payload_net_handler>::gray_peerlist_housekeeping, this));
+    m_peerlist_store_interval.do_call(std::bind(&node_server<t_payload_net_handler>::store_config, this));
+    m_incoming_connections_interval.do_call(std::bind(&node_server<t_payload_net_handler>::check_incoming_connections, this));
     return true;
   }
   //-----------------------------------------------------------------------------------

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -29,7 +29,6 @@
 #include "rpc_args.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/bind/bind.hpp>
 // #include "common/command_line.h" // already #included in rpc/rpc_args.h
 #include "common/i18n.h"
 #include "hex.h"
@@ -217,17 +216,10 @@ namespace cryptonote
         LOG_ERROR(arg.rpc_access_control_origins.name  << tr(" requires RPC server password --") << arg.rpc_login.name << tr(" cannot be empty"));
         return std::nullopt;
       }
-#if BOOST_VERSION >= 106100
       std::vector<std::string> access_control_origins;
       boost::split(access_control_origins, access_control_origins_input, boost::is_any_of(","));
-      std::for_each(access_control_origins.begin(), access_control_origins.end(), boost::bind(&boost::trim<std::string>, boost::placeholders::_1, std::locale::classic()));
+      std::for_each(access_control_origins.begin(), access_control_origins.end(), std::bind(&boost::trim<std::string>, std::placeholders::_1, std::locale::classic()));
       config.access_control_origins = std::move(access_control_origins);
-#else
-      std::vector<std::string> access_control_origins;
-      boost::split(access_control_origins, access_control_origins_input, boost::is_any_of(","));
-      std::for_each(access_control_origins.begin(), access_control_origins.end(), boost::bind(&boost::trim<std::string>, _1, std::locale::classic()));
-      config.access_control_origins = std::move(access_control_origins);
-#endif
     }
 
     auto ssl_options = do_process_ssl(vm, arg, any_cert_option);

--- a/src/rpc/zmq_server.cpp
+++ b/src/rpc/zmq_server.cpp
@@ -230,7 +230,7 @@ std::shared_ptr<listener::zmq_pub> ZmqServer::init_pub(epee::span<const std::str
 
 void ZmqServer::run()
 {
-  run_thread = boost::thread(boost::bind(&ZmqServer::serve, this));
+  run_thread = boost::thread(std::bind(&ZmqServer::serve, this));
 }
 
 void ZmqServer::stop()

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -68,12 +68,6 @@
 #include "readline_buffer.h"
 #endif
 
-#if BOOST_VERSION >= 106100
-#define BOOST_PLACEHOLDERS boost::placeholders
-#else
-#define BOOST_PLACEHOLDERS
-#endif
-
 using namespace std;
 using namespace epee;
 using namespace cryptonote;
@@ -3167,84 +3161,84 @@ simple_wallet::simple_wallet()
 {
 
   m_cmd_binder.set_handler("start_mining",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::start_mining, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::start_mining, std::placeholders::_1),
                            tr(USAGE_START_MINING),
                            tr("Start mining in the daemon."));
   m_cmd_binder.set_handler("stop_mining",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::stop_mining, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::stop_mining, std::placeholders::_1),
                            tr("Stop mining in the daemon."));
   m_cmd_binder.set_handler("set_daemon",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_daemon, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_daemon, std::placeholders::_1),
                            tr(USAGE_SET_DAEMON),
                            tr("Set another daemon to connect to."));
   m_cmd_binder.set_handler("save_bc",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::save_bc, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::save_bc, std::placeholders::_1),
                            tr("Save the current blockchain data."));
   m_cmd_binder.set_handler("refresh",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::refresh, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::refresh, std::placeholders::_1),
                            tr("Synchronize the transactions and balance."));
   m_cmd_binder.set_handler("balance",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_balance, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_balance, std::placeholders::_1),
                            tr(USAGE_SHOW_BALANCE),
                            tr("Show the wallet's balance of the currently selected account."));
   m_cmd_binder.set_handler("incoming_transfers",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_incoming_transfers, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_incoming_transfers, std::placeholders::_1),
                            tr(USAGE_INCOMING_TRANSFERS),
                            tr("Show the incoming transfers, all or filtered by availability and address index.\n\n"
                               "Output format:\n"
                               "Amount, Spent(\"T\"|\"F\"), \"frozen\"|\"locked\"|\"unlocked\", RingCT, Global Index, Transaction Hash, Address Index, [Public Key, Key Image] "));
   m_cmd_binder.set_handler("payments",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_payments, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_payments, std::placeholders::_1),
                            tr(USAGE_PAYMENTS),
                            tr("Show the payments for the given payment IDs."));
   m_cmd_binder.set_handler("bc_height",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_blockchain_height, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_blockchain_height, std::placeholders::_1),
                            tr("Show the blockchain height."));
-  m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::on_command, this, &simple_wallet::transfer, BOOST_PLACEHOLDERS::_1),
+  m_cmd_binder.set_handler("transfer", std::bind(&simple_wallet::on_command, this, &simple_wallet::transfer, std::placeholders::_1),
                            tr(USAGE_TRANSFER),
                            tr("Transfer <amount> to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
   m_cmd_binder.set_handler("locked_transfer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::locked_transfer, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::locked_transfer, std::placeholders::_1),
                            tr(USAGE_LOCKED_TRANSFER),
                            tr("Transfer <amount> to <address> and lock it for <lockblocks> (max. 500000). If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
   m_cmd_binder.set_handler("locked_sweep_all",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::locked_sweep_all, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::locked_sweep_all, std::placeholders::_1),
                            tr(USAGE_LOCKED_SWEEP_ALL),
                            tr("Send all unlocked balance to an address and lock it for <lockblocks> (max. 500000). If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. <priority> is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability."));
   m_cmd_binder.set_handler("sweep_unmixable",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_unmixable, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_unmixable, std::placeholders::_1),
                            tr("Send all unmixable outputs to yourself with ring_size 1"));
-  m_cmd_binder.set_handler("sweep_all", boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_all, BOOST_PLACEHOLDERS::_1),
+  m_cmd_binder.set_handler("sweep_all", std::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_all, std::placeholders::_1),
                            tr(USAGE_SWEEP_ALL),
                            tr("Send all unlocked balance to an address. If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs."));
-  m_cmd_binder.set_handler("sweep_account", boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_account, BOOST_PLACEHOLDERS::_1),
+  m_cmd_binder.set_handler("sweep_account", std::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_account, std::placeholders::_1),
                            tr(USAGE_SWEEP_ACCOUNT),
                            tr("Send all unlocked balance from a given account to an address. If the parameter \"index=<N1>[,<N2>,...]\" or \"index=all\" is specified, the wallet sweeps outputs received by those or all address indices, respectively. If omitted, the wallet randomly chooses an address index to be used. If the parameter \"outputs=<N>\" is specified and  N > 0, wallet splits the transaction into N even outputs."));
   m_cmd_binder.set_handler("sweep_below",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_below, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_below, std::placeholders::_1),
                            tr(USAGE_SWEEP_BELOW),
                            tr("Send all unlocked outputs below the threshold to an address."));
   m_cmd_binder.set_handler("sweep_single",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_single, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::sweep_single, std::placeholders::_1),
                            tr(USAGE_SWEEP_SINGLE),
                            tr("Send a single output of the given key image to an address without change."));
   m_cmd_binder.set_handler("donate",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::donate, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::donate, std::placeholders::_1),
                            tr(USAGE_DONATE),
                            tr("Donate <amount> to the development team (donate.sumokoin.org)."));
   m_cmd_binder.set_handler("sign_transfer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sign_transfer, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::sign_transfer, std::placeholders::_1),
                            tr(USAGE_SIGN_TRANSFER),
                            tr("Sign a transaction from a file. If the parameter \"export_raw\" is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported."));
   m_cmd_binder.set_handler("submit_transfer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::submit_transfer, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::submit_transfer, std::placeholders::_1),
                            tr("Submit a signed transaction from a file."));
   m_cmd_binder.set_handler("set_log",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_log, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_log, std::placeholders::_1),
                            tr(USAGE_SET_LOG),
                            tr("Change the current log detail (level must be <0-4>)."));
   m_cmd_binder.set_handler("account",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::account, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::account, std::placeholders::_1),
                            tr(USAGE_ACCOUNT),
                            tr("If no arguments are specified, the wallet shows all the existing accounts along with their balances.\n"
                               "If the \"new\" argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).\n"
@@ -3254,37 +3248,37 @@ simple_wallet::simple_wallet()
                               "If the \"untag\" argument is specified, the tags assigned to the specified accounts <account_index_1>, <account_index_2> ..., are removed.\n"
                               "If the \"tag_description\" argument is specified, the tag <tag_name> is assigned an arbitrary text <description>."));
   m_cmd_binder.set_handler("address",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::print_address, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::print_address, std::placeholders::_1),
                            tr(USAGE_ADDRESS),
                            tr("If no arguments are specified or <index> is specified, the wallet shows the default or specified address. If \"all\" is specified, the wallet shows all the existing addresses in the currently selected account. If \"new \" is specified, the wallet creates a new address with the provided label text (which can be empty). If \"label\" is specified, the wallet sets the label of the address specified by <index> to the provided label text. If \"one-off\" is specified,the address for the specified index is generated and displayed, and remembered by the wallet"));
   m_cmd_binder.set_handler("integrated_address",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::print_integrated_address, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::print_integrated_address, std::placeholders::_1),
                            tr(USAGE_INTEGRATED_ADDRESS),
                            tr("Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID"));
   m_cmd_binder.set_handler("address_book",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::address_book, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::address_book, std::placeholders::_1),
                            tr(USAGE_ADDRESS_BOOK),
                            tr("Print all entries in the address book, optionally adding/deleting an entry to/from it."));
   m_cmd_binder.set_handler("save",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::save, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::save, std::placeholders::_1),
                            tr("Save the wallet data."));
   m_cmd_binder.set_handler("save_watch_only",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::save_watch_only, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::save_watch_only, std::placeholders::_1),
                            tr("Save a watch-only keys file."));
   m_cmd_binder.set_handler("viewkey",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::viewkey, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::viewkey, std::placeholders::_1),
                            tr("Display the private view key."));
   m_cmd_binder.set_handler("spendkey",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::spendkey, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::spendkey, std::placeholders::_1),
                            tr("Display the private spend key."));
   m_cmd_binder.set_handler("seed",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::seed, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::seed, std::placeholders::_1),
                            tr("Display the Electrum-style mnemonic seed"));
   m_cmd_binder.set_handler("restore_height",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::restore_height, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::restore_height, std::placeholders::_1),
                            tr("Display the restore height"));
   m_cmd_binder.set_handler("set",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_variable, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_variable, std::placeholders::_1),
                            tr(USAGE_SET_VARIABLE),
                            tr("Available options:\n "
                                   "seed language\n "
@@ -3352,51 +3346,51 @@ simple_wallet::simple_wallet()
                                   "credits-target <unsigned int>\n"
                                   "  The RPC payment credits balance to target (0 for default)."));
   m_cmd_binder.set_handler("encrypted_seed",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::encrypted_seed, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::encrypted_seed, std::placeholders::_1),
                            tr("Display the encrypted Electrum-style mnemonic seed."));
   m_cmd_binder.set_handler("rescan_spent",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::rescan_spent, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::rescan_spent, std::placeholders::_1),
                            tr("Rescan the blockchain for spent outputs."));
   m_cmd_binder.set_handler("get_tx_key",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_tx_key, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::get_tx_key, std::placeholders::_1),
                            tr(USAGE_GET_TX_KEY),
                            tr("Get the transaction key (r) for a given <txid>."));
   m_cmd_binder.set_handler("set_tx_key",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_tx_key, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_tx_key, std::placeholders::_1),
                            tr(USAGE_SET_TX_KEY),
                            tr("Set the transaction key (r) for a given <txid> in case the tx was made by some other device or 3rd party wallet."));
   m_cmd_binder.set_handler("check_tx_key",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::check_tx_key, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::check_tx_key, std::placeholders::_1),
                            tr(USAGE_CHECK_TX_KEY),
                            tr("Check the amount going to <address> in <txid>."));
   m_cmd_binder.set_handler("get_tx_proof",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_tx_proof, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::get_tx_proof, std::placeholders::_1),
                            tr(USAGE_GET_TX_PROOF),
                            tr("Generate a signature proving funds sent to <address> in <txid>, optionally with a challenge string <message>, using either the transaction secret key (when <address> is not your wallet's address) or the view secret key (otherwise), which does not disclose the secret key."));
   m_cmd_binder.set_handler("check_tx_proof",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::check_tx_proof, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::check_tx_proof, std::placeholders::_1),
                            tr(USAGE_CHECK_TX_PROOF),
                            tr("Check the proof for funds going to <address> in <txid> with the challenge string <message> if any."));
   m_cmd_binder.set_handler("get_spend_proof",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_spend_proof, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::get_spend_proof, std::placeholders::_1),
                            tr(USAGE_GET_SPEND_PROOF),
                            tr("Generate a signature proving that you generated <txid> using the spend secret key, optionally with a challenge string <message>."));
   m_cmd_binder.set_handler("check_spend_proof",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::check_spend_proof, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::check_spend_proof, std::placeholders::_1),
                            tr(USAGE_CHECK_SPEND_PROOF),
                            tr("Check a signature proving that the signer generated <txid>, optionally with a challenge string <message>."));
   m_cmd_binder.set_handler("get_reserve_proof",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_reserve_proof, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::get_reserve_proof, std::placeholders::_1),
                            tr(USAGE_GET_RESERVE_PROOF),
                            tr("Generate a signature proving that you own at least this much, optionally with a challenge string <message>.\n"
                               "If 'all' is specified, you prove the entire sum of all of your existing accounts' balances.\n"
                               "Otherwise, you prove the reserve of the smallest possible amount above <amount> available in your current account."));
   m_cmd_binder.set_handler("check_reserve_proof",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::check_reserve_proof, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::check_reserve_proof, std::placeholders::_1),
                            tr(USAGE_CHECK_RESERVE_PROOF),
                            tr("Check a signature proving that the owner of <address> holds at least this much, optionally with a challenge string <message>."));
   m_cmd_binder.set_handler("show_transfers",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_transfers, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_transfers, std::placeholders::_1),
                            tr(USAGE_SHOW_TRANSFERS),
                            // Seemingly broken formatting to compensate for the backslash before the quotes.
                            tr("Show the incoming/outgoing transfers within an optional height range.\n\n"
@@ -3408,120 +3402,120 @@ simple_wallet::simple_wallet()
                               "* Excluding change and fee.\n"
                               "** Set of address indices used as inputs in this transfer."));
   m_cmd_binder.set_handler("export_transfers",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::export_transfers, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::export_transfers, std::placeholders::_1),
                            tr("export_transfers [in|out|all|pending|failed|pool|coinbase] [index=<N1>[,<N2>,...]] [<min_height> [<max_height>]] [output=<filepath>]"),
                            tr("Export to CSV the incoming/outgoing transfers within an optional height range."));
   m_cmd_binder.set_handler("unspent_outputs",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::unspent_outputs, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::unspent_outputs, std::placeholders::_1),
                            tr(USAGE_UNSPENT_OUTPUTS),
                            tr("Show the unspent outputs of a specified address within an optional amount range."));
   m_cmd_binder.set_handler("rescan_bc",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::rescan_blockchain, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::rescan_blockchain, std::placeholders::_1),
                            tr(USAGE_RESCAN_BC),
                            tr("Rescan the blockchain from scratch. If \"hard\" is specified, you will lose any information which can not be recovered from the blockchain itself."));
   m_cmd_binder.set_handler("set_tx_note",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_tx_note, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_tx_note, std::placeholders::_1),
                            tr(USAGE_SET_TX_NOTE),
                            tr("Set an arbitrary string note for a <txid>."));
   m_cmd_binder.set_handler("get_tx_note",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_tx_note, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::get_tx_note, std::placeholders::_1),
                            tr(USAGE_GET_TX_NOTE),
                            tr("Get a string note for a txid."));
   m_cmd_binder.set_handler("set_description",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_description, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_description, std::placeholders::_1),
                            tr(USAGE_SET_DESCRIPTION),
                            tr("Set an arbitrary description for the wallet."));
   m_cmd_binder.set_handler("get_description",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::get_description, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::get_description, std::placeholders::_1),
                            tr(USAGE_GET_DESCRIPTION),
                            tr("Get the description of the wallet."));
   m_cmd_binder.set_handler("status",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::status, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::status, std::placeholders::_1),
                            tr("Show the wallet's status."));
   m_cmd_binder.set_handler("wallet_info",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::wallet_info, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::wallet_info, std::placeholders::_1),
                            tr("Show the wallet's information."));
   m_cmd_binder.set_handler("sign",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sign, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::sign, std::placeholders::_1),
                            tr(USAGE_SIGN),
                            tr("Sign the contents of a file with the given subaddress (or the main address if not specified)"));
   m_cmd_binder.set_handler("verify",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::verify, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::verify, std::placeholders::_1),
                            tr(USAGE_VERIFY),
                            tr("Verify a signature on the contents of a file."));
   m_cmd_binder.set_handler("export_key_images",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::export_key_images, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::export_key_images, std::placeholders::_1),
                            tr(USAGE_EXPORT_KEY_IMAGES),
                            tr("Export a signed set of key images to a <filename>."));
   m_cmd_binder.set_handler("import_key_images",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::import_key_images, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::import_key_images, std::placeholders::_1),
                            tr(USAGE_IMPORT_KEY_IMAGES),
                            tr("Import a signed key images list and verify their spent status."));
   m_cmd_binder.set_handler("hw_key_images_sync",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::hw_key_images_sync, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::hw_key_images_sync, std::placeholders::_1),
                            tr(USAGE_HW_KEY_IMAGES_SYNC),
                            tr("Synchronizes key images with the hw wallet."));
   m_cmd_binder.set_handler("hw_reconnect",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::hw_reconnect, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::hw_reconnect, std::placeholders::_1),
                            tr(USAGE_HW_RECONNECT),
                            tr("Attempts to reconnect HW wallet."));
   m_cmd_binder.set_handler("export_outputs",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::export_outputs, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::export_outputs, std::placeholders::_1),
                            tr(USAGE_EXPORT_OUTPUTS),
                            tr("Export a set of outputs owned by this wallet."));
   m_cmd_binder.set_handler("import_outputs",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::import_outputs, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::import_outputs, std::placeholders::_1),
                            tr(USAGE_IMPORT_OUTPUTS),
                            tr("Import a set of outputs owned by this wallet."));
   m_cmd_binder.set_handler("show_transfer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_transfer, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_transfer, std::placeholders::_1),
                            tr(USAGE_SHOW_TRANSFER),
                            tr("Show information about a transfer to/from this address."));
   m_cmd_binder.set_handler("password",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::change_password, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::change_password, std::placeholders::_1),
                            tr("Change the wallet's password."));
   m_cmd_binder.set_handler("payment_id",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::payment_id, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::payment_id, std::placeholders::_1),
                            tr(USAGE_PAYMENT_ID),
                            tr("Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids."));
   m_cmd_binder.set_handler("fee",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::print_fee_info, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::print_fee_info, std::placeholders::_1),
                            tr("Print the information about the current fee and transaction backlog."));
-  m_cmd_binder.set_handler("prepare_multisig", boost::bind(&simple_wallet::on_command, this, &simple_wallet::prepare_multisig, BOOST_PLACEHOLDERS::_1),
+  m_cmd_binder.set_handler("prepare_multisig", std::bind(&simple_wallet::on_command, this, &simple_wallet::prepare_multisig, std::placeholders::_1),
                            tr("Export data needed to create a multisig wallet"));
-  m_cmd_binder.set_handler("make_multisig", boost::bind(&simple_wallet::on_command, this, &simple_wallet::make_multisig, BOOST_PLACEHOLDERS::_1),
+  m_cmd_binder.set_handler("make_multisig", std::bind(&simple_wallet::on_command, this, &simple_wallet::make_multisig, std::placeholders::_1),
                            tr(USAGE_MAKE_MULTISIG),
                            tr("Turn this wallet into a multisig wallet"));
   m_cmd_binder.set_handler("finalize_multisig",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::finalize_multisig, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::finalize_multisig, std::placeholders::_1),
                            tr(USAGE_FINALIZE_MULTISIG),
                            tr("Turn this wallet into a multisig wallet, extra step for N-1/N wallets"));
   m_cmd_binder.set_handler("exchange_multisig_keys",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::exchange_multisig_keys, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::exchange_multisig_keys, std::placeholders::_1),
                            tr(USAGE_EXCHANGE_MULTISIG_KEYS),
                            tr("Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets"));
   m_cmd_binder.set_handler("export_multisig_info",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::export_multisig, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::export_multisig, std::placeholders::_1),
                            tr(USAGE_EXPORT_MULTISIG_INFO),
                            tr("Export multisig info for other participants"));
   m_cmd_binder.set_handler("import_multisig_info",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::import_multisig, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::import_multisig, std::placeholders::_1),
                            tr(USAGE_IMPORT_MULTISIG_INFO),
                            tr("Import multisig info from other participants"));
   m_cmd_binder.set_handler("sign_multisig",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::sign_multisig, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::sign_multisig, std::placeholders::_1),
                            tr(USAGE_SIGN_MULTISIG),
                            tr("Sign a multisig transaction from a file"));
   m_cmd_binder.set_handler("submit_multisig",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::submit_multisig, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::submit_multisig, std::placeholders::_1),
                            tr(USAGE_SUBMIT_MULTISIG),
                            tr("Submit a signed multisig transaction from a file"));
   m_cmd_binder.set_handler("export_raw_multisig_tx",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::export_raw_multisig, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::export_raw_multisig, std::placeholders::_1),
                            tr(USAGE_EXPORT_RAW_MULTISIG_TX),
                            tr("Export a signed multisig transaction to a file"));
   m_cmd_binder.set_handler("mms",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS),
                            tr("Interface with the MMS (Multisig Messaging System)\n"
                               "<subcommand> is one of:\n"
@@ -3529,177 +3523,177 @@ simple_wallet::simple_wallet()
                               "  send_signer_config, start_auto_config, stop_auto_config, auto_config, config_checksum\n"
                               "Get help about a subcommand with: help mms <subcommand>"));
   m_cmd_binder.set_handler("mms init",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_INIT),
                            tr("Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig"));
   m_cmd_binder.set_handler("mms info",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_INFO),
                            tr("Display current MMS configuration"));
   m_cmd_binder.set_handler("mms signer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_SIGNER),
                            tr("Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers"));
   m_cmd_binder.set_handler("mms list",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_LIST),
                            tr("List all messages"));
   m_cmd_binder.set_handler("mms next",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_NEXT),
                            tr("Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice\n"
                               "By using 'sync' processing of waiting messages with multisig sync info can be forced regardless of wallet state"));
   m_cmd_binder.set_handler("mms sync",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_SYNC),
                            tr("Force generation of multisig sync info regardless of wallet state, to recover from special situations like \"stale data\" errors"));
   m_cmd_binder.set_handler("mms transfer",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_TRANSFER),
                            tr("Initiate transfer with MMS support; arguments identical to normal 'transfer' command arguments, for info see there"));
   m_cmd_binder.set_handler("mms delete",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_DELETE),
                            tr("Delete a single message by giving its id, or delete all messages by using 'all'"));
   m_cmd_binder.set_handler("mms send",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_SEND),
                            tr("Send a single message by giving its id, or send all waiting messages"));
   m_cmd_binder.set_handler("mms receive",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_RECEIVE),
                            tr("Check right away for new messages to receive"));
   m_cmd_binder.set_handler("mms export",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_EXPORT),
                            tr("Write the content of a message to a file \"mms_message_content\""));
   m_cmd_binder.set_handler("mms note",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_NOTE),
                            tr("Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes"));
   m_cmd_binder.set_handler("mms show",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_SHOW),
                            tr("Show detailed info about a single message"));
   m_cmd_binder.set_handler("mms set",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_SET),
                            tr("Available options:\n "
                                   "auto-send <1|0>\n "
                                   "  Whether to automatically send newly generated messages right away.\n "));
   m_cmd_binder.set_handler("mms send_signer_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_SEND_SIGNER_CONFIG),
                            tr("Send completed signer config to all other authorized signers"));
   m_cmd_binder.set_handler("mms start_auto_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_START_AUTO_CONFIG),
                            tr("Start auto-config at the auto-config manager's wallet by issuing auto-config tokens and optionally set others' labels"));
   m_cmd_binder.set_handler("mms config_checksum",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_CONFIG_CHECKSUM),
                            tr("Get a checksum that allows signers to easily check for identical MMS configuration"));
   m_cmd_binder.set_handler("mms stop_auto_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_STOP_AUTO_CONFIG),
                            tr("Delete any auto-config tokens and abort a auto-config process"));
   m_cmd_binder.set_handler("mms auto_config",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::mms, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::mms, std::placeholders::_1),
                            tr(USAGE_MMS_AUTO_CONFIG),
                            tr("Start auto-config by using the token received from the auto-config manager"));
   m_cmd_binder.set_handler("print_ring",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::print_ring, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::print_ring, std::placeholders::_1),
                            tr(USAGE_PRINT_RING),
                            tr("Print the ring(s) used to spend a given key image or transaction (if the ring size is > 1)\n\n"
                               "Output format:\n"
                               "Key Image, \"absolute\", list of rings"));
   m_cmd_binder.set_handler("set_ring",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::set_ring, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::set_ring, std::placeholders::_1),
                            tr(USAGE_SET_RING),
                            tr("Set the ring used for a given key image, so it can be reused in a fork"));
   m_cmd_binder.set_handler("unset_ring",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::unset_ring, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::unset_ring, std::placeholders::_1),
                            tr(USAGE_UNSET_RING),
                            tr("Unsets the ring used for a given key image or transaction"));
   m_cmd_binder.set_handler("save_known_rings",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::save_known_rings, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::save_known_rings, std::placeholders::_1),
                            tr(USAGE_SAVE_KNOWN_RINGS),
                            tr("Save known rings to the shared rings database"));
   m_cmd_binder.set_handler("mark_output_spent",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::blackball, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::blackball, std::placeholders::_1),
                            tr(USAGE_MARK_OUTPUT_SPENT),
                            tr("Mark output(s) as spent so they never get selected as fake outputs in a ring"));
   m_cmd_binder.set_handler("mark_output_unspent",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::unblackball, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::unblackball, std::placeholders::_1),
                            tr(USAGE_MARK_OUTPUT_UNSPENT),
                            tr("Marks an output as unspent so it may get selected as a fake output in a ring"));
   m_cmd_binder.set_handler("is_output_spent",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::blackballed, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::blackballed, std::placeholders::_1),
                            tr(USAGE_IS_OUTPUT_SPENT),
                            tr("Checks whether an output is marked as spent"));
   m_cmd_binder.set_handler("freeze",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::freeze, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::freeze, std::placeholders::_1),
                            tr(USAGE_FREEZE),
                            tr("Freeze a single output by key image so it will not be used"));
   m_cmd_binder.set_handler("thaw",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::thaw, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::thaw, std::placeholders::_1),
                            tr(USAGE_THAW),
                            tr("Thaw a single output by key image so it may be used again"));
   m_cmd_binder.set_handler("frozen",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::frozen, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::frozen, std::placeholders::_1),
                            tr(USAGE_FROZEN),
                            tr("Checks whether a given output is currently frozen by key image"));
   m_cmd_binder.set_handler("lock",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::lock, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::lock, std::placeholders::_1),
                            tr(USAGE_LOCK),
                            tr("Lock the wallet console, requiring the wallet password to continue"));
   m_cmd_binder.set_handler("disable_lock",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::disable_lock, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::disable_lock, std::placeholders::_1),
                            tr(USAGE_DISABLE_LOCK),
                            tr("Disable automatic locking of wallet due to inactivity"));
   m_cmd_binder.set_handler("net_stats",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::net_stats, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::net_stats, std::placeholders::_1),
                            tr(USAGE_NET_STATS),
                            tr("Prints simple network stats"));
   m_cmd_binder.set_handler("public_nodes",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::public_nodes, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::public_nodes, std::placeholders::_1),
                            tr(USAGE_PUBLIC_NODES),
                            tr("Lists known public nodes"));
   m_cmd_binder.set_handler("welcome",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::welcome, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::welcome, std::placeholders::_1),
                            tr(USAGE_WELCOME),
                            tr("Prints basic info about Monero for first time users"));
   m_cmd_binder.set_handler("version",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::version, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::version, std::placeholders::_1),
                            tr(USAGE_VERSION),
                            tr("Returns version information"));
   m_cmd_binder.set_handler("rpc_payment_info",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::rpc_payment_info, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::rpc_payment_info, std::placeholders::_1),
                            tr(USAGE_RPC_PAYMENT_INFO),
                            tr("Get info about RPC payments to current node"));
   m_cmd_binder.set_handler("start_mining_for_rpc",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::start_mining_for_rpc, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::start_mining_for_rpc, std::placeholders::_1),
                            tr(USAGE_START_MINING_FOR_RPC),
                            tr("Start mining to pay for RPC access"));
   m_cmd_binder.set_handler("stop_mining_for_rpc",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::stop_mining_for_rpc, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::stop_mining_for_rpc, std::placeholders::_1),
                            tr(USAGE_STOP_MINING_FOR_RPC),
                            tr("Stop mining to pay for RPC access"));
   m_cmd_binder.set_handler("show_qr_code",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::show_qr_code, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::show_qr_code, std::placeholders::_1),
                            tr(USAGE_SHOW_QR_CODE),
                            tr("Show address as QR code"));
   m_cmd_binder.set_handler("help",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::help, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::help, std::placeholders::_1),
                            tr(USAGE_HELP),
                            tr("Show the help section or the documentation about a <command>."));
   m_cmd_binder.set_handler("search_command",
-                           boost::bind(&simple_wallet::on_command, this, &simple_wallet::search_command, BOOST_PLACEHOLDERS::_1),
+                           std::bind(&simple_wallet::on_command, this, &simple_wallet::search_command, std::placeholders::_1),
                             tr(USAGE_SEARCH_COMMAND),
                             tr("Search all command descriptions for keyword(s)"));
-  m_cmd_binder.set_unknown_command_handler(boost::bind(&simple_wallet::on_command, this, &simple_wallet::on_unknown_command, BOOST_PLACEHOLDERS::_1));
-  m_cmd_binder.set_empty_command_handler(boost::bind(&simple_wallet::on_empty_command, this));
-  m_cmd_binder.set_cancel_handler(boost::bind(&simple_wallet::on_cancelled_command, this));
+  m_cmd_binder.set_unknown_command_handler(std::bind(&simple_wallet::on_command, this, &simple_wallet::on_unknown_command, std::placeholders::_1));
+  m_cmd_binder.set_empty_command_handler(std::bind(&simple_wallet::on_empty_command, this));
+  m_cmd_binder.set_cancel_handler(std::bind(&simple_wallet::on_cancelled_command, this));
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::set_variable(const std::vector<std::string> &args)
@@ -3818,7 +3812,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     CHECK_SIMPLE_VARIABLE("inactivity-lock-timeout", set_inactivity_lock_timeout, tr("unsigned integer (seconds, 0 to disable)"));
     CHECK_SIMPLE_VARIABLE("device-name", set_device_name, tr("<device_name[:device_spec]>"));
     CHECK_SIMPLE_VARIABLE("export-format", set_export_format, tr("\"binary\" or \"ascii\""));
-    CHECK_SIMPLE_VARIABLE("load-deprecated-formats", set_load_deprecated_formats, tr("0 or 1"));    
+    CHECK_SIMPLE_VARIABLE("load-deprecated-formats", set_load_deprecated_formats, tr("0 or 1"));
     CHECK_SIMPLE_VARIABLE("persistent-rpc-client-id", set_persistent_rpc_client_id, tr("0 or 1"));
     CHECK_SIMPLE_VARIABLE("auto-mine-for-rpc-payment-threshold", set_auto_mine_for_rpc_payment_threshold, tr("floating point >= 0"));
     CHECK_SIMPLE_VARIABLE("credits-target", set_credits_target, tr("unsigned integer"));
@@ -7916,7 +7910,7 @@ bool simple_wallet::set_tx_key(const std::vector<std::string> &args_)
   {
     fail_msg_writer() << tr("Failed to store tx key: ") << e.what();
     if (!single_destination_subaddress)
-      fail_msg_writer() << tr("It could be because the transfer was to a subaddress. If this is the case, pass the subaddress last");    
+      fail_msg_writer() << tr("It could be because the transfer was to a subaddress. If this is the case, pass the subaddress last");
   }
   return true;
 }
@@ -8995,11 +8989,11 @@ void simple_wallet::wallet_idle_thread()
     if (dt_actual < threshold) // if less than a threshold... would a very slow machine always miss it ?
     {
 #ifndef _WIN32
-      m_inactivity_checker.do_call(boost::bind(&simple_wallet::check_inactivity, this));
+      m_inactivity_checker.do_call(std::bind(&simple_wallet::check_inactivity, this));
 #endif
-      m_refresh_checker.do_call(boost::bind(&simple_wallet::check_refresh, this));
-      m_mms_checker.do_call(boost::bind(&simple_wallet::check_mms, this));
-      m_rpc_payment_checker.do_call(boost::bind(&simple_wallet::check_rpc_payment, this));
+      m_refresh_checker.do_call(std::bind(&simple_wallet::check_refresh, this));
+      m_mms_checker.do_call(std::bind(&simple_wallet::check_mms, this));
+      m_rpc_payment_checker.do_call(std::bind(&simple_wallet::check_rpc_payment, this));
 
       if (!m_idle_run.load(std::memory_order_relaxed))
         break;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -949,11 +949,7 @@ uint32_t get_subaddress_clamped_sum(uint32_t idx, uint32_t extra)
 
 static void setup_shim(hw::wallet_shim * shim, tools::wallet2 * wallet)
 {
-#if BOOST_VERSION >= 106100
-  shim->get_tx_pub_key_from_received_outs = boost::bind(&tools::wallet2::get_tx_pub_key_from_received_outs, wallet, boost::placeholders::_1);
-#else
-  shim->get_tx_pub_key_from_received_outs = boost::bind(&tools::wallet2::get_tx_pub_key_from_received_outs, wallet, _1);
-#endif
+  shim->get_tx_pub_key_from_received_outs = std::bind(&tools::wallet2::get_tx_pub_key_from_received_outs, wallet, std::placeholders::_1);
 }
 
 bool get_pruned_tx(const cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry &entry, cryptonote::transaction &tx, crypto::hash &tx_hash)
@@ -2022,7 +2018,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
         // the first one was already checked
         for (size_t i = 1; i < tx.vout.size(); ++i)
         {
-          tpool.submit(&waiter, boost::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
+          tpool.submit(&waiter, std::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
             std::cref(is_out_data_ptr), std::ref(tx_scan_info[i]), std::ref(output_found[i])), true);
         }
         THROW_WALLET_EXCEPTION_IF(!waiter.wait(), error::wallet_internal_error, "Exception in thread pool");
@@ -2049,7 +2045,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
     {
       for (size_t i = 0; i < tx.vout.size(); ++i)
       {
-        tpool.submit(&waiter, boost::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
+        tpool.submit(&waiter, std::bind(&wallet2::check_acc_out_precomp_once, this, std::cref(tx.vout[i]), std::cref(derivation), std::cref(additional_derivations), i,
             std::cref(is_out_data_ptr), std::ref(tx_scan_info[i]), std::ref(output_found[i])), true);
       }
       THROW_WALLET_EXCEPTION_IF(!waiter.wait(), error::wallet_internal_error, "Exception in thread pool");
@@ -2867,7 +2863,7 @@ void wallet2::pull_and_parse_next_blocks(uint64_t start_height, uint64_t &blocks
     parsed_blocks.resize(blocks.size());
     for (size_t i = 0; i < blocks.size(); ++i)
     {
-      tpool.submit(&waiter, boost::bind(&wallet2::parse_block_round, this, std::cref(blocks[i].block),
+      tpool.submit(&waiter, std::bind(&wallet2::parse_block_round, this, std::cref(blocks[i].block),
         std::ref(parsed_blocks[i].block), std::ref(parsed_blocks[i].hash), std::ref(parsed_blocks[i].error)), true);
     }
     THROW_WALLET_EXCEPTION_IF(!waiter.wait(), error::wallet_internal_error, "Exception in thread pool");
@@ -11006,7 +11002,7 @@ void wallet2::set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_
         break;
       }
     }
-  }    
+  }
   THROW_WALLET_EXCEPTION_IF(!found, error::wallet_internal_error, "Given tx secret key doesn't agree with the tx public key in the blockchain");
   tx_extra_additional_pub_keys additional_tx_pub_keys;
   find_tx_extra_field_by_type(tx_extra_fields, additional_tx_pub_keys);


### PR DESCRIPTION
where no code refactoring is needed (for example where an std::map is not involved).
Avoid the boost placeholders issue with boost versions altogether as well
Parts we dont build like trezor were left unchanged