### PR TITLE
[testnet-HF10] revert enforce claiming maximum coinbase amount and move testnet HF a bit higher

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1522,22 +1522,11 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
     return false;
   }
 
-  // Until hf 10, we were allowing a miner to claim less block reward than is allowed, in case a miner wants less dust
-  if (version >= HF_VERSION_EXACT_COINBASE)
-  {
-    if(base_reward + fee != money_in_use)
-    {
-      MDEBUG("coinbase transaction doesn't use full amount of block reward:  spent: " << money_in_use << ",  block reward " << base_reward + fee << "(" << base_reward << "+" << fee << ")");
-      return false;
-    }
-  }
-  else
-  {
-    CHECK_AND_ASSERT_MES(money_in_use - fee <= base_reward, false, "base reward calculation bug");
-    if (base_reward + fee != money_in_use)
-      partial_block_reward = true;
-    base_reward = money_in_use - fee;
-  }
+  CHECK_AND_ASSERT_MES(money_in_use - fee <= base_reward, false, "base reward calculation bug");
+  if (base_reward + fee != money_in_use)
+    partial_block_reward = true;
+  base_reward = money_in_use - fee;
+  
   return true;
 }
 //------------------------------------------------------------------

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -57,7 +57,7 @@ const hardfork_t testnet_hard_forks[] = {
   { 7, 130530, 0, 1554465078 },
   { 8, 130560, 0, 1554479506 },
   { 9, 164100, 0, 1572592223 },
-  { 10, 231500, 0, 1603158050 }, // CLSAG & EXACT COINBASE
+  { 10, 231580, 0, 1603158050 }, // CLSAG & EXACT COINBASE
   { 11, 233500, 0, 1603638050 }, // FORBID MLSAG ALLOW CLSAG ONLY
 };
 const size_t num_testnet_hard_forks = sizeof(testnet_hard_forks) / sizeof(testnet_hard_forks[0]);
@@ -72,7 +72,7 @@ const hardfork_t stagenet_hard_forks[] = {
   { 7, 130530, 0, 1554465078 },
   { 8, 130560, 0, 1554479506 },
   { 9, 164100, 0, 1572592223 },
-  { 10, 231500, 0, 1603158050 }, // CLSAG & EXACT COINBASE
+  { 10, 231580, 0, 1603158050 }, // CLSAG & EXACT COINBASE
   { 11, 233500, 0, 1603638050 }, // FORBID MLSAG ALLOW CLSAG ONLY   
 };
 const size_t num_stagenet_hard_forks = sizeof(stagenet_hard_forks) / sizeof(stagenet_hard_forks[0]);

--- a/src/hardforks_checkpoints_config.h
+++ b/src/hardforks_checkpoints_config.h
@@ -43,7 +43,6 @@
 #define HF_VERSION_MIN_2_OUTPUTS                          9
 #define HF_VERSION_ENFORCE_MIN_AGE                        9
 #define HF_VERSION_EFFECTIVE_SHORT_TERM_MEDIAN_IN_PENALTY 9
-#define HF_VERSION_EXACT_COINBASE                         10
 #define HF_VERSION_CLSAG                                  10
 #define HF_VERSION_DETERMINISTIC_UNLOCK_TIME              10
 
@@ -103,4 +102,4 @@
     ADD_CHECKPOINT(190000, "2d42389a1fd0946c8084cd6141bf7562cb262093957f268208d068f9adbc9839"); \
     ADD_CHECKPOINT(210000, "1fd6d9669525a94cf5d034972d41a9ff4f57d28f1136bbdea395819d85dcc841"); \
     ADD_CHECKPOINT(225000, "8ee300b366f522f06869baf5c5cdbc7c23863fdf8f9d09be4c4d6618baffa62f"); \
-
+    


### PR DESCRIPTION
it was breaking block verification due to our emission scheme. it is not a feature worth thinking about twice anyhow.
resetting testnet hf a bit higher