### PR TITLE
[testnet HF-CLSAG] set hardfork heights and timestamps for HF10 & HF 11

### DIFF
--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -42,7 +42,7 @@ const hardfork_t mainnet_hard_forks[] = {
   { 7, MAINNET_HARDFORK_V7_HEIGHT, 0, 1555234940 },
   { 8, MAINNET_HARDFORK_V8_HEIGHT, 0, 1555321375 },
   { 9, 350000, 0, 1574120819 }, // abt 6h47' Nov 19, 2019
-//{ 10, XXXXXX, 0, XXXXXXXXXX }, // CLSAG & EXACT COINBASE - ALLOW BOTH MLSAG AND CLSAG 
+//{ 10, XXXXXX, 0, XXXXXXXXXX }, // CLSAG & EXACT COINBASE - ALLOW BOTH MLSAG AND CLSAG
 //{ 11, XXXXXX, 0, XXXXXXXXXX }, // FORBID MLSAG ALLOW CLSAG ONLY - SHOULD HAPPEN A DAY OR TWO AFTER HF 10
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
@@ -57,8 +57,8 @@ const hardfork_t testnet_hard_forks[] = {
   { 7, 130530, 0, 1554465078 },
   { 8, 130560, 0, 1554479506 },
   { 9, 164100, 0, 1572592223 },
-//{ 10, XXXXXX, 0, XXXXXXXXXX }, // CLSAG & EXACT COINBASE
-//{ 11, XXXXXX, 0, XXXXXXXXXX }, // FORBID MLSAG ALLOW CLSAG ONLY  
+  { 10, 231500, 0, 1603158050 }, // CLSAG & EXACT COINBASE
+  { 11, 233500, 0, 1603638050 }, // FORBID MLSAG ALLOW CLSAG ONLY
 };
 const size_t num_testnet_hard_forks = sizeof(testnet_hard_forks) / sizeof(testnet_hard_forks[0]);
 
@@ -72,7 +72,7 @@ const hardfork_t stagenet_hard_forks[] = {
   { 7, 130530, 0, 1554465078 },
   { 8, 130560, 0, 1554479506 },
   { 9, 164100, 0, 1572592223 },
-//{ 10, XXXXXX, 0, XXXXXXXXXX }, // CLSAG & EXACT COINBASE
-//{ 11, XXXXXX, 0, XXXXXXXXXX }, // FORBID MLSAG ALLOW CLSAG ONLY  
+  { 10, 231500, 0, 1603158050 }, // CLSAG & EXACT COINBASE
+  { 11, 233500, 0, 1603638050 }, // FORBID MLSAG ALLOW CLSAG ONLY   
 };
 const size_t num_stagenet_hard_forks = sizeof(stagenet_hard_forks) / sizeof(stagenet_hard_forks[0]);


### PR DESCRIPTION
  Testnet
  HF 10 Height 231500 Timestamp 1603158050  // CLSAG & EXACT COINBASE
  HF 11 Height 233500 Timestamp 1603638050 // FORBID MLSAG ALLOW CLSAG ONLY