### PR TITLE
[epee+p2p+protocol] various improvements and fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/cache@v2
       with:
-        path: ~/.ccache
+        path: /Users/runner/Library/Caches/ccache
         key: ccache-macos-build-${{ github.sha }}
         restore-keys: ccache-macos-build-
     - name: install dependencies
@@ -60,17 +60,28 @@ jobs:
 
   build-windows-native-msys2:
     runs-on: windows-latest
+    env:
+      CCACHE_COMPRESS: 1
+      CCACHE_TEMPDIR: C:\Users\runneradmin\.ccache-temp
+      CCACHE_DIR: C:\Users\runneradmin\.ccache    
     defaults:
       run:
         shell: msys2 {0}
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/cache@v2
+      with:
+        path: C:\Users\runneradmin\.ccache
+        key: ccache-windows-build-${{ github.sha }}
+        restore-keys: ccache-windows-build-    
     - uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-libunwind mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
+        install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache mingw-w64-x86_64-libunwind mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git
     - name: build sumokoin
-      run: make release-static-win64 -j2
+      run: |
+        ccache --max-size=150M
+        make release-static-win64 -j2
 
   Windows64-cross-on-bionic:
     runs-on: ubuntu-18.04

--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,15 +22,17 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 
 #pragma once
 
-#include <limits>
-#include <boost/thread.hpp>
 #include <boost/utility/value_init.hpp>
+#include <boost/shared_ptr.hpp>
+#include <limits>
+#include <functional>
+#include <vector>
 namespace epee
 {
 #define STD_TRY_BEGIN() try {
@@ -60,7 +62,7 @@ namespace misc_utils
 			return (std::numeric_limits<t_type>::max)();
 		}
 
-		
+
 	template<typename t_iterator>
 		t_iterator move_it_forward(t_iterator it, size_t count)
 		{
@@ -94,17 +96,9 @@ namespace misc_utils
   {	// apply operator< to operands
       return memcmp(&_Left, &_Right, sizeof(_Left)) < 0;
   }
-	
 
-	inline
-	bool sleep_no_w(long ms )
-	{
-		boost::this_thread::sleep( 
-			boost::get_system_time() + 
-			boost::posix_time::milliseconds( std::max<long>(ms,0) ) );
-		
-		return true;
-	}
+
+	bool sleep_no_w(long ms );
 
   template<class type_vec_type>
   type_vec_type median(std::vector<type_vec_type> &v)
@@ -120,7 +114,7 @@ namespace misc_utils
     if(v.size()%2)
     {//1, 3, 5...
       return v[n];
-    }else 
+    }else
     {//2, 4, 6...
       return (v[n-1] + v[n])/2;
     }

--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -64,13 +64,13 @@ namespace http
     abstract_http_client() {}
     virtual ~abstract_http_client() {}
     bool set_server(const std::string& address, std::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect);
-    virtual bool set_proxy(const std::string& address);    
+    virtual bool set_proxy(const std::string& address);
     virtual void set_server(std::string host, std::string port, std::optional<login> user, ssl_options_t ssl_options = ssl_support_t::e_ssl_support_autodetect) = 0;
     virtual void set_auto_connect(bool auto_connect) = 0;
     virtual bool connect(std::chrono::milliseconds timeout) = 0;
     virtual bool disconnect() = 0;
     virtual bool is_connected(bool *ssl = NULL) = 0;
-    virtual bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
+    virtual bool invoke(const boost::string_ref uri, const boost::string_ref method, const boost::string_ref body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual bool invoke_post(const boost::string_ref uri, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual uint64_t get_bytes_sent() const = 0;

--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -2,30 +2,30 @@
 /// @author rfree (current maintainer in monero.cc project)
 /// @brief base for connection, contains e.g. the ratelimit hooks
 
-// ! This file might contain variable names same as in template class connection<> 
+// ! This file might contain variable names same as in template class connection<>
 // ! from files contrib/epee/include/net/abstract_tcp_server2.*
 // ! I am not a lawyer; afaik APIs, var names etc are not copyrightable ;)
 // ! (how ever if in some wonderful juristdictions that is not the case, then why not make another sub-class withat that members and licence it as epee part)
 // ! Working on above premise, IF this is valid in your juristdictions, then consider this code as released as:
 
 // Copyright (c) 2014-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -95,7 +95,7 @@ class connection_basic_pimpl; // PIMPL for this class
 	  e_connection_type_RPC = 1, // the rpc commands  (probably not rate limited, not chunked, etc)
 	  e_connection_type_P2P = 2  // to other p2p node (probably limited)
   };
-  
+
   std::string to_string(t_connection_type type);
 
 class connection_basic { // not-templated base class for rapid developmet of some code parts
@@ -132,10 +132,10 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		ssl_support_t get_ssl_support() const { return m_ssl_support; }
 		void disable_ssl() { m_ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_disabled; }
 
-		bool handshake(boost::asio::ssl::stream_base::handshake_type type)
+		bool handshake(boost::asio::ssl::stream_base::handshake_type type, boost::asio::const_buffer buffer = {})
 		{
 			//m_state != nullptr verified in constructor
-			return m_state->ssl_options().handshake(socket_, type);
+			return m_state->ssl_options().handshake(socket_, type, buffer);
 		}
 
 		template<typename MutableBufferSequence, typename ReadHandler>
@@ -173,7 +173,7 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		void logger_handle_net_read(size_t size); // network data read
 
 		// config for rate limit
-		
+
 		static void set_rate_up_limit(uint64_t limit);
 		static void set_rate_down_limit(uint64_t limit);
 		static uint64_t get_rate_up_limit();
@@ -193,5 +193,3 @@ class connection_basic { // not-templated base class for rapid developmet of som
 } // nameserver
 
 #endif
-
-

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -232,7 +232,7 @@ namespace net_utils
 			}
 
 			//---------------------------------------------------------------------------
-			inline bool invoke(const boost::string_ref uri, const boost::string_ref method, const std::string& body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) override
+			inline bool invoke(const boost::string_ref uri, const boost::string_ref method, const boost::string_ref body, std::chrono::milliseconds timeout, const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) override
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				if(!is_connected())

--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -118,8 +118,10 @@
         return true; \
       } \
       uint64_t ticks2 = misc_utils::get_tick_count(); \
-      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), response_info.m_body); \
+      epee::byte_slice buffer; \
+      epee::serialization::store_t_to_binary(static_cast<command_type::response&>(resp), buffer, 64 * 1024); \
       uint64_t ticks3 = epee::misc_utils::get_tick_count(); \
+      response_info.m_body.assign(reinterpret_cast<const char*>(buffer.data()), buffer.size()); \
       response_info.m_mime_tipe = " application/octet-stream"; \
       response_info.m_header_info.m_content_type = " application/octet-stream"; \
       MDEBUG( s_pattern << "() processed with " << ticks1-ticks << "/"<< ticks2-ticks1 << "/" << ticks3-ticks2 << "ms"); \

--- a/contrib/epee/include/net/levin_base.h
+++ b/contrib/epee/include/net/levin_base.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,7 +22,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 
@@ -31,7 +31,6 @@
 
 #include <cstdint>
 
-#include "byte_slice.h"
 #include "net_utils_base.h"
 #include "span.h"
 
@@ -39,6 +38,7 @@
 
 namespace epee
 {
+class byte_slice;
 namespace levin
 {
 #pragma pack(push)
@@ -72,21 +72,22 @@ namespace levin
 
 
 #define LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED 0
-#define LEVIN_DEFAULT_MAX_PACKET_SIZE 100000000      //100MB by default
+#define LEVIN_INITIAL_MAX_PACKET_SIZE  256*1024      // 256 KiB before handshake
+#define LEVIN_DEFAULT_MAX_PACKET_SIZE 100000000      //100MB by default after handshake
 
 #define LEVIN_PACKET_REQUEST			0x00000001
 #define LEVIN_PACKET_RESPONSE		0x00000002
 #define LEVIN_PACKET_BEGIN		0x00000004
 #define LEVIN_PACKET_END		0x00000008
-  
+
 
 #define LEVIN_PROTOCOL_VER_0         0
 #define LEVIN_PROTOCOL_VER_1         1
- 
+
   template<class t_connection_context = net_utils::connection_context_base>
   struct levin_commands_handler
   {
-    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, t_connection_context& context)=0;
+    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, byte_slice& buff_out, t_connection_context& context)=0;
     virtual int notify(int command, const epee::span<const uint8_t> in_buff, t_connection_context& context)=0;
     virtual void callback(t_connection_context& context){};
 
@@ -150,4 +151,3 @@ namespace levin
 
 
 #endif //_LEVIN_BASE_H_
-

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -44,6 +44,7 @@
 #include <boost/lambda/lambda.hpp>
 #include <boost/interprocess/detail/atomic.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <functional>
 #include "net/net_utils_base.h"
 #include "net/net_ssl.h"
@@ -178,7 +179,7 @@ namespace net_utils
 					// SSL Options
 					if (m_ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled || m_ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
 					{
-						if (!m_ssl_options.handshake(*m_ssl_socket, boost::asio::ssl::stream_base::client, addr, timeout))
+						if (!m_ssl_options.handshake(*m_ssl_socket, boost::asio::ssl::stream_base::client, {}, addr, timeout))
 						{
 							if (m_ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
 							{
@@ -280,7 +281,7 @@ namespace net_utils
 
 
 		inline
-		bool send(const std::string& buff, std::chrono::milliseconds timeout)
+		bool send(const boost::string_ref buff, std::chrono::milliseconds timeout)
 		{
 
 			try
@@ -298,7 +299,7 @@ namespace net_utils
 				// object is used as a callback and will update the ec variable when the
 				// operation completes. The blocking_udp_client.cpp example shows how you
 				// can use std::bind rather than boost::lambda.
-				async_write(buff.c_str(), buff.size(), ec);
+				async_write(buff.data(), buff.size(), ec);
 
 				// Block until the asynchronous operation has completed.
 				while (ec == boost::asio::error::would_block)

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,7 +22,7 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 
@@ -132,6 +132,7 @@ namespace net_utils
     bool handshake(
       boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket,
       boost::asio::ssl::stream_base::handshake_type type,
+      boost::asio::const_buffer buffer = {},			
       const std::string& host = {},
       std::chrono::milliseconds timeout = std::chrono::seconds(15)) const;
   };

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -27,7 +27,10 @@
 #pragma once
 
 #include "portable_storage_template_helper.h"
+#include <boost/utility/string_ref.hpp>
 #include <boost/utility/value_init.hpp>
+#include <functional>
+#include "byte_slice.h"
 #include "span.h"
 #include "net/levin_base.h"
 
@@ -49,6 +52,11 @@ namespace
     snprintf(buf, sizeof(buf),  "command-%u", command);
     return on_levin_traffic(context, initiator, sent, error, bytes, buf);
   }
+  static const constexpr epee::serialization::portable_storage::limits_t default_levin_limits = {
+    8192, // objects
+    16384, // fields
+    16384, // strings
+  };
 }
 
 namespace epee
@@ -74,7 +82,7 @@ namespace epee
         return false;
       }
       serialization::portable_storage stg_ret;
-      if(!stg_ret.load_from_binary(buff_to_recv))
+      if(!stg_ret.load_from_binary(buff_to_recv, &default_levin_limits))
       {
         LOG_ERROR("Failed to load_from_binary on command " << command);
         return false;
@@ -109,18 +117,19 @@ namespace epee
       const boost::uuids::uuid &conn_id = context.m_connection_id;
       typename serialization::portable_storage stg;
       out_struct.store(stg);
-      std::string buff_to_send, buff_to_recv;
-      stg.store_to_binary(buff_to_send);
+      byte_slice buff_to_send;
+      std::string buff_to_recv;
+      stg.store_to_binary(buff_to_send, 16 * 1024);
 
       on_levin_traffic(context, true, true, false, buff_to_send.size(), command);
-      int res = transport.invoke(command, buff_to_send, buff_to_recv, conn_id);
+      int res = transport.invoke(command, boost::string_ref{reinterpret_cast<const char*>(buff_to_send.data()), buff_to_send.size()}, buff_to_recv, conn_id);
       if( res <=0 )
       {
         LOG_PRINT_L1("Failed to invoke command " << command << " return code " << res);
         return false;
       }
       typename serialization::portable_storage stg_ret;
-      if(!stg_ret.load_from_binary(buff_to_recv))
+      if(!stg_ret.load_from_binary(buff_to_recv, &default_levin_limits))
       {
         on_levin_traffic(context, true, false, true, buff_to_recv.size(), command);
         LOG_ERROR("Failed to load_from_binary on command " << command);
@@ -136,10 +145,10 @@ namespace epee
       const boost::uuids::uuid &conn_id = context.m_connection_id;
       typename serialization::portable_storage stg;
       const_cast<t_arg&>(out_struct).store(stg);//TODO: add true const support to searilzation
-      std::string buff_to_send;
-      stg.store_to_binary(buff_to_send);
+      byte_slice buff_to_send;
+      stg.store_to_binary(buff_to_send, 16 * 1024);
       on_levin_traffic(context, true, true, false, buff_to_send.size(), command);
-      int res = transport.invoke_async(command, epee::strspan<uint8_t>(buff_to_send), conn_id, [cb, command](int code, const epee::span<const uint8_t> buff, typename t_transport::connection_context& context)->bool
+      int res = transport.invoke_async(command, epee::to_span(buff_to_send), conn_id, [cb, command](int code, const epee::span<const uint8_t> buff, typename t_transport::connection_context& context)->bool
       {
         t_result result_struct = AUTO_VAL_INIT(result_struct);
         if( code <=0 )
@@ -151,7 +160,7 @@ namespace epee
           return false;
         }
         serialization::portable_storage stg_ret;
-        if(!stg_ret.load_from_binary(buff))
+        if(!stg_ret.load_from_binary(buff, &default_levin_limits))
         {
           on_levin_traffic(context, true, false, true, buff.size(), command);
           LOG_ERROR("Failed to load_from_binary on command " << command);
@@ -183,11 +192,11 @@ namespace epee
       const boost::uuids::uuid &conn_id = context.m_connection_id;
       serialization::portable_storage stg;
       out_struct.store(stg);
-      std::string buff_to_send;
+      byte_slice buff_to_send;
       stg.store_to_binary(buff_to_send);
 
       on_levin_traffic(context, true, true, false, buff_to_send.size(), command);
-      int res = transport.notify(command, epee::strspan<uint8_t>(buff_to_send), conn_id);
+      int res = transport.notify(command, epee::to_span(buff_to_send), conn_id);
       if(res <=0 )
       {
         MERROR("Failed to notify command " << command << " return code " << res);
@@ -198,10 +207,10 @@ namespace epee
     //----------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------
     template<class t_owner, class t_in_type, class t_out_type, class t_context, class callback_t>
-    int buff_to_t_adapter(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, callback_t cb, t_context& context )
+    int buff_to_t_adapter(int command, const epee::span<const uint8_t> in_buff, byte_slice& buff_out, callback_t cb, t_context& context )
     {
       serialization::portable_storage strg;
-      if(!strg.load_from_binary(in_buff))
+      if(!strg.load_from_binary(in_buff, &default_levin_limits))
       {
         on_levin_traffic(context, false, false, true, in_buff.size(), command);
         LOG_ERROR("Failed to load_from_binary in command " << command);
@@ -221,7 +230,7 @@ namespace epee
       serialization::portable_storage strg_out;
       static_cast<t_out_type&>(out_struct).store(strg_out);
 
-      if(!strg_out.store_to_binary(buff_out))
+      if(!strg_out.store_to_binary(buff_out, 32 * 1024))
       {
         LOG_ERROR("Failed to store_to_binary in command" << command);
         return -1;
@@ -235,7 +244,7 @@ namespace epee
     int buff_to_t_adapter(t_owner* powner, int command, const epee::span<const uint8_t> in_buff, callback_t cb, t_context& context)
     {
       serialization::portable_storage strg;
-      if(!strg.load_from_binary(in_buff))
+      if(!strg.load_from_binary(in_buff, &default_levin_limits))
       {
         on_levin_traffic(context, false, false, true, in_buff.size(), command);
         LOG_ERROR("Failed to load_from_binary in notify " << command);
@@ -253,7 +262,7 @@ namespace epee
     }
 
 #define CHAIN_LEVIN_INVOKE_MAP2(context_type) \
-  int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, context_type& context) \
+  int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, context_type& context) \
   { \
   bool handled = false; \
   return handle_invoke_map(false, command, in_buff, buff_out, context, handled); \
@@ -262,13 +271,13 @@ namespace epee
 #define CHAIN_LEVIN_NOTIFY_MAP2(context_type) \
   int notify(int command, const epee::span<const uint8_t> in_buff, context_type& context) \
   { \
-  bool handled = false; std::string fake_str;\
+  bool handled = false; epee::byte_slice fake_str; \
   return handle_invoke_map(true, command, in_buff, fake_str, context, handled); \
   }
 
 
 #define CHAIN_LEVIN_INVOKE_MAP() \
-  int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, epee::net_utils::connection_context_base& context) \
+  int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, epee::net_utils::connection_context_base& context) \
   { \
   bool handled = false; \
   return handle_invoke_map(false, command, in_buff, buff_out, context, handled); \
@@ -288,7 +297,7 @@ namespace epee
   }
 
 #define BEGIN_INVOKE_MAP2(owner_type) \
-  template <class t_context> int handle_invoke_map(bool is_notify, int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, t_context& context, bool& handled) \
+  template <class t_context> int handle_invoke_map(bool is_notify, int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, t_context& context, bool& handled) \
   { \
   try { \
   typedef owner_type internal_owner_type_name;
@@ -309,6 +318,7 @@ namespace epee
 #define HANDLE_NOTIFY_T2(NOTIFY, func) \
   if(is_notify && NOTIFY::ID == command) \
   {handled=true;return epee::net_utils::buff_to_t_adapter<internal_owner_type_name, typename NOTIFY::request>(this, command, in_buff, std::bind(func, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), context);}
+
 
 #define CHAIN_INVOKE_MAP2(func) \
   { \
@@ -338,7 +348,7 @@ namespace epee
   } \
   catch (const std::exception &e) { \
     MERROR("Error in handle_invoke_map: " << e.what()); \
-    return LEVIN_ERROR_CONNECTION_TIMEDOUT; \
+    return LEVIN_ERROR_CONNECTION_TIMEDOUT; /* seems kinda appropriate */ \
   } \
   }
 

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,26 +22,18 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
+#pragma once
 
-
-#pragma once 
-
-#include <type_traits>
-
-#include "misc_language.h"
 #include "portable_storage_base.h"
-#include "portable_storage_to_bin.h"
-#include "portable_storage_from_bin.h"
-#include "portable_storage_to_json.h"
-#include "portable_storage_from_json.h"
 #include "portable_storage_val_converters.h"
+#include "misc_log_ex.h"
 #include "span.h"
-#include "int-util.h"
 
 namespace epee
 {
+  class byte_slice;
   namespace serialization
   {
     /************************************************************************/
@@ -53,6 +45,13 @@ namespace epee
       typedef epee::serialization::hsection hsection;
       typedef epee::serialization::harray  harray;
       typedef storage_entry meta_entry;
+
+      struct limits_t
+      {
+        size_t n_objects;
+        size_t n_fields;
+        size_t n_strings; // not counting field names
+      };
 
       portable_storage(){}
       virtual ~portable_storage(){}
@@ -83,9 +82,9 @@ namespace epee
       bool        delete_entry(const std::string& pentry_name, hsection hparent_section = nullptr);
 
       //-------------------------------------------------------------------------------
-      bool		store_to_binary(binarybuffer& target);
-      bool		load_from_binary(const epee::span<const uint8_t> target);
-      bool		load_from_binary(const std::string& target) { return load_from_binary(epee::strspan<uint8_t>(target)); }
+      bool		store_to_binary(byte_slice& target, std::size_t initial_buffer_size = 8192);
+      bool		load_from_binary(const epee::span<const uint8_t> target, const limits_t *limits = NULL);
+      bool		load_from_binary(const std::string& target, const limits_t *limits = NULL);
       template<class trace_policy>
       bool		  dump_as_xml(std::string& targetObj, const std::string& root_name = "");
       bool		  dump_as_json(std::string& targetObj, size_t indent = 0, bool insert_newlines = true);
@@ -110,23 +109,6 @@ namespace epee
       };
 #pragma pack(pop)
     };
-    inline
-    bool portable_storage::dump_as_json(std::string& buff, size_t indent, bool insert_newlines)
-    {
-      TRY_ENTRY();
-      std::stringstream ss;
-      epee::serialization::dump_as_json(ss, m_root, indent, insert_newlines);
-      buff = ss.str();
-      return true;
-      CATCH_ENTRY("portable_storage::dump_as_json", false)
-    }
-    inline
-    bool portable_storage::load_from_json(const std::string& source)
-    {
-      TRY_ENTRY();
-      return json::load_from_json(source, *this);
-      CATCH_ENTRY("portable_storage::load_from_json", false)
-    }
 
     template<class trace_policy>
     bool portable_storage::dump_as_xml(std::string& targetObj, const std::string& root_name)
@@ -134,75 +116,6 @@ namespace epee
       return false;//TODO: don't think i ever again will use xml - ambiguous and "overtagged" format
     }
 
-    inline
-    bool portable_storage::store_to_binary(binarybuffer& target)
-    {
-      TRY_ENTRY();
-      std::stringstream ss;
-      storage_block_header sbh = AUTO_VAL_INIT(sbh);
-      sbh.m_signature_a = SWAP32LE(PORTABLE_STORAGE_SIGNATUREA);
-      sbh.m_signature_b = SWAP32LE(PORTABLE_STORAGE_SIGNATUREB);
-      sbh.m_ver = PORTABLE_STORAGE_FORMAT_VER;
-      ss.write((const char*)&sbh, sizeof(storage_block_header));
-      pack_entry_to_buff(ss, m_root);
-      target = ss.str();
-      return true;
-      CATCH_ENTRY("portable_storage::store_to_binary", false)
-    }
-    inline
-    bool portable_storage::load_from_binary(const epee::span<const uint8_t> source)
-    {
-      m_root.m_entries.clear();
-      if(source.size() < sizeof(storage_block_header))
-      {
-        LOG_ERROR("portable_storage: wrong binary format, packet size = " << source.size() << " less than expected sizeof(storage_block_header)=" << sizeof(storage_block_header));
-        return false;
-      }
-      storage_block_header* pbuff = (storage_block_header*)source.data();
-      if(pbuff->m_signature_a != SWAP32LE(PORTABLE_STORAGE_SIGNATUREA) ||
-        pbuff->m_signature_b != SWAP32LE(PORTABLE_STORAGE_SIGNATUREB)
-        )
-      {
-        LOG_ERROR("portable_storage: wrong binary format - signature mismatch");
-        return false;
-      }
-      if(pbuff->m_ver != PORTABLE_STORAGE_FORMAT_VER)
-      {
-        LOG_ERROR("portable_storage: wrong binary format - unknown format ver = " << pbuff->m_ver);
-        return false;
-      }
-      TRY_ENTRY();
-      throwable_buffer_reader buf_reader(source.data()+sizeof(storage_block_header), source.size()-sizeof(storage_block_header));
-      buf_reader.read(m_root);
-      return true;//TODO:
-      CATCH_ENTRY("portable_storage::load_from_binary", false);
-    }
-    //---------------------------------------------------------------------------------------------------------------
-    inline
-    hsection portable_storage::open_section(const std::string& section_name,  hsection hparent_section, bool create_if_notexist)
-    {
-      TRY_ENTRY();
-      hparent_section = hparent_section ? hparent_section:&m_root;
-      storage_entry* pentry = find_storage_entry(section_name, hparent_section);
-      if(!pentry)
-      {
-        if(!create_if_notexist)
-          return nullptr;
-        return insert_new_section(section_name, hparent_section);
-      }
-      CHECK_AND_ASSERT(pentry , nullptr);
-      //check that section_entry we find is real "CSSection"
-      if(pentry->type() != typeid(section))
-      {
-        if(create_if_notexist)
-          *pentry = storage_entry(section());//replace
-        else
-          return nullptr;
-      }
-      return &boost::get<section>(*pentry);
-      CATCH_ENTRY("portable_storage::open_section", nullptr);
-    }
-    //---------------------------------------------------------------------------------------------------------------
     template<class to_type>
     struct get_value_visitor: boost::static_visitor<void>
     {
@@ -215,7 +128,7 @@ namespace epee
     template<class t_value>
     bool portable_storage::get_value(const std::string& value_name, t_value& val, hsection hparent_section)
     {
-      BOOST_MPL_ASSERT(( boost::mpl::contains<storage_entry::types, t_value> )); 
+      BOOST_MPL_ASSERT(( boost::mpl::contains<storage_entry::types, t_value> ));
       //TRY_ENTRY();
       if(!hparent_section) hparent_section = &m_root;
       storage_entry* pentry = find_storage_entry(value_name, hparent_section);
@@ -228,22 +141,8 @@ namespace epee
       //CATCH_ENTRY("portable_storage::template<>get_value", false);
     }
     //---------------------------------------------------------------------------------------------------------------
-    inline
-    bool portable_storage::get_value(const std::string& value_name, storage_entry& val, hsection hparent_section)
-    {
-      //TRY_ENTRY();
-      if(!hparent_section) hparent_section = &m_root;
-      storage_entry* pentry = find_storage_entry(value_name, hparent_section);
-      if(!pentry)
-        return false;
-
-      val = *pentry;
-      return true;
-      //CATCH_ENTRY("portable_storage::template<>get_value", false);
-    }
-    //---------------------------------------------------------------------------------------------------------------
     template<class t_value>
-    bool portable_storage::set_value(const std::string& value_name, t_value&& v, hsection hparent_section)        
+    bool portable_storage::set_value(const std::string& value_name, t_value&& v, hsection hparent_section)
     {
       using t_real_value = typename std::decay<t_value>::type;
       BOOST_MPL_ASSERT(( boost::mpl::contains<boost::mpl::push_front<storage_entry::types, storage_entry>::type, t_real_value> ));
@@ -263,38 +162,16 @@ namespace epee
       CATCH_ENTRY("portable_storage::template<>set_value", false);
     }
     //---------------------------------------------------------------------------------------------------------------
-    inline
-    storage_entry* portable_storage::find_storage_entry(const std::string& pentry_name, hsection psection)
-    {
-      TRY_ENTRY();
-      CHECK_AND_ASSERT(psection, nullptr);
-      auto it = psection->m_entries.find(pentry_name);
-      if(it == psection->m_entries.end())
-        return nullptr;
-
-      return &it->second;
-      CATCH_ENTRY("portable_storage::find_storage_entry", nullptr);
-    }
-    //---------------------------------------------------------------------------------------------------------------
     template<class entry_type>
     storage_entry* portable_storage::insert_new_entry_get_storage_entry(const std::string& pentry_name, hsection psection, entry_type&& entry)
     {
       static_assert(std::is_rvalue_reference<entry_type&&>(), "unexpected copy of value");
       TRY_ENTRY();
       CHECK_AND_ASSERT(psection, nullptr);
+      CHECK_AND_ASSERT(!pentry_name.empty(), nullptr);
       auto ins_res = psection->m_entries.emplace(pentry_name, std::forward<entry_type>(entry));
       return &ins_res.first->second;
       CATCH_ENTRY("portable_storage::insert_new_entry_get_storage_entry", nullptr);
-    }
-    //---------------------------------------------------------------------------------------------------------------
-    inline
-    hsection portable_storage::insert_new_section(const std::string& pentry_name, hsection psection)
-    {
-      TRY_ENTRY();
-      storage_entry* pse = insert_new_entry_get_storage_entry(pentry_name, psection, section());
-      if(!pse) return nullptr;
-      return &boost::get<section>(*pse);
-      CATCH_ENTRY("portable_storage::insert_new_section", nullptr);
     }
     //---------------------------------------------------------------------------------------------------------------
     template<class to_type>
@@ -316,7 +193,7 @@ namespace epee
     template<class t_value>
     harray portable_storage::get_first_value(const std::string& value_name, t_value& target, hsection hparent_section)
     {
-      BOOST_MPL_ASSERT(( boost::mpl::contains<storage_entry::types, t_value> )); 
+      BOOST_MPL_ASSERT(( boost::mpl::contains<storage_entry::types, t_value> ));
       //TRY_ENTRY();
       if(!hparent_section) hparent_section = &m_root;
       storage_entry* pentry = find_storage_entry(value_name, hparent_section);
@@ -325,7 +202,7 @@ namespace epee
       if(pentry->type() != typeid(array_entry))
         return nullptr;
       array_entry& ar_entry = boost::get<array_entry>(*pentry);
-      
+
       get_first_value_visitor<t_value> gfv(target);
       if(!boost::apply_visitor(gfv, ar_entry))
         return nullptr;
@@ -350,11 +227,10 @@ namespace epee
       }
     };
 
-
     template<class t_value>
     bool portable_storage::get_next_value(harray hval_array, t_value& target)
     {
-      BOOST_MPL_ASSERT(( boost::mpl::contains<storage_entry::types, t_value> )); 
+      BOOST_MPL_ASSERT(( boost::mpl::contains<storage_entry::types, t_value> ));
       //TRY_ENTRY();
       CHECK_AND_ASSERT(hval_array, false);
       array_entry& ar_entry = *hval_array;
@@ -363,7 +239,7 @@ namespace epee
         return false;
       return true;
       //CATCH_ENTRY("portable_storage::get_next_value", false);
-    } 
+    }
     //---------------------------------------------------------------------------------------------------------------
     template<class t_value>
     harray portable_storage::insert_first_value(const std::string& value_name, t_value&& target, hsection hparent_section)
@@ -408,83 +284,5 @@ namespace epee
       return true;
       CATCH_ENTRY("portable_storage::insert_next_value", false);
     }
-    //---------------------------------------------------------------------------------------------------------------
-    //sections
-    inline
-    harray portable_storage::get_first_section(const std::string& sec_name, hsection& h_child_section, hsection hparent_section)
-    {
-      TRY_ENTRY();
-      if(!hparent_section) hparent_section = &m_root;
-      storage_entry* pentry = find_storage_entry(sec_name, hparent_section);
-      if(!pentry)
-        return nullptr;
-      if(pentry->type() != typeid(array_entry))
-        return nullptr;
-      array_entry& ar_entry = boost::get<array_entry>(*pentry);
-      if(ar_entry.type() != typeid(array_entry_t<section>))
-        return nullptr;
-      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(ar_entry);
-      section* psec = sec_array.get_first_val();
-      if(!psec)
-        return nullptr;
-      h_child_section = psec;
-      return &ar_entry;
-      CATCH_ENTRY("portable_storage::get_first_section", nullptr);
-    }
-    //---------------------------------------------------------------------------------------------------------------
-    inline
-    bool portable_storage::get_next_section(harray hsec_array, hsection& h_child_section)
-    {
-      TRY_ENTRY();
-      CHECK_AND_ASSERT(hsec_array, false);
-      if(hsec_array->type() != typeid(array_entry_t<section>))
-        return false;
-      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
-      h_child_section = sec_array.get_next_val();
-      if(!h_child_section)
-        return false;
-      return true;
-      CATCH_ENTRY("portable_storage::get_next_section", false);
-    }
-    //---------------------------------------------------------------------------------------------------------------
-    inline
-    harray portable_storage::insert_first_section(const std::string& sec_name, hsection& hinserted_childsection, hsection hparent_section)
-    {
-      TRY_ENTRY();
-      if(!hparent_section) hparent_section = &m_root;
-      storage_entry* pentry = find_storage_entry(sec_name, hparent_section);
-      if(!pentry)
-      {
-        pentry = insert_new_entry_get_storage_entry(sec_name, hparent_section, array_entry(array_entry_t<section>()));
-        if(!pentry)
-          return nullptr;
-      }
-      if(pentry->type() != typeid(array_entry))
-        *pentry = storage_entry(array_entry(array_entry_t<section>()));
-
-      array_entry& ar_entry = boost::get<array_entry>(*pentry);
-      if(ar_entry.type() != typeid(array_entry_t<section>))
-        ar_entry = array_entry(array_entry_t<section>());
-
-      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(ar_entry);
-      hinserted_childsection = &sec_array.insert_first_val(section());
-      return &ar_entry;
-      CATCH_ENTRY("portable_storage::insert_first_section", nullptr);
-    }
-    //---------------------------------------------------------------------------------------------------------------
-    inline
-    bool portable_storage::insert_next_section(harray hsec_array, hsection& hinserted_childsection)
-    {
-      TRY_ENTRY();
-      CHECK_AND_ASSERT(hsec_array, false);
-      CHECK_AND_ASSERT_MES(hsec_array->type() == typeid(array_entry_t<section>), 
-        false, "unexpected type(not 'section') in insert_next_section, type: " << hsec_array->type().name());
-
-      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
-      hinserted_childsection = &sec_array.insert_next_value(section());
-      return true;
-      CATCH_ENTRY("portable_storage::insert_next_section", false);
-    }
-    //---------------------------------------------------------------------------------------------------------------
   }
 }

--- a/contrib/epee/include/storages/portable_storage_base.h
+++ b/contrib/epee/include/storages/portable_storage_base.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,34 +22,34 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 
-#pragma once 
+#pragma once
 
 #include <boost/variant.hpp>
-#include <boost/any.hpp>
 #include <string>
 #include <vector>
 #include <deque>
+#include <map>
 #include "misc_log_ex.h"
 
 #define PORTABLE_STORAGE_SIGNATUREA 0x01011101
-#define PORTABLE_STORAGE_SIGNATUREB 0x01020101 // bender's nightmare 
+#define PORTABLE_STORAGE_SIGNATUREB 0x01020101 // bender's nightmare
 #define PORTABLE_STORAGE_FORMAT_VER 1
 
-#define PORTABLE_RAW_SIZE_MARK_MASK   0x03 
+#define PORTABLE_RAW_SIZE_MARK_MASK   0x03
 #define PORTABLE_RAW_SIZE_MARK_BYTE   0
 #define PORTABLE_RAW_SIZE_MARK_WORD   1
 #define PORTABLE_RAW_SIZE_MARK_DWORD  2
 #define PORTABLE_RAW_SIZE_MARK_INT64  3
 
-#ifndef MAX_STRING_LEN_POSSIBLE       
+#ifndef MAX_STRING_LEN_POSSIBLE
 #define MAX_STRING_LEN_POSSIBLE       2000000000 //do not let string be so big
 #endif
 
-//data types 
+//data types
 #define SERIALIZE_TYPE_INT64                1
 #define SERIALIZE_TYPE_INT32                2
 #define SERIALIZE_TYPE_INT16                3
@@ -82,7 +82,7 @@ namespace epee
     template<class t_entry_type>
     struct array_entry_t
     {
-      array_entry_t():m_it(m_array.end()){}        
+      array_entry_t():m_it(m_array.end()){}
       array_entry_t(const array_entry_t& other):m_array(other.m_array), m_it(m_array.end()){}
 
       array_entry_t& operator=(const array_entry_t& other)
@@ -91,28 +91,28 @@ namespace epee
         m_it = m_array.end();
         return *this;
       }
-        
-      const t_entry_type* get_first_val() const 
+
+      const t_entry_type* get_first_val() const
       {
         m_it = m_array.begin();
         return get_next_val();
       }
 
-      t_entry_type* get_first_val() 
+      t_entry_type* get_first_val()
       {
         m_it = m_array.begin();
         return get_next_val();
       }
 
 
-      const t_entry_type* get_next_val() const 
+      const t_entry_type* get_next_val() const
       {
         if(m_it == m_array.end())
           return nullptr;
         return &(*(m_it++));
       }
 
-      t_entry_type* get_next_val() 
+      t_entry_type* get_next_val()
       {
         if(m_it == m_array.end())
           return nullptr;
@@ -143,25 +143,25 @@ namespace epee
 
 
     typedef  boost::make_recursive_variant<
-      array_entry_t<section>, 
-      array_entry_t<uint64_t>, 
-      array_entry_t<uint32_t>, 
-      array_entry_t<uint16_t>, 
-      array_entry_t<uint8_t>, 
-      array_entry_t<int64_t>, 
-      array_entry_t<int32_t>, 
-      array_entry_t<int16_t>, 
-      array_entry_t<int8_t>, 
-      array_entry_t<double>, 
-      array_entry_t<bool>, 
+      array_entry_t<section>,
+      array_entry_t<uint64_t>,
+      array_entry_t<uint32_t>,
+      array_entry_t<uint16_t>,
+      array_entry_t<uint8_t>,
+      array_entry_t<int64_t>,
+      array_entry_t<int32_t>,
+      array_entry_t<int16_t>,
+      array_entry_t<int8_t>,
+      array_entry_t<double>,
+      array_entry_t<bool>,
       array_entry_t<std::string>,
-      array_entry_t<section>, 
-      array_entry_t<boost::recursive_variant_> 
+      array_entry_t<section>,
+      array_entry_t<boost::recursive_variant_>
     >::type array_entry;
 
     typedef boost::variant<uint64_t, uint32_t, uint16_t, uint8_t, int64_t, int32_t, int16_t, int8_t, double, bool, std::string, section, array_entry> storage_entry;
 
-    typedef std::string binarybuffer;//it's ok      
+    typedef std::string binarybuffer;//it's ok
 
     /************************************************************************/
     /*                                                                      */
@@ -172,7 +172,7 @@ namespace epee
     };
 
     //handle-like aliases
-    typedef section*      hsection;  
+    typedef section*      hsection;
     typedef array_entry*  harray;
   }
 }

--- a/contrib/epee/include/storages/portable_storage_from_json.h
+++ b/contrib/epee/include/storages/portable_storage_from_json.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,11 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 #pragma once
 #include <boost/lexical_cast.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include "parserse_base_utils.h"
 #include "file_io_utils.h"
@@ -51,26 +52,26 @@ namespace epee
         CHECK_AND_ASSERT_THROW_MES(recursion < EPEE_JSON_RECURSION_LIMIT_INTERNAL, "Wrong JSON data: recursion limitation (" << EPEE_JSON_RECURSION_LIMIT_INTERNAL << ") exceeded");
 
         std::string::const_iterator sub_element_start;
-        std::string name;        
+        std::string name;
         typename t_storage::harray h_array = nullptr;
         enum match_state
         {
-          match_state_lookup_for_section_start, 
-          match_state_lookup_for_name, 
-          match_state_waiting_separator, 
-          match_state_wonder_after_separator, 
-          match_state_wonder_after_value, 
-          match_state_wonder_array, 
+          match_state_lookup_for_section_start,
+          match_state_lookup_for_name,
+          match_state_waiting_separator,
+          match_state_wonder_after_separator,
+          match_state_wonder_after_value,
+          match_state_wonder_array,
           match_state_array_after_value,
-          match_state_array_waiting_value, 
+          match_state_array_waiting_value,
           match_state_error
         };
 
         enum array_mode
         {
           array_mode_undifined = 0,
-          array_mode_sections, 
-          array_mode_string, 
+          array_mode_sections,
+          array_mode_string,
           array_mode_numbers,
           array_mode_booleans
         };
@@ -113,7 +114,7 @@ namespace epee
             {//just a named string value started
               std::string val;
               match_string2(it, buf_end, val);
-              //insert text value 
+              //insert text value
               stg.set_value(name, std::move(val), current_section);
               state = match_state_wonder_after_value;
             }else if (epee::misc_utils::parse::isdigit(*it) || *it == '-')
@@ -128,20 +129,20 @@ namespace epee
                   errno = 0;
                   int64_t nval = strtoll(val.data(), NULL, 10);
                   if (errno) throw std::runtime_error("Invalid number: " + std::string(val));
-                  stg.set_value(name, int64_t(nval), current_section);              
+                  stg.set_value(name, int64_t(nval), current_section);
                 }else
                 {
                   errno = 0;
                   uint64_t nval = strtoull(val.data(), NULL, 10);
                   if (errno) throw std::runtime_error("Invalid number: " + std::string(val));
-                  stg.set_value(name, uint64_t(nval), current_section);              
+                  stg.set_value(name, uint64_t(nval), current_section);
                 }
               }else
               {
                 errno = 0;
                 double nval = strtod(val.data(), NULL);
                 if (errno) throw std::runtime_error("Invalid number: " + std::string(val));
-                stg.set_value(name, double(nval), current_section);              
+                stg.set_value(name, double(nval), current_section);
               }
               state = match_state_wonder_after_value;
             }else if(isalpha(*it) )
@@ -151,14 +152,14 @@ namespace epee
               if(boost::iequals(word, "null"))
               {
                 state = match_state_wonder_after_value;
-                //just skip this, 
+                //just skip this,
               }else if(boost::iequals(word, "true"))
               {
-                stg.set_value(name, true, current_section);              
+                stg.set_value(name, true, current_section);
                 state = match_state_wonder_after_value;
               }else if(boost::iequals(word, "false"))
               {
-                stg.set_value(name, false, current_section);              
+                stg.set_value(name, false, current_section);
                 state = match_state_wonder_after_value;
               }else ASSERT_MES_AND_THROW("Unknown value keyword " << word);
             }else if(*it == '{')
@@ -186,7 +187,7 @@ namespace epee
           case match_state_wonder_array:
             if(*it == '[')
             {
-              ASSERT_MES_AND_THROW("array of array not suppoerted yet :( sorry"); 
+              ASSERT_MES_AND_THROW("array of array not suppoerted yet :( sorry");
               //mean array of array
             }
             if(*it == '{')
@@ -249,13 +250,13 @@ namespace epee
               match_word2(it, buf_end, word);
               if(boost::iequals(word, "true"))
               {
-                h_array = stg.insert_first_value(name, true, current_section);              
+                h_array = stg.insert_first_value(name, true, current_section);
                 CHECK_AND_ASSERT_THROW_MES(h_array, " failed to insert values section entry");
                 state = match_state_array_after_value;
                 array_md = array_mode_booleans;
               }else if(boost::iequals(word, "false"))
               {
-                h_array = stg.insert_first_value(name, false, current_section);              
+                h_array = stg.insert_first_value(name, false, current_section);
                 CHECK_AND_ASSERT_THROW_MES(h_array, " failed to insert values section entry");
                 state = match_state_array_after_value;
                 array_md = array_mode_booleans;
@@ -323,7 +324,7 @@ namespace epee
                   errno = 0;
                   double nval = strtod(val.data(), NULL);
                   if (errno) throw std::runtime_error("Invalid number: " + std::string(val));
-                  insert_res = stg.insert_next_value(h_array, double(nval));              
+                  insert_res = stg.insert_next_value(h_array, double(nval));
                 }
                 CHECK_AND_ASSERT_THROW_MES(insert_res, "Failed to insert next value");
                 state = match_state_array_after_value;
@@ -337,7 +338,7 @@ namespace epee
                 match_word2(it, buf_end, word);
                 if(boost::iequals(word, "true"))
                 {
-                  bool r = stg.insert_next_value(h_array, true);              
+                  bool r = stg.insert_next_value(h_array, true);
                   CHECK_AND_ASSERT_THROW_MES(r, " failed to insert values section entry");
                   state = match_state_array_after_value;
                 }else if(boost::iequals(word, "false"))
@@ -369,9 +370,9 @@ namespace epee
         "streetAddress": "21 2nd Street",
         "city": "New York",
         "state": "NY",
-        "postalCode": -10021, 
-        "have_boobs": true, 
-        "have_balls": false 
+        "postalCode": -10021,
+        "have_boobs": true,
+        "have_balls": false
     },
     "phoneNumber": [
         {
@@ -382,7 +383,7 @@ namespace epee
             "type": "fax",
             "number": "646 555-4567"
         }
-    ], 
+    ],
     "phoneNumbers": [
     "812 123-1234",
     "916 123-4567"

--- a/contrib/epee/include/storages/portable_storage_template_helper.h
+++ b/contrib/epee/include/storages/portable_storage_template_helper.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,15 +22,17 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 #pragma once
 
 #include <string>
 
+#include "byte_slice.h"
 #include "parserse_base_utils.h"
 #include "portable_storage.h"
 #include "file_io_utils.h"
+#include "span.h"
 
 namespace epee
 {
@@ -84,10 +86,10 @@ namespace epee
     }
     //-----------------------------------------------------------------------------------------------------------
     template<class t_struct>
-    bool load_t_from_binary(t_struct& out, const epee::span<const uint8_t> binary_buff)
+    bool load_t_from_binary(t_struct& out, const epee::span<const uint8_t> binary_buff, const epee::serialization::portable_storage::limits_t *limits = NULL)
     {
       portable_storage ps;
-      bool rs = ps.load_from_binary(binary_buff);
+      bool rs = ps.load_from_binary(binary_buff, limits);
       if(!rs)
         return false;
 
@@ -111,18 +113,18 @@ namespace epee
     }
     //-----------------------------------------------------------------------------------------------------------
     template<class t_struct>
-    bool store_t_to_binary(t_struct& str_in, std::string& binary_buff, size_t indent = 0)
+    bool store_t_to_binary(t_struct& str_in, byte_slice& binary_buff, size_t initial_buffer_size = 8192)
     {
       portable_storage ps;
       str_in.store(ps);
-      return ps.store_to_binary(binary_buff);
+      return ps.store_to_binary(binary_buff, initial_buffer_size);
     }
     //-----------------------------------------------------------------------------------------------------------
     template<class t_struct>
-    std::string store_t_to_binary(t_struct& str_in, size_t indent = 0)
+    byte_slice store_t_to_binary(t_struct& str_in, size_t initial_buffer_size = 8192)
     {
-      std::string binary_buff;
-      store_t_to_binary(str_in, binary_buff, indent);
+      byte_slice binary_buff;
+      store_t_to_binary(str_in, binary_buff, initial_buffer_size);
       return binary_buff;
     }
   }

--- a/contrib/epee/include/storages/portable_storage_to_bin.h
+++ b/contrib/epee/include/storages/portable_storage_to_bin.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // * Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
 // * Neither the name of the Andrey N. Sabelnikov nor the
 // names of its contributors may be used to endorse or promote products
 // derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,16 +22,17 @@
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 
 
 
-#pragma once 
+#pragma once
 
 #include "pragma_comp_defs.h"
 #include "misc_language.h"
 #include "portable_storage_base.h"
 #include "portable_storage_bin_utils.h"
+#include "misc_log_ex.h"
 
 namespace epee
 {
@@ -80,7 +81,7 @@ namespace epee
     {
       pack_varint(strm, v.size());
       if(v.size())
-        strm.write((const char*)v.data(), v.size());        
+        strm.write((const char*)v.data(), v.size());
       return true;
     }
 
@@ -123,7 +124,7 @@ namespace epee
           put_string(m_strm, s);
         return true;
       }
-      bool operator()(const array_entry_t<section>& arr_sec)    
+      bool operator()(const array_entry_t<section>& arr_sec)
       {
         uint8_t type = SERIALIZE_TYPE_OBJECT|SERIALIZE_FLAG_ARRAY;
         m_strm.write((const char*)&type, 1);
@@ -132,7 +133,7 @@ namespace epee
           pack_entry_to_buff(m_strm, s);
         return true;
       }
-      bool operator()(const array_entry_t<array_entry>& arra_ar)    
+      bool operator()(const array_entry_t<array_entry>& arra_ar)
       {
         uint8_t type = SERIALIZE_TYPE_ARRAY|SERIALIZE_FLAG_ARRAY;
         m_strm.write((const char*)&type, 1);
@@ -174,14 +175,14 @@ namespace epee
         put_string(m_strm, v);
         return true;
       }
-      bool operator()(const section& v)  
+      bool operator()(const section& v)
       {
         uint8_t type = SERIALIZE_TYPE_OBJECT;
         m_strm.write((const char*)&type, 1);
         return pack_entry_to_buff(m_strm, v);
       }
 
-      bool operator()(const array_entry& v)  
+      bool operator()(const array_entry& v)
       {
         //uint8_t type = SERIALIZE_TYPE_ARRAY;
         //m_strm.write((const char*)&type, 1);
@@ -211,6 +212,7 @@ namespace epee
       for(const section_pair& se: sec.m_entries)
       {
         CHECK_AND_ASSERT_THROW_MES(se.first.size() < std::numeric_limits<uint8_t>::max(), "storage_entry_name is too long: " << se.first.size() << ", val: " << se.first);
+        CHECK_AND_ASSERT_THROW_MES(!se.first.empty(), "storage_entry_name is empty");
         uint8_t len = static_cast<uint8_t>(se.first.size());
         strm.write((const char*)&len, sizeof(len));
         strm.write(se.first.data(), size_t(len));

--- a/contrib/epee/include/storages/portable_storage_val_converters.h
+++ b/contrib/epee/include/storages/portable_storage_val_converters.h
@@ -28,19 +28,24 @@
 
 #pragma once
 
-#include <time.h>
 #include <boost/regex.hpp>
 
 #include "misc_language.h"
 #include "portable_storage_base.h"
+#include "parserse_base_utils.h"
 #include "warnings.h"
+#include "misc_log_ex.h"
+
+#include <boost/lexical_cast.hpp>
+#include <typeinfo>
+#include <iomanip>
 
 namespace epee
 {
   namespace serialization
   {
 #define ASSERT_AND_THROW_WRONG_CONVERSION() ASSERT_MES_AND_THROW("WRONG DATA CONVERSION: from type=" << typeid(from).name() << " to type " << typeid(to).name())
-	
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 
@@ -141,7 +146,7 @@ POP_WARNINGS
 
     // For MyMonero/OpenMonero backend compatibility
     // MyMonero backend sends amount, fees and timestamp values as strings.
-    // Until MM backend is updated, this is needed for compatibility between OpenMonero and MyMonero. 
+    // Until MM backend is updated, this is needed for compatibility between OpenMonero and MyMonero.
     template<>
     struct convert_to_integral<std::string, uint64_t, false>
     {

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -1,21 +1,21 @@
 # Copyright (c) 2014-2020, The Monero Project
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this list of
 #    conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice, this list
 #    of conditions and the following disclaimer in the documentation and/or other
 #    materials provided with the distribution.
-# 
+#
 # 3. Neither the name of the copyright holder nor the names of its contributors may be
 #    used to endorse or promote products derived from this software without specific
 #    prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -28,7 +28,7 @@
 
 add_library(epee STATIC byte_slice.cpp byte_stream.cpp hex.cpp abstract_http_client.cpp http_auth.cpp mlog.cpp net_helper.cpp net_utils_base.cpp string_tools.cpp
     wipeable_string.cpp levin_base.cpp memwipe.c connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp buffer.cpp net_ssl.cpp
-    int-util.cpp)
+    int-util.cpp portable_storage.cpp misc_language.cpp )
 
 if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
   add_library(epee_readline STATIC readline_buffer.cpp)
@@ -70,3 +70,5 @@ if (USE_READLINE AND (GNU_READLINE_FOUND OR (DEPENDS AND NOT MINGW)))
     PRIVATE
     ${GNU_READLINE_LIBRARY})
 endif()
+
+target_include_directories(epee PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")

--- a/contrib/epee/src/misc_language.cpp
+++ b/contrib/epee/src/misc_language.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "misc_language.h"
+
+#include <boost/thread.hpp>
+
+namespace epee
+{
+namespace misc_utils
+{
+	bool sleep_no_w(long ms )
+	{
+		boost::this_thread::sleep(
+			boost::get_system_time() +
+			boost::posix_time::milliseconds( std::max<long>(ms,0) ) );
+
+		return true;
+	}
+}
+}

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -482,6 +482,7 @@ bool ssl_options_t::has_fingerprint(boost::asio::ssl::verify_context &ctx) const
 bool ssl_options_t::handshake(
   boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket,
   boost::asio::ssl::stream_base::handshake_type type,
+  boost::asio::const_buffer buffer,
   const std::string& host,
   std::chrono::milliseconds timeout) const
 {
@@ -539,7 +540,7 @@ bool ssl_options_t::handshake(
   });
 
   boost::system::error_code ec = boost::asio::error::would_block;
-  socket.async_handshake(type, boost::lambda::var(ec) = boost::lambda::_1);
+  socket.async_handshake(type, boost::asio::buffer(buffer), boost::lambda::var(ec) = boost::lambda::_1);
   if (io_service.stopped())
   {
     io_service.reset();

--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -1,0 +1,244 @@
+// Copyright (c) 2006-2013, Andrey N. Sabelnikov, www.sabelnikov.net
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of the Andrey N. Sabelnikov nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER  BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "byte_slice.h"
+#include "byte_stream.h"
+#include "misc_log_ex.h"
+#include "span.h"
+#include "storages/portable_storage.h"
+#include "storages/portable_storage_to_json.h"
+#include "storages/portable_storage_from_json.h"
+#include "storages/portable_storage_to_bin.h"
+#include "storages/portable_storage_from_bin.h"
+
+#include <boost/utility/string_ref.hpp>
+
+#include <string>
+#include <sstream>
+
+namespace epee
+{
+namespace serialization
+{
+  bool portable_storage::store_to_binary(byte_slice& target, const std::size_t initial_buffer_size)
+  {
+    TRY_ENTRY();
+    byte_stream ss;
+    ss.reserve(initial_buffer_size);
+    storage_block_header sbh{};
+    sbh.m_signature_a = SWAP32LE(PORTABLE_STORAGE_SIGNATUREA);
+    sbh.m_signature_b = SWAP32LE(PORTABLE_STORAGE_SIGNATUREB);
+    sbh.m_ver = PORTABLE_STORAGE_FORMAT_VER;
+    ss.write(epee::as_byte_span(sbh));
+    pack_entry_to_buff(ss, m_root);
+    target = epee::byte_slice{std::move(ss)};
+    return true;
+    CATCH_ENTRY("portable_storage::store_to_binary", false)
+  }
+
+    bool portable_storage::dump_as_json(std::string& buff, size_t indent, bool insert_newlines)
+    {
+      TRY_ENTRY();
+      std::stringstream ss;
+      epee::serialization::dump_as_json(ss, m_root, indent, insert_newlines);
+      buff = ss.str();
+      return true;
+      CATCH_ENTRY("portable_storage::dump_as_json", false)
+    }
+
+    bool portable_storage::load_from_json(const std::string& source)
+    {
+      TRY_ENTRY();
+      return json::load_from_json(source, *this);
+      CATCH_ENTRY("portable_storage::load_from_json", false)
+    }
+
+    bool portable_storage::load_from_binary(const std::string& target, const limits_t *limits)
+    {
+         return load_from_binary(epee::strspan<uint8_t>(target), limits);
+    }
+
+    bool portable_storage::load_from_binary(const epee::span<const uint8_t> source, const limits_t *limits)
+    {
+      m_root.m_entries.clear();
+      if(source.size() < sizeof(storage_block_header))
+      {
+        LOG_ERROR("portable_storage: wrong binary format, packet size = " << source.size() << " less than expected sizeof(storage_block_header)=" << sizeof(storage_block_header));
+        return false;
+      }
+      storage_block_header* pbuff = (storage_block_header*)source.data();
+      if(pbuff->m_signature_a != SWAP32LE(PORTABLE_STORAGE_SIGNATUREA) ||
+        pbuff->m_signature_b != SWAP32LE(PORTABLE_STORAGE_SIGNATUREB)
+        )
+      {
+        LOG_ERROR("portable_storage: wrong binary format - signature mismatch");
+        return false;
+      }
+      if(pbuff->m_ver != PORTABLE_STORAGE_FORMAT_VER)
+      {
+        LOG_ERROR("portable_storage: wrong binary format - unknown format ver = " << pbuff->m_ver);
+        return false;
+      }
+      TRY_ENTRY();
+      throwable_buffer_reader buf_reader(source.data()+sizeof(storage_block_header), source.size()-sizeof(storage_block_header));
+      if (limits)
+        buf_reader.set_limits(limits->n_objects, limits->n_fields, limits->n_strings);
+      buf_reader.read(m_root);
+      return true;//TODO:
+      CATCH_ENTRY("portable_storage::load_from_binary", false);
+    }
+
+    hsection portable_storage::open_section(const std::string& section_name,  hsection hparent_section, bool create_if_notexist)
+    {
+      TRY_ENTRY();
+      hparent_section = hparent_section ? hparent_section:&m_root;
+      storage_entry* pentry = find_storage_entry(section_name, hparent_section);
+      if(!pentry)
+      {
+        if(!create_if_notexist)
+          return nullptr;
+        return insert_new_section(section_name, hparent_section);
+      }
+      CHECK_AND_ASSERT(pentry , nullptr);
+      //check that section_entry we find is real "CSSection"
+      if(pentry->type() != typeid(section))
+      {
+        if(create_if_notexist)
+          *pentry = storage_entry(section());//replace
+        else
+          return nullptr;
+      }
+      return &boost::get<section>(*pentry);
+      CATCH_ENTRY("portable_storage::open_section", nullptr);
+    }
+
+    bool portable_storage::get_value(const std::string& value_name, storage_entry& val, hsection hparent_section)
+    {
+      //TRY_ENTRY();
+      if(!hparent_section) hparent_section = &m_root;
+      storage_entry* pentry = find_storage_entry(value_name, hparent_section);
+      if(!pentry)
+        return false;
+
+      val = *pentry;
+      return true;
+      //CATCH_ENTRY("portable_storage::template<>get_value", false);
+    }
+
+    storage_entry* portable_storage::find_storage_entry(const std::string& pentry_name, hsection psection)
+    {
+      TRY_ENTRY();
+      CHECK_AND_ASSERT(psection, nullptr);
+      auto it = psection->m_entries.find(pentry_name);
+      if(it == psection->m_entries.end())
+        return nullptr;
+
+      return &it->second;
+      CATCH_ENTRY("portable_storage::find_storage_entry", nullptr);
+    }
+
+    hsection portable_storage::insert_new_section(const std::string& pentry_name, hsection psection)
+    {
+      TRY_ENTRY();
+      storage_entry* pse = insert_new_entry_get_storage_entry(pentry_name, psection, section());
+      if(!pse) return nullptr;
+      return &boost::get<section>(*pse);
+      CATCH_ENTRY("portable_storage::insert_new_section", nullptr);
+    }
+
+    harray portable_storage::get_first_section(const std::string& sec_name, hsection& h_child_section, hsection hparent_section)
+    {
+      TRY_ENTRY();
+      if(!hparent_section) hparent_section = &m_root;
+      storage_entry* pentry = find_storage_entry(sec_name, hparent_section);
+      if(!pentry)
+        return nullptr;
+      if(pentry->type() != typeid(array_entry))
+        return nullptr;
+      array_entry& ar_entry = boost::get<array_entry>(*pentry);
+      if(ar_entry.type() != typeid(array_entry_t<section>))
+        return nullptr;
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(ar_entry);
+      section* psec = sec_array.get_first_val();
+      if(!psec)
+        return nullptr;
+      h_child_section = psec;
+      return &ar_entry;
+      CATCH_ENTRY("portable_storage::get_first_section", nullptr);
+    }
+
+    bool portable_storage::get_next_section(harray hsec_array, hsection& h_child_section)
+    {
+      TRY_ENTRY();
+      CHECK_AND_ASSERT(hsec_array, false);
+      if(hsec_array->type() != typeid(array_entry_t<section>))
+        return false;
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
+      h_child_section = sec_array.get_next_val();
+      if(!h_child_section)
+        return false;
+      return true;
+      CATCH_ENTRY("portable_storage::get_next_section", false);
+    }
+
+    harray portable_storage::insert_first_section(const std::string& sec_name, hsection& hinserted_childsection, hsection hparent_section)
+    {
+      TRY_ENTRY();
+      if(!hparent_section) hparent_section = &m_root;
+      storage_entry* pentry = find_storage_entry(sec_name, hparent_section);
+      if(!pentry)
+      {
+        pentry = insert_new_entry_get_storage_entry(sec_name, hparent_section, array_entry(array_entry_t<section>()));
+        if(!pentry)
+          return nullptr;
+      }
+      if(pentry->type() != typeid(array_entry))
+        *pentry = storage_entry(array_entry(array_entry_t<section>()));
+
+      array_entry& ar_entry = boost::get<array_entry>(*pentry);
+      if(ar_entry.type() != typeid(array_entry_t<section>))
+        ar_entry = array_entry(array_entry_t<section>());
+
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(ar_entry);
+      hinserted_childsection = &sec_array.insert_first_val(section());
+      return &ar_entry;
+      CATCH_ENTRY("portable_storage::insert_first_section", nullptr);
+    }
+
+    bool portable_storage::insert_next_section(harray hsec_array, hsection& hinserted_childsection)
+    {
+      TRY_ENTRY();
+      CHECK_AND_ASSERT(hsec_array, false);
+      CHECK_AND_ASSERT_MES(hsec_array->type() == typeid(array_entry_t<section>),
+        false, "unexpected type(not 'section') in insert_next_section, type: " << hsec_array->type().name());
+
+      array_entry_t<section>& sec_array = boost::get<array_entry_t<section>>(*hsec_array);
+      hinserted_childsection = &sec_array.insert_next_value(section());
+      return true;
+      CATCH_ENTRY("portable_storage::insert_next_section", false);
+    }
+}
+}

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1302,17 +1302,20 @@ public:
    * height. The number of blocks returned is variable, based on the max_size passed.
    *
    * @param start_height the height of the first block
-   * @param min_count the minimum number of blocks to return, if they exist
-   * @param max_count the maximum number of blocks to return
+   * @param min_block_count the minimum number of blocks to return, if they exist
+   * @param max_block_count the maximum number of blocks to return
+   * @param max_tx_count the maximum number of txes to return
    * @param max_size the maximum size of block/transaction data to return (will be exceeded by one blocks's worth at most, if min_count is met)
    * @param blocks the returned block/transaction data
    * @param pruned whether to return full or pruned tx data
    * @param skip_coinbase whether to return or skip coinbase transactions (they're in blocks regardless)
    * @param get_miner_tx_hash whether to calculate and return the miner (coinbase) tx hash
    *
+   * The call will return at least min_block_count if possible, even if this contravenes max_tx_count
+   *
    * @return true iff the blocks and transactions were found
    */
-  virtual bool get_blocks_from(uint64_t start_height, size_t min_count, size_t max_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const = 0;
+  virtual bool get_blocks_from(uint64_t start_height, size_t min_block_count, size_t max_block_count, size_t max_tx_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const = 0;
 
   /**
    * @brief fetches the prunable transaction blob with the given hash

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3144,7 +3144,7 @@ bool BlockchainLMDB::get_pruned_tx_blobs_from(const crypto::hash& h, size_t coun
   return true;
 }
 
-bool BlockchainLMDB::get_blocks_from(uint64_t start_height, size_t min_count, size_t max_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const
+bool BlockchainLMDB::get_blocks_from(uint64_t start_height, size_t min_block_count, size_t max_block_count, size_t max_tx_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
@@ -3158,14 +3158,15 @@ bool BlockchainLMDB::get_blocks_from(uint64_t start_height, size_t min_count, si
     RCURSOR(txs_prunable);
   }
 
-  blocks.reserve(std::min<size_t>(max_count, 10000)); // guard against very large max count if only checking bytes
+  blocks.reserve(std::min<size_t>(max_block_count, 10000)); // guard against very large max count if only checking bytes
   const uint64_t blockchain_height = height();
   uint64_t size = 0;
+  size_t num_txes = 0;
   MDB_val_copy<uint64_t> key(start_height);
   MDB_val k, v, val_tx_id;
   uint64_t tx_id = ~0;
   MDB_cursor_op op = MDB_SET;
-  for (uint64_t h = start_height; h < blockchain_height && blocks.size() < max_count && (size < max_size || blocks.size() < min_count); ++h)
+  for (uint64_t h = start_height; h < blockchain_height && blocks.size() < max_block_count && (size < max_size || blocks.size() < min_block_count); ++h)
   {
     MDB_cursor_op op = h == start_height ? MDB_SET : MDB_NEXT;
     int result = mdb_cursor_get(m_cur_blocks, &key, &v, op);
@@ -3216,6 +3217,7 @@ bool BlockchainLMDB::get_blocks_from(uint64_t start_height, size_t min_count, si
     op = MDB_NEXT;
 
     current_block.second.reserve(b.tx_hashes.size());
+    num_txes += b.tx_hashes.size() + (skip_coinbase ? 0 : 1);
     for (const auto &tx_hash: b.tx_hashes)
     {
       // get pruned data
@@ -3235,6 +3237,9 @@ bool BlockchainLMDB::get_blocks_from(uint64_t start_height, size_t min_count, si
       current_block.second.push_back(std::make_pair(tx_hash, std::move(tx_blob)));
       size += current_block.second.back().second.size();
     }
+
+    if (blocks.size() >= min_block_count && num_txes >= max_tx_count)
+      break;    
   }
 
   TXN_POSTFIX_RDONLY();

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -255,7 +255,7 @@ public:
   virtual bool get_tx_blob(const crypto::hash& h, cryptonote::blobdata &tx) const;
   virtual bool get_pruned_tx_blob(const crypto::hash& h, cryptonote::blobdata &tx) const;
   virtual bool get_pruned_tx_blobs_from(const crypto::hash& h, size_t count, std::vector<cryptonote::blobdata> &bd) const;
-  virtual bool get_blocks_from(uint64_t start_height, size_t min_count, size_t max_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const;
+  virtual bool get_blocks_from(uint64_t start_height, size_t min_block_count, size_t max_block_count, size_t max_tx_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const;
   virtual bool get_prunable_tx_blob(const crypto::hash& h, cryptonote::blobdata &tx) const;
   virtual bool get_prunable_tx_hash(const crypto::hash& tx_hash, crypto::hash &prunable_hash) const;
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -70,7 +70,7 @@ public:
   virtual bool get_tx_blob(const crypto::hash& h, cryptonote::blobdata &tx) const override { return false; }
   virtual bool get_pruned_tx_blob(const crypto::hash& h, cryptonote::blobdata &tx) const override { return false; }
   virtual bool get_pruned_tx_blobs_from(const crypto::hash& h, size_t count, std::vector<cryptonote::blobdata> &bd) const override { return false; }
-  virtual bool get_blocks_from(uint64_t start_height, size_t min_count, size_t max_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const override { return false; }
+  virtual bool get_blocks_from(uint64_t start_height, size_t min_block_count, size_t max_block_count, size_t max_tx_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const override { return false; }
   virtual bool get_prunable_tx_blob(const crypto::hash& h, cryptonote::blobdata &tx) const override { return false; }
   virtual bool get_prunable_tx_hash(const crypto::hash& tx_hash, crypto::hash &prunable_hash) const override { return false; }
   virtual uint64_t get_block_height(const crypto::hash& h) const override { return 0; }

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -28,6 +28,7 @@
 
 set(cryptonote_basic_sources
   account.cpp
+  connection_context.cpp
   cryptonote_basic_impl.cpp
   cryptonote_format_utils.cpp
   difficulty.cpp

--- a/src/cryptonote_basic/connection_context.cpp
+++ b/src/cryptonote_basic/connection_context.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "connection_context.h"
+
+#include "cryptonote_protocol/cryptonote_protocol_defs.h"
+#include "p2p/p2p_protocol_defs.h"
+
+namespace cryptonote
+{
+  std::size_t cryptonote_connection_context::get_max_bytes(const int command) noexcept
+  {
+    switch (command)
+    {
+    case nodetool::COMMAND_HANDSHAKE_T<cryptonote::CORE_SYNC_DATA>::ID:
+      return 65536;
+    case nodetool::COMMAND_TIMED_SYNC_T<cryptonote::CORE_SYNC_DATA>::ID:
+      return 65536;
+    case nodetool::COMMAND_PING::ID:
+      return 4096;
+    case nodetool::COMMAND_REQUEST_SUPPORT_FLAGS::ID:
+      return 4096;
+    case cryptonote::NOTIFY_NEW_BLOCK::ID:
+      return 1024 * 1024 * 128; // 128 MB (max packet is a bit less than 100 MB though)
+    case cryptonote::NOTIFY_NEW_TRANSACTIONS::ID:
+      return 1024 * 1024 * 128; // 128 MB (max packet is a bit less than 100 MB though)
+    case cryptonote::NOTIFY_REQUEST_GET_OBJECTS::ID:
+      return 1024 * 1024 * 2; // 2 MB
+    case cryptonote::NOTIFY_RESPONSE_GET_OBJECTS::ID:
+      return 1024 * 1024 * 128; // 128 MB (max packet is a bit less than 100 MB though)
+    case cryptonote::NOTIFY_REQUEST_CHAIN::ID:
+      return 512 * 1024; // 512 kB
+    case cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::ID:
+      return 1024 * 1024 * 4; // 4 MB
+    case cryptonote::NOTIFY_NEW_FLUFFY_BLOCK::ID:
+      return 1024 * 1024 * 4; // 4 MB, but it does not includes transaction data
+    case cryptonote::NOTIFY_REQUEST_FLUFFY_MISSING_TX::ID:
+      return 1024 * 1024; // 1 MB
+    case cryptonote::NOTIFY_GET_TXPOOL_COMPLEMENT::ID:
+      return 1024 * 1024 * 4; // 4 MB
+    default:
+      break;
+    };
+    return std::numeric_limits<size_t>::max();
+  }
+} // cryptonote

--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -31,6 +31,7 @@
 #pragma once
 #include <unordered_set>
 #include <atomic>
+#include <algorithm>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include "net/net_utils_base.h"
 #include "copyable_atomic.h"
@@ -38,13 +39,12 @@
 
 namespace cryptonote
 {
-
   struct cryptonote_connection_context: public epee::net_utils::connection_context_base
   {
     cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
         m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
         m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_rpc_credits_per_hash(0), m_anchor(false), m_score(0),
-        m_expect_response(0) {}
+        m_expect_response(0), m_expect_height(0), m_num_requested(0) {}
 
     enum state
     {
@@ -54,6 +54,12 @@ namespace cryptonote
       state_idle,
       state_normal
     };
+
+    static constexpr int handshake_command() noexcept { return 1001; }
+    bool handshake_complete() const noexcept { return m_state != state_before_handshake; }
+
+    //! \return Maximum number of bytes permissible for `command`.
+    static size_t get_max_bytes(int command) noexcept;
 
     state m_state;
     std::vector<std::pair<crypto::hash, uint64_t>> m_needed_objects;
@@ -69,7 +75,8 @@ namespace cryptonote
     bool m_anchor;
     int32_t m_score;
     int m_expect_response;
-    uint64_t m_expect_height;    
+    uint64_t m_expect_height;
+    size_t m_num_requested;
   };
 
   inline std::string get_protocol_state_string(cryptonote_connection_context::state s)

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -507,10 +507,12 @@ namespace cryptonote
      * for a block with the given hash
      *
      * @param id the hash to search for
+     * @param where the type of block, if non NULL
      *
      * @return true if the block is known, else false
      */
-    bool have_block(const crypto::hash& id) const;
+     bool have_block_unlocked(const crypto::hash& id, int *where = NULL) const;
+     bool have_block(const crypto::hash& id, int *where = NULL) const;
 
     /**
      * @brief gets the total number of transactions on the main chain
@@ -595,11 +597,12 @@ namespace cryptonote
      * @param total_height return-by-reference our current blockchain height
      * @param start_height return-by-reference the height of the first block returned
      * @param pruned whether to return full or pruned tx blobs
-     * @param max_count the max number of blocks to get
+     * @param max_block_count the max number of blocks to get
+     * @param max_tx_count the max number of txes to get (it can get overshot by the last block's number of txes minus 1)
      *
      * @return true if a block found in common or req_start_block specified, else false
      */
-    bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_count) const;
+    bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const;
 
     /**
      * @brief retrieves a set of blocks and their transactions, and possibly other transactions

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1325,9 +1325,9 @@ namespace cryptonote
     return m_blockchain_storage.find_blockchain_supplement(qblock_ids, clip_pruned, resp);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_count) const
+  bool core::find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const
   {
-    return m_blockchain_storage.find_blockchain_supplement(req_start_block, qblock_ids, blocks, total_height, start_height, pruned, get_miner_tx_hash, max_count);
+    return m_blockchain_storage.find_blockchain_supplement(req_start_block, qblock_ids, blocks, total_height, start_height, pruned, get_miner_tx_hash, max_block_count, max_tx_count);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMAND_RPC_GET_OUTPUTS_BIN::response& res) const
@@ -1433,7 +1433,7 @@ namespace cryptonote
   {
     return m_pprotocol != nullptr && m_pprotocol->is_synchronized();
   }
-  //-----------------------------------------------------------------------------------------------  
+  //-----------------------------------------------------------------------------------------------
   void core::on_synchronized()
   {
     m_miner.on_synchronized();
@@ -1544,9 +1544,14 @@ namespace cryptonote
     return m_mempool.get_transactions_count(include_sensitive_txes);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::have_block(const crypto::hash& id) const
+  bool core::have_block_unlocked(const crypto::hash& id, int *where) const
   {
-    return m_blockchain_storage.have_block(id);
+    return m_blockchain_storage.have_block_unlocked(id, where);
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::have_block(const crypto::hash& id, int *where) const
+  {
+    return m_blockchain_storage.have_block(id, where);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::parse_tx_from_blob(transaction& tx, crypto::hash& tx_hash, const blobdata& blob) const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -55,6 +55,8 @@
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
+enum { HAVE_BLOCK_MAIN_CHAIN, HAVE_BLOCK_ALT_CHAIN, HAVE_BLOCK_INVALID };
+
 namespace cryptonote
 {
    struct test_options {
@@ -543,7 +545,8 @@ namespace cryptonote
       *
       * @note see Blockchain::have_block
       */
-     bool have_block(const crypto::hash& id) const;
+      bool have_block_unlocked(const crypto::hash& id, int *where = NULL) const;
+      bool have_block(const crypto::hash& id, int *where = NULL) const;
 
      /**
       * @copydoc Blockchain::get_short_chain_history
@@ -564,7 +567,7 @@ namespace cryptonote
       *
       * @note see Blockchain::find_blockchain_supplement(const uint64_t, const std::list<crypto::hash>&, std::vector<std::pair<cryptonote::blobdata, std::vector<transaction> > >&, uint64_t&, uint64_t&, size_t) const
       */
-     bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_count) const;
+     bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const;
 
      /**
       * @copydoc Blockchain::get_tx_outputs_gindexs

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -34,6 +34,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include "byte_slice.h"
 #include "common/expect.h"
 #include "common/varint.h"
 #include "cryptonote_config.h"
@@ -47,14 +48,6 @@
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net.p2p.tx"
-
-namespace
-{
-  int get_command_from_message(const cryptonote::blobdata &msg)
-  {
-    return msg.size() >= sizeof(epee::levin::bucket_head2) ? SWAP32LE(((epee::levin::bucket_head2*)msg.data())->m_command) : 0;
-  }
-}
 
 namespace cryptonote
 {
@@ -164,7 +157,7 @@ namespace levin
       return get_out_connections(p2p, get_blockchain_height(p2p, core));
     }
 
-    std::string make_tx_payload(std::vector<blobdata>&& txs, const bool pad, const bool fluff)
+    epee::byte_slice make_tx_payload(std::vector<blobdata>&& txs, const bool pad, const bool fluff)
     {
       NOTIFY_NEW_TRANSACTIONS::request request{};
       request.txs = std::move(txs);
@@ -186,7 +179,7 @@ namespace levin
           padding -= overhead;
         request._ = std::string(padding, ' ');
 
-        std::string arg_buff;
+        epee::byte_slice arg_buff;
         epee::serialization::store_t_to_binary(request, arg_buff);
 
         // we probably lowballed the payload size a bit, so added a but too much. Fix this now.
@@ -198,7 +191,7 @@ namespace levin
         // if the size of _ moved enough, we might lose byte in size encoding, we don't care
       }
 
-      std::string fullBlob;
+      epee::byte_slice fullBlob;
       if (!epee::serialization::store_t_to_binary(request, fullBlob))
         throw std::runtime_error{"Failed to serialize to epee binary format"};
 
@@ -207,12 +200,12 @@ namespace levin
 
     bool make_payload_send_txs(connections& p2p, std::vector<blobdata>&& txs, const boost::uuids::uuid& destination, const bool pad, const bool fluff)
     {
-      const cryptonote::blobdata blob = make_tx_payload(std::move(txs), pad, fluff);
+      const epee::byte_slice blob = make_tx_payload(std::move(txs), pad, fluff);
       p2p.for_connection(destination, [&blob](detail::p2p_context& context) {
-        on_levin_traffic(context, true, true, false, blob.size(), get_command_from_message(blob));
+        on_levin_traffic(context, true, true, false, blob.size(), NOTIFY_NEW_TRANSACTIONS::ID);
         return true;
       });
-      return p2p.notify(NOTIFY_NEW_TRANSACTIONS::ID, epee::strspan<std::uint8_t>(blob), destination);
+      return p2p.notify(NOTIFY_NEW_TRANSACTIONS::ID, epee::to_span(blob), destination);
     }
 
     /* The current design uses `asio::strand`s. The documentation isn't as clear
@@ -440,7 +433,7 @@ namespace levin
         zone->p2p->foreach_connection([txs, now, &zone, &source, &in_duration, &out_duration, &next_flush] (detail::p2p_context& context)
         {
           // When i2p/tor, only fluff to outbound connections
-          if (source != context.m_connection_id && (zone->nzone == epee::net_utils::zone::public_ || !context.m_is_income))
+          if (context.handshake_complete() && source != context.m_connection_id && (zone->nzone == epee::net_utils::zone::public_ || !context.m_is_income))
           {
             if (context.fluff_txs.empty())
               context.flush_time = now + (context.m_is_income ? in_duration() : out_duration());
@@ -830,9 +823,9 @@ namespace levin
 
       // Padding is not useful when using noise mode. Send as stem so receiver
       // forwards in Dandelion++ mode.
-      const std::string payload = make_tx_payload(std::move(txs), false, false);
+      const epee::byte_slice payload = make_tx_payload(std::move(txs), false, false);
       epee::byte_slice message = epee::levin::make_fragmented_notify(
-        zone_->noise, NOTIFY_NEW_TRANSACTIONS::ID, epee::strspan<std::uint8_t>(payload)
+        zone_->noise, NOTIFY_NEW_TRANSACTIONS::ID, epee::to_span(payload)
       );
       if (CRYPTONOTE_MAX_FRAGMENTS * zone_->noise.size() < message.size())
       {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -696,9 +696,7 @@ bool t_rpc_command_executor::show_status() {
   std::cout << "\033[1m------------" << std::endl;
   std::cout << "NETWORK INFO" << std::endl;
   std::cout << "------------\033[0m" << std::endl;
-  std::cout << "\033[1mOutgoing connections: \033[0m" << "\033[32;1m" << ires.outgoing_connections_count << "\033[0m" << "  " <<
-  	         "\033[1mIncoming connections: \033[0m" << "\033[32;1m" << ires.incoming_connections_count << "\033[0m" << "  " <<
-   	         "\033[1mDifficulty: \033[0m" << "\033[32;1m" << cryptonote::difficulty_type(ires.wide_difficulty) << "\033[0m" << "  " <<
+  std::cout << "\033[1mDifficulty: \033[0m" << "\033[32;1m" << cryptonote::difficulty_type(ires.wide_difficulty) << "\033[0m" << "  " <<
                "\033[1mNetwork hashrate: \033[0m" << "\033[32;1m" << get_mining_speed(cryptonote::difficulty_type(ires.wide_difficulty) / ires.target) << "\033[0m" << "  " << std::endl;
   std::cout << "\033[1m-----------" << std::endl;
   std::cout << "MINING INFO" << std::endl;
@@ -836,7 +834,7 @@ bool t_rpc_command_executor::print_connections() {
       std::string seed_3 = SEED_MAINNET_3; std::string seed3 = seed_3.erase(seed_3.length()-6); std::string seed_4 = SEED_MAINNET_4; std::string seed4 = seed_4.erase(seed_4.length()-6);
       std::string seed_5 = SEED_MAINNET_5; std::string seed5 = seed_5.erase(seed_5.length()-6); std::string seed_6 = SEED_MAINNET_6; std::string seed6 = seed_6.erase(seed_6.length()-6);
       std::string seed_7 = SEED_MAINNET_7; std::string seed7 = seed_7.erase(seed_7.length()-6); std::string seed_8 = SEED_MAINNET_8; std::string seed8 = seed_8.erase(seed_8.length()-6);
-      std::vector<std::string> seeds {seed1, seed2, seed3, seed4, seed5, seed6, seed7, seed8};     
+      std::vector<std::string> seeds {seed1, seed2, seed3, seed4, seed5, seed6, seed7, seed8};
       if (search_array(info.ip, seeds))
       {
         address += info.ip + ":" + info.port + "(seed)";
@@ -2553,6 +2551,7 @@ bool t_rpc_command_executor::sync_info()
       tools::success_msg_writer() << "Next needed pruning seed: " << res.next_needed_pruning_seed;
 
     tools::success_msg_writer() << std::to_string(res.peers.size()) << " peers";
+    tools::success_msg_writer() << "Remote Host                        Peer_ID   State   Prune_Seed          Height  DL kB/s, Queued Blocks / MB";    
     for (const auto &p: res.peers)
     {
       if (!(p.info.state == "before_handshake" && std::time(NULL) > p.info.live_time + 10))

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -33,6 +33,7 @@
 #include "device_ledger.hpp"
 #include "cryptonote_basic/subaddress_index.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
+#include <boost/thread/locks.hpp>
 
 namespace hw {
 

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -42,7 +42,7 @@ const hardfork_t mainnet_hard_forks[] = {
   { 7, MAINNET_HARDFORK_V7_HEIGHT, 0, 1555234940 },
   { 8, MAINNET_HARDFORK_V8_HEIGHT, 0, 1555321375 },
   { 9, 350000, 0, 1574120819 }, // abt 6h47' Nov 19, 2019
-  { 10, 502257, 0, 1610700171 }, // CLSAG & EXACT COINBASE - ALLOW BOTH MLSAG AND CLSAG (abt January 15, 2021 8:42:51 AM GMT)
+  { 10, 502257, 0, 1610700171 }, // CLSAG & DETERMINISTIC UNLOCK - ALLOW BOTH MLSAG AND CLSAG (abt January 15, 2021 8:42:51 AM GMT)
   { 11, 502617, 0, 1610786571 }, // FORBID MLSAG ALLOW CLSAG ONLY - A DAY AFTER HF 10
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
@@ -73,6 +73,6 @@ const hardfork_t stagenet_hard_forks[] = {
   { 8, 130560, 0, 1554479506 },
   { 9, 164100, 0, 1572592223 },
   { 10, 231580, 0, 1603158050 }, // CLSAG & EXACT COINBASE
-  { 11, 233500, 0, 1603638050 }, // FORBID MLSAG ALLOW CLSAG ONLY   
+  { 11, 233500, 0, 1603638050 }, // FORBID MLSAG ALLOW CLSAG ONLY
 };
 const size_t num_stagenet_hard_forks = sizeof(stagenet_hard_forks) / sizeof(stagenet_hard_forks[0]);

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -157,7 +157,8 @@ namespace nodetool
     const command_line::arg_descriptor<bool> arg_pad_transactions = {
       "pad-transactions", "Pad relayed transactions to help defend against traffic volume analysis", false
     };
-
+    const command_line::arg_descriptor<uint32_t> arg_max_connections_per_ip = {"max-connections-per-ip", "Maximum number of connections allowed from the same IP address", 1};
+    
     std::optional<std::vector<proxy>> get_proxies(boost::program_options::variables_map const& vm)
     {
         namespace ip = boost::asio::ip;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -139,6 +139,7 @@ namespace nodetool
 
     typedef COMMAND_HANDSHAKE_T<typename t_payload_net_handler::payload_type> COMMAND_HANDSHAKE;
     typedef COMMAND_TIMED_SYNC_T<typename t_payload_net_handler::payload_type> COMMAND_TIMED_SYNC;
+    static_assert(p2p_connection_context::handshake_command() == COMMAND_HANDSHAKE::ID, "invalid handshake command id");
 
     typedef epee::net_utils::boosted_tcp_server<epee::levin::async_protocol_handler<p2p_connection_context>> net_server;
 
@@ -249,7 +250,8 @@ namespace nodetool
         m_same_version(false),
         m_offline(false),
         is_closing(false),
-        m_network_id()
+        m_network_id(),
+        max_connections(1)
     {}
     virtual ~node_server();
 
@@ -496,6 +498,8 @@ namespace nodetool
     cryptonote::network_type m_nettype;
 
     epee::net_utils::ssl_support_t m_ssl_support;
+
+    uint32_t max_connections;
   };
 
     const int64_t default_limit_up = P2P_DEFAULT_LIMIT_RATE_UP;      // kB/s
@@ -529,7 +533,7 @@ namespace nodetool
     extern const command_line::arg_descriptor<int64_t> arg_limit_rate_down;
     extern const command_line::arg_descriptor<int64_t> arg_limit_rate;
     extern const command_line::arg_descriptor<bool> arg_pad_transactions;
-
+    extern const command_line::arg_descriptor<uint32_t> arg_max_connections_per_ip;
 }
 
 POP_WARNINGS

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #pragma once
@@ -37,10 +37,6 @@
 #include "net/tor_address.h"
 #include "net/i2p_address.h"
 #include "p2p/p2p_protocol_defs.h"
-
-#ifdef CRYPTONOTE_PRUNING_DEBUG_SPOOF_SEED
-#include "common/pruning.h"
-#endif
 
 BOOST_CLASS_VERSION(nodetool::peerlist_entry, 3)
 
@@ -228,12 +224,6 @@ namespace boost
         return;
       }
       a & pl.pruning_seed;
-#ifdef CRYPTONOTE_PRUNING_DEBUG_SPOOF_SEED
-      if (!typename Archive::is_saving())
-      {
-        pl.pruning_seed = tools::make_pruning_seed(1+pl.adr.as<epee::net_utils::ipv4_network_address>().ip() % (1<<CRYPTONOTE_PRUNING_LOG_STRIPES), CRYPTONOTE_PRUNING_LOG_STRIPES);
-      }
-#endif
       if (ver < 2)
       {
         if (!typename Archive::is_saving())

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -135,7 +135,7 @@ namespace nodetool
       FIELD(adr)
       FIELD(id)
       FIELD(is_income)
-    END_SERIALIZE()    
+    END_SERIALIZE()
   };
   typedef connection_entry_base<epee::net_utils::network_address> connection_entry;
 
@@ -188,6 +188,7 @@ namespace nodetool
     uint16_t rpc_port;
     uint32_t rpc_credits_per_hash;
     peerid_type peer_id;
+    uint32_t support_flags;
     std::string version;
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -197,6 +198,7 @@ namespace nodetool
       KV_SERIALIZE(version)
       KV_SERIALIZE_OPT(rpc_port, (uint16_t)(0))
       KV_SERIALIZE_OPT(rpc_credits_per_hash, (uint32_t)0)
+      KV_SERIALIZE_OPT(support_flags, (uint32_t)0)      
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/p2p_config.h
+++ b/src/p2p_config.h
@@ -52,13 +52,13 @@ namespace config
 #define BLOCKS_IDS_SYNCHRONIZING_MAX_COUNT              25000  //max blocks ids count in synchronizing
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              10     //by default, blocks count in blocks downloading
 
-#define COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT           1000
+#define COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT     1000
+#define COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT        20000
 
 #define P2P_LOCAL_WHITE_PEERLIST_LIMIT                  1000
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   5000
 
-#define P2P_DEFAULT_CONNECTIONS_COUNT_OUT               12
-#define P2P_DEFAULT_CONNECTIONS_COUNT_IN                28
+#define P2P_DEFAULT_CONNECTIONS_COUNT	                24
 #define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //seconds
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
 #define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  250
@@ -74,10 +74,10 @@ namespace config
 #define P2P_DEFAULT_LIMIT_RATE_UP                       2048       // kB/s
 #define P2P_DEFAULT_LIMIT_RATE_DOWN                     8192       // kB/s
 
-#define P2P_FAILED_ADDR_FORGET_SECONDS                  (24*60*60)     //a day
+#define P2P_FAILED_ADDR_FORGET_SECONDS                  (60*60)     //1 hour
 #define P2P_IP_BLOCKTIME                                (2*60*60*24)  //two days
 #define P2P_IP_FAILS_BEFORE_BLOCK                       5
-#define P2P_IDLE_CONNECTION_KILL_INTERVAL               (30) //30 seconds
+#define P2P_IDLE_CONNECTION_KILL_INTERVAL               (5*60) //5 minutes
 
 #define P2P_SUPPORT_FLAG_FLUFFY_BLOCKS                  0x01
 #define P2P_SUPPORT_FLAGS                               P2P_SUPPORT_FLAG_FLUFFY_BLOCKS

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -478,7 +478,7 @@ namespace cryptonote
       res.database_size = round_up(res.database_size, 5ull* 1024 * 1024 * 1024);
 //  res.update_available = restricted ? false : m_core.is_update_available();
     res.version = restricted ? "" : SUMOKOIN_VERSION_FULL;
-    res.synchronized = check_core_ready();    
+    res.synchronized = check_core_ready();
     res.busy_syncing = m_p2p.get_payload_object().is_busy_syncing();
 
     res.status = CORE_RPC_STATUS_OK;
@@ -543,12 +543,12 @@ namespace cryptonote
       }
     }
 
-    size_t max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT;
+    size_t max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT;
     if (m_rpc_payment)
     {
       max_blocks = res.credits / COST_PER_BLOCK;
-      if (max_blocks > COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT)
-        max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT;
+      if (max_blocks > COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT)
+        max_blocks = COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT;
       if (max_blocks == 0)
       {
         res.status = CORE_RPC_STATUS_PAYMENT_REQUIRED;
@@ -557,7 +557,7 @@ namespace cryptonote
     }
 
     std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > > bs;
-    if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.start_height, req.prune, !req.no_miner_tx, max_blocks))
+    if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.start_height, req.prune, !req.no_miner_tx, max_blocks, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT))
     {
       res.status = "Failed";
       add_host_fail(ctx);

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -119,7 +119,7 @@ namespace rpc
   {
     std::vector<std::pair<std::pair<blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, blobdata> > > > blocks;
 
-    if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, blocks, res.current_height, res.start_height, req.prune, true, COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT))
+    if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, blocks, res.current_height, res.start_height, req.prune, true, COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT))
     {
       res.status = Message::STATUS_FAILED;
       res.error_details = "core::find_blockchain_supplement() returned false";

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2017-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -31,6 +31,8 @@
 #include "rpc/rpc_payment_signature.h"
 #include "rpc/rpc_payment_costs.h"
 #include "storages/http_abstract_invoke.h"
+
+#include <boost/thread.hpp>
 
 #define RETURN_ON_RPC_RESPONSE_ERROR(r, error, res, method) \
   do { \

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -1,21 +1,21 @@
 // Copyright (c) 2017-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 #include "include_base_utils.h"
 #include "net/abstract_http_client.h"
 #include "rpc/core_rpc_server_commands_defs.h"

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2958,7 +2958,7 @@ void wallet2::update_pool_state(std::vector<std::tuple<cryptonote::transaction, 
 
   // remove any pending tx that's not in the pool
   constexpr const std::chrono::seconds tx_propagation_timeout{CRYPTONOTE_DANDELIONPP_EMBARGO_AVERAGE * 3 / 2};
-  const auto now = std::chrono::system_clock::now();	
+  const auto now = std::chrono::system_clock::now();
   std::unordered_map<crypto::hash, wallet2::unconfirmed_transfer_details>::iterator it = m_unconfirmed_txs.begin();
   while (it != m_unconfirmed_txs.end())
   {
@@ -3779,7 +3779,7 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
 //----------------------------------------------------------------------------------------------------
 std::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const epee::wipeable_string& password, bool watch_only)
 {
-  std::string account_data;
+  epee::byte_slice account_data;
   std::string multisig_signers;
   std::string multisig_derivations;
   cryptonote::account_base account = m_account;
@@ -3806,7 +3806,7 @@ std::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const epee::w
   rapidjson::Document json;
   json.SetObject();
   rapidjson::Value value(rapidjson::kStringType);
-  value.SetString(account_data.c_str(), account_data.length());
+  value.SetString(reinterpret_cast<const char*>(account_data.data()), account_data.size());
   json.AddMember("key_data", value, json.GetAllocator());
   if (!seed_language.empty())
   {
@@ -3977,13 +3977,12 @@ std::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const epee::w
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   json.Accept(writer);
-  account_data = buffer.GetString();
 
   // Encrypt the entire JSON object.
   std::string cipher;
-  cipher.resize(account_data.size());
+  cipher.resize(buffer.GetSize());
   keys_file_data.value().iv = crypto::rand<crypto::chacha_iv>();
-  crypto::chacha20(account_data.data(), account_data.size(), key, keys_file_data.value().iv, &cipher[0]);
+  crypto::chacha20(buffer.GetString(), buffer.GetSize(), key, keys_file_data.value().iv, &cipher[0]);
   keys_file_data.value().account_data = cipher;
   return keys_file_data;
 }

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(unit_tests_sources
   dns_resolver.cpp
   epee_boosted_tcp_server.cpp
   epee_levin_protocol_handler_async.cpp
+  epee_serialization.cpp
   epee_utils.cpp
   expect.cpp
 #  fee.cpp (Needs have manipulation to work with sumo TODO)

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <boost/chrono/chrono.hpp>
@@ -37,6 +37,7 @@
 #include "include_base_utils.h"
 #include "string_tools.h"
 #include "net/abstract_tcp_server2.h"
+#include "net/levin_protocol_handler_async.h"
 
 namespace
 {

--- a/tests/unit_tests/epee_levin_protocol_handler_async.cpp
+++ b/tests/unit_tests/epee_levin_protocol_handler_async.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <boost/thread/mutex.hpp>
@@ -43,6 +43,9 @@ namespace
 {
   struct test_levin_connection_context : public epee::net_utils::connection_context_base
   {
+    static constexpr int handshake_command() noexcept { return 1001; }
+    static constexpr bool handshake_complete() noexcept { return true; }
+    size_t get_max_bytes(int command) const { return LEVIN_DEFAULT_MAX_PACKET_SIZE; }
   };
 
   typedef epee::levin::async_protocol_handler_config<test_levin_connection_context> test_levin_protocol_handler_config;
@@ -56,13 +59,13 @@ namespace
     {
     }
 
-    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, test_levin_connection_context& context)
+    virtual int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, test_levin_connection_context& context)
     {
       m_invoke_counter.inc();
       boost::unique_lock<boost::mutex> lock(m_mutex);
       m_last_command = command;
       m_last_in_buf = std::string((const char*)in_buff.data(), in_buff.size());
-      buff_out = m_invoke_out_buf;
+      buff_out = m_invoke_out_buf.clone();
       return m_return_code;
     }
 
@@ -102,8 +105,7 @@ namespace
     int return_code() const { return m_return_code; }
     void return_code(int v) { m_return_code = v; }
 
-    const std::string& invoke_out_buf() const { return m_invoke_out_buf; }
-    void invoke_out_buf(const std::string& v) { m_invoke_out_buf = v; }
+    void invoke_out_buf(std::string v) { m_invoke_out_buf = epee::byte_slice{std::move(v)}; }
 
     int last_command() const { return m_last_command; }
     const std::string& last_in_buf() const { return m_last_in_buf; }
@@ -118,7 +120,7 @@ namespace
     boost::mutex m_mutex;
 
     int m_return_code;
-    std::string m_invoke_out_buf;
+    epee::byte_slice m_invoke_out_buf;
 
     int m_last_command;
     std::string m_last_in_buf;
@@ -194,6 +196,7 @@ namespace
     {
       m_handler_config.set_handler(m_pcommands_handler, [](epee::levin::levin_commands_handler<test_levin_connection_context> *handler) { delete handler; });
       m_handler_config.m_invoke_timeout = invoke_timeout;
+      m_handler_config.m_initial_max_packet_size = max_packet_size;
       m_handler_config.m_max_packet_size = max_packet_size;
     }
 
@@ -587,7 +590,7 @@ TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_chunke
 
   ASSERT_TRUE(m_conn->m_protocol_handler.handle_recv(buf2.data(), buf2.size()));
   ASSERT_EQ(1, m_commands_handler.invoke_counter());
-} 
+}
 
 
 TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_chunked_body)

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+#include "storages/portable_storage.h"
+#include "span.h"
+
+TEST(epee_binary, two_keys)
+{
+  static constexpr const std::uint8_t data[] = {
+    0x01, 0x11, 0x01, 0x1, 0x01, 0x01, 0x02, 0x1, 0x1, 0x08, 0x01, 'a',
+    0x0B, 0x00, 0x01, 'b', 0x0B, 0x00
+  };
+
+  epee::serialization::portable_storage storage{};
+  EXPECT_TRUE(storage.load_from_binary(data));
+}
+
+TEST(epee_binary, duplicate_key)
+{
+  static constexpr const std::uint8_t data[] = {
+    0x01, 0x11, 0x01, 0x1, 0x01, 0x01, 0x02, 0x1, 0x1, 0x08, 0x01, 'a',
+    0x0B, 0x00, 0x01, 'a', 0x0B, 0x00
+  };
+
+  epee::serialization::portable_storage storage{};
+  EXPECT_FALSE(storage.load_from_binary(data));
+}

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -886,8 +886,6 @@ TEST(ByteStream, Empty)
 {
   epee::byte_stream stream;
 
-  EXPECT_EQ(epee::byte_stream::default_increase(), stream.increase_size());
-
   EXPECT_EQ(nullptr, stream.data());
   EXPECT_EQ(nullptr, stream.tellp());
   EXPECT_EQ(0u, stream.available());
@@ -912,43 +910,55 @@ TEST(ByteStream, Write)
     {0xde, 0xad, 0xbe, 0xef, 0xef};
 
   std::vector<std::uint8_t> bytes;
-  epee::byte_stream stream{4};
-
-  EXPECT_EQ(4u, stream.increase_size());
+  epee::byte_stream stream{};
 
   stream.write({source, 3});
   bytes.insert(bytes.end(), source, source + 3);
   EXPECT_EQ(3u, stream.size());
-  EXPECT_EQ(1u, stream.available());
-  EXPECT_EQ(4u, stream.capacity());
+  EXPECT_LE(3u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+
+  const std::size_t capacity = stream.capacity();
 
   stream.write({source, 2});
   bytes.insert(bytes.end(), source, source + 2);
   EXPECT_EQ(5u, stream.size());
-  EXPECT_EQ(3u, stream.available());
-  EXPECT_EQ(8u, stream.capacity());
+  EXPECT_LE(5u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 
   stream.write({source, 5});
   bytes.insert(bytes.end(), source, source + 5);
   EXPECT_EQ(10u, stream.size());
-  EXPECT_EQ(2u, stream.available());
-  EXPECT_EQ(12u, stream.capacity());
+  EXPECT_LE(10u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 
   stream.write({source, 2});
   bytes.insert(bytes.end(), source, source + 2);
   EXPECT_EQ(12u, stream.size());
-  EXPECT_EQ(0u, stream.available());
-  EXPECT_EQ(12u, stream.capacity());
+  EXPECT_LE(12u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 
   stream.write({source, 5});
   bytes.insert(bytes.end(), source, source + 5);
   EXPECT_EQ(17u, stream.size());
-  EXPECT_EQ(0u, stream.available());
-  EXPECT_EQ(17u, stream.capacity());
+  EXPECT_LE(17u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
+  EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
+
+  // ensure it can overflow properly
+  while (capacity == stream.capacity())
+  {
+    stream.write({source, 5});
+    bytes.insert(bytes.end(), source, source + 5);
+  }
+
+  EXPECT_EQ(bytes.size(), stream.size());
+  EXPECT_LE(bytes.size(), stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 }
 
@@ -967,8 +977,8 @@ TEST(ByteStream, Put)
   }
 
   EXPECT_EQ(200u, stream.size());
-  EXPECT_EQ(epee::byte_stream::default_increase() - 200, stream.available());
-  EXPECT_EQ(epee::byte_stream::default_increase(), stream.capacity());
+  EXPECT_LE(200u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 }
 
@@ -998,14 +1008,12 @@ TEST(ByteStream, Reserve)
     {0xde, 0xad, 0xbe, 0xef, 0xef};
 
   std::vector<std::uint8_t> bytes;
-  epee::byte_stream stream{4};
-
-  EXPECT_EQ(4u, stream.increase_size());
+  epee::byte_stream stream{};
 
   stream.reserve(100);
-  EXPECT_EQ(100u, stream.capacity());
+  EXPECT_LE(100u, stream.capacity());
   EXPECT_EQ(0u, stream.size());
-  EXPECT_EQ(100u, stream.available());
+  EXPECT_EQ(stream.available(), stream.capacity());
 
   for (std::size_t i = 0; i < 100 / sizeof(source); ++i)
   {
@@ -1014,8 +1022,8 @@ TEST(ByteStream, Reserve)
   }
 
   EXPECT_EQ(100u, stream.size());
-  EXPECT_EQ(0u, stream.available());
-  EXPECT_EQ(100u, stream.capacity());
+  EXPECT_LE(100u, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
   EXPECT_TRUE(equal(bytes, byte_span{stream.data(), stream.size()}));
 }
 
@@ -1050,29 +1058,31 @@ TEST(ByteStream, Move)
   static constexpr const std::uint8_t source[] =
     {0xde, 0xad, 0xbe, 0xef, 0xef};
 
-  epee::byte_stream stream{10};
+  epee::byte_stream stream{};
   stream.write(source);
+
+  const std::size_t capacity = stream.capacity();
+  std::uint8_t const* const data = stream.data();
+  EXPECT_LE(5u, capacity);
+  EXPECT_NE(nullptr, data);
 
   epee::byte_stream stream2{std::move(stream)};
 
-  EXPECT_EQ(10u, stream.increase_size());
   EXPECT_EQ(0u, stream.size());
   EXPECT_EQ(0u, stream.available());
   EXPECT_EQ(0u, stream.capacity());
   EXPECT_EQ(nullptr, stream.data());
   EXPECT_EQ(nullptr, stream.tellp());
 
-  EXPECT_EQ(10u, stream2.increase_size());
   EXPECT_EQ(5u, stream2.size());
-  EXPECT_EQ(5u, stream2.available());
-  EXPECT_EQ(10u, stream2.capacity());
-  EXPECT_NE(nullptr, stream2.data());
-  EXPECT_NE(nullptr, stream2.tellp());
+  EXPECT_EQ(capacity, stream2.capacity());
+  EXPECT_EQ(capacity - 5, stream2.available());
+  EXPECT_EQ(data, stream2.data());
+  EXPECT_EQ(data + 5u, stream2.tellp());
   EXPECT_TRUE(equal(source, byte_span{stream2.data(), stream2.size()}));
 
   stream = epee::byte_stream{};
 
-  EXPECT_EQ(epee::byte_stream::default_increase(), stream.increase_size());
   EXPECT_EQ(0u, stream.size());
   EXPECT_EQ(0u, stream.available());
   EXPECT_EQ(0u, stream.capacity());
@@ -1081,15 +1091,13 @@ TEST(ByteStream, Move)
 
   stream = std::move(stream2);
 
-  EXPECT_EQ(10u, stream.increase_size());
   EXPECT_EQ(5u, stream.size());
-  EXPECT_EQ(5u, stream.available());
-  EXPECT_EQ(10u, stream.capacity());
+  EXPECT_EQ(capacity, stream.capacity());
+  EXPECT_EQ(capacity - 5, stream.available());
   EXPECT_NE(nullptr, stream.data());
   EXPECT_NE(nullptr, stream.tellp());
   EXPECT_TRUE(equal(source, byte_span{stream.data(), stream.size()}));
 
-  EXPECT_EQ(10u, stream2.increase_size());
   EXPECT_EQ(0u, stream2.size());
   EXPECT_EQ(0u, stream2.available());
   EXPECT_EQ(0u, stream2.capacity());
@@ -1139,9 +1147,7 @@ TEST(ByteStream, Clear)
   static constexpr const std::uint8_t source[] =
     {0xde, 0xad, 0xbe, 0xef, 0xef};
 
-  epee::byte_stream stream{4};
-
-  EXPECT_EQ(4u, stream.increase_size());
+  epee::byte_stream stream{};
 
   EXPECT_EQ(nullptr, stream.data());
   EXPECT_EQ(nullptr, stream.tellp());
@@ -1163,16 +1169,17 @@ TEST(ByteStream, Clear)
   EXPECT_EQ(loc, stream.data());
   EXPECT_EQ(loc + 3, stream.tellp());
   EXPECT_EQ(3u, stream.size());
-  EXPECT_EQ(1u, stream.available());
-  EXPECT_EQ(4u, stream.capacity());
+  EXPECT_LE(stream.size(), stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
 
+  const std::size_t capacity = stream.capacity();
   stream.clear();
 
   EXPECT_EQ(loc, stream.data());
   EXPECT_EQ(loc, stream.tellp());
   EXPECT_EQ(0u, stream.size());
-  EXPECT_EQ(4u, stream.available());
-  EXPECT_EQ(4u, stream.capacity());
+  EXPECT_EQ(capacity, stream.capacity());
+  EXPECT_EQ(stream.available(), stream.capacity() - stream.size());
 }
 
 TEST(ToHex, String)

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, The Monero Project
+// Copyright (c) 2019-2020, The Monero Project
 //
 // All rights reserved.
 //
@@ -178,17 +178,17 @@ namespace
         {
             using base_type = epee::net_utils::connection_context_base;
             static_cast<base_type&>(context_) = base_type{random_generator(), {}, is_incoming, false};
+            context_.m_state = cryptonote::cryptonote_connection_context::state_normal;
             handler_.after_init_connection();
         }
 
         //\return Number of messages processed
-        std::size_t process_send_queue()
+        std::size_t process_send_queue(const bool valid = true)
         {
             std::size_t count = 0;
             for ( ; !endpoint_.send_queue_.empty(); ++count, endpoint_.send_queue_.pop_front())
             {
-                // invalid messages shoudn't be possible in this test;
-                EXPECT_TRUE(handler_.handle_recv(endpoint_.send_queue_.front().data(), endpoint_.send_queue_.front().size()));
+                EXPECT_EQ(valid, handler_.handle_recv(endpoint_.send_queue_.front().data(), endpoint_.send_queue_.front().size()));
             }
             return count;
         }
@@ -238,9 +238,16 @@ namespace
             return {connection, std::move(request)};
         }
 
-        virtual int invoke(int command, const epee::span<const uint8_t> in_buff, std::string& buff_out, cryptonote::levin::detail::p2p_context& context) override final
+        static received_message get_raw_message(std::deque<received_message>& queue)
         {
-            buff_out.clear();
+            received_message out{std::move(queue.front())};
+            queue.pop_front();
+            return out;
+        }
+
+        virtual int invoke(int command, const epee::span<const uint8_t> in_buff, epee::byte_slice& buff_out, cryptonote::levin::detail::p2p_context& context) override final
+        {
+            buff_out = nullptr;
             invoked_.push_back(
                 {context.m_connection_id, command, std::string{reinterpret_cast<const char*>(in_buff.data()), in_buff.size()}}
             );
@@ -294,6 +301,11 @@ namespace
         {
             return get_message<T>(notified_);
         }
+
+        received_message get_raw_notification()
+        {
+            return get_raw_message(notified_);
+        }
     };
 
     class levin_notify : public ::testing::Test
@@ -321,6 +333,8 @@ namespace
             EXPECT_EQ(0u, receiver_.notified_size());
             EXPECT_EQ(0u, events_.relayed_method_size());
         }
+
+        cryptonote::levin::connections& get_connections() noexcept { return *connections_; }
 
         void add_connection(const bool is_incoming)
         {
@@ -2139,4 +2153,28 @@ TEST_F(levin_notify, noise_stem)
             EXPECT_FALSE(notification.dandelionpp_fluff);
         }
     }
+}
+
+TEST_F(levin_notify, command_max_bytes)
+{
+    static constexpr int ping_command = nodetool::COMMAND_PING::ID;
+
+    add_connection(true);
+
+    std::string bytes(4096, 'h');
+
+    EXPECT_EQ(1, get_connections().notify(ping_command, epee::strspan<std::uint8_t>(bytes), contexts_.front().get_id()));
+    EXPECT_EQ(1u, contexts_.front().process_send_queue(true));
+    EXPECT_EQ(1u, receiver_.notified_size());
+
+    const received_message msg = receiver_.get_raw_notification();
+    EXPECT_EQ(ping_command, msg.command);
+    EXPECT_EQ(contexts_.front().get_id(), msg.connection);
+    EXPECT_EQ(bytes, msg.payload);
+
+    bytes.push_back('e');
+
+    EXPECT_EQ(1, get_connections().notify(ping_command, epee::strspan<std::uint8_t>(bytes), contexts_.front().get_id()));
+    EXPECT_EQ(1u, contexts_.front().process_send_queue(false));
+    EXPECT_EQ(0u, receiver_.notified_size());
 }

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -245,7 +245,7 @@ namespace
 
 TEST(tor_address, epee_serializev_v2)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_tor command{MONERO_UNWRAP(net::tor_address::make(v2_onion, 10))};
         EXPECT_FALSE(command.tor.is_unknown());
@@ -266,7 +266,7 @@ TEST(tor_address, epee_serializev_v2)
         EXPECT_EQ(0u, command.tor.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_FALSE(command.tor.is_unknown());
@@ -277,7 +277,7 @@ TEST(tor_address, epee_serializev_v2)
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("tor", nullptr, false)));
@@ -296,7 +296,7 @@ TEST(tor_address, epee_serializev_v2)
 
 TEST(tor_address, epee_serializev_v3)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_tor command{MONERO_UNWRAP(net::tor_address::make(v3_onion, 10))};
         EXPECT_FALSE(command.tor.is_unknown());
@@ -317,7 +317,7 @@ TEST(tor_address, epee_serializev_v3)
         EXPECT_EQ(0u, command.tor.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_FALSE(command.tor.is_unknown());
@@ -328,7 +328,7 @@ TEST(tor_address, epee_serializev_v3)
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("tor", nullptr, false)));
@@ -347,7 +347,7 @@ TEST(tor_address, epee_serializev_v3)
 
 TEST(tor_address, epee_serialize_unknown)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_tor command{net::tor_address::unknown()};
         EXPECT_TRUE(command.tor.is_unknown());
@@ -368,7 +368,7 @@ TEST(tor_address, epee_serialize_unknown)
         EXPECT_EQ(0u, command.tor.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_TRUE(command.tor.is_unknown());
@@ -379,7 +379,7 @@ TEST(tor_address, epee_serialize_unknown)
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("tor", nullptr, false)));
@@ -700,7 +700,7 @@ namespace
 
 TEST(i2p_address, epee_serializev_b32)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_i2p command{MONERO_UNWRAP(net::i2p_address::make(b32_i2p, 10))};
         EXPECT_FALSE(command.i2p.is_unknown());
@@ -721,7 +721,7 @@ TEST(i2p_address, epee_serializev_b32)
         EXPECT_EQ(0u, command.i2p.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_FALSE(command.i2p.is_unknown());
@@ -732,7 +732,7 @@ TEST(i2p_address, epee_serializev_b32)
     // make sure that exceeding max buffer doesn't destroy i2p_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("i2p", nullptr, false)));
@@ -751,7 +751,7 @@ TEST(i2p_address, epee_serializev_b32)
 
 TEST(i2p_address, epee_serialize_unknown)
 {
-    std::string buffer{};
+    epee::byte_slice buffer{};
     {
         test_command_i2p command{net::i2p_address::unknown()};
         EXPECT_TRUE(command.i2p.is_unknown());
@@ -772,7 +772,7 @@ TEST(i2p_address, epee_serialize_unknown)
         EXPECT_EQ(0u, command.i2p.port());
 
         epee::serialization::portable_storage stg{};
-        EXPECT_TRUE(stg.load_from_binary(buffer));
+        EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
     EXPECT_TRUE(command.i2p.is_unknown());
@@ -783,7 +783,7 @@ TEST(i2p_address, epee_serialize_unknown)
     // make sure that exceeding max buffer doesn't destroy i2p_address::_load
     {
         epee::serialization::portable_storage stg{};
-        stg.load_from_binary(buffer);
+        stg.load_from_binary(epee::to_span(buffer));
 
         std::string host{};
         ASSERT_TRUE(stg.get_value("host", host, stg.open_section("i2p", nullptr, false)));

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -47,7 +47,7 @@ namespace cryptonote {
 class test_core : public cryptonote::i_core_events
 {
 public:
-  virtual bool is_synchronized() const final { return true; }  
+  virtual bool is_synchronized() const final { return true; }
   void on_synchronized(){}
   void safesyncmode(const bool){}
   virtual uint64_t get_current_blockchain_height() const final {return 1;}
@@ -55,7 +55,8 @@ public:
   bool init(const boost::program_options::variables_map& vm) {return true ;}
   bool deinit(){return true;}
   bool get_short_chain_history(std::list<crypto::hash>& ids) const { return true; }
-  bool have_block(const crypto::hash& id) const {return true;}
+  bool have_block(const crypto::hash& id, int *where = NULL) const {return false;}
+  bool have_block_unlocked(const crypto::hash& id, int *where = NULL) const {return false;}
   void get_blockchain_top(uint64_t& height, crypto::hash& top_id)const{height=0;top_id=crypto::null_hash;}
   bool handle_incoming_tx(const cryptonote::tx_blob_entry& tx_blob, cryptonote::tx_verification_context& tvc, cryptonote::relay_method tx_relay, bool relayed) { return true; }
   bool handle_incoming_txs(const std::vector<cryptonote::tx_blob_entry>& tx_blob, std::vector<cryptonote::tx_verification_context>& tvc, cryptonote::relay_method tx_relay, bool relayed) { return true; }
@@ -93,6 +94,7 @@ public:
   bool has_block_weights(uint64_t height, uint64_t nblocks) const { return false; }
   bool get_txpool_complement(const std::vector<crypto::hash> &hashes, std::vector<cryptonote::blobdata> &txes) { return false; }
   bool get_pool_transaction_hashes(std::vector<crypto::hash>& txs, bool include_unrelayed_txes = true) const { return false; }
+  crypto::hash get_block_id_by_height(uint64_t height) const { return crypto::null_hash; }
   uint64_t get_free_space() const { return 0; }
   void stop() {}
 };

--- a/tests/unit_tests/test_protocol_pack.cpp
+++ b/tests/unit_tests/test_protocol_pack.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2020, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "gtest/gtest.h"
@@ -34,9 +34,9 @@
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "storages/portable_storage_template_helper.h"
 
-TEST(protocol_pack, protocol_pack_command) 
+TEST(protocol_pack, protocol_pack_command)
 {
-  std::string buff;
+  epee::byte_slice buff;
   cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::request r;
   r.start_height = 1;
   r.total_height = 3;
@@ -47,7 +47,7 @@ TEST(protocol_pack, protocol_pack_command)
     ASSERT_TRUE(res);
 
     cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::request r2;
-    res = epee::serialization::load_t_from_binary(r2, buff);
+    res = epee::serialization::load_t_from_binary(r2, epee::to_span(buff));
     ASSERT_TRUE(res);
     ASSERT_TRUE(r.m_block_ids.size() == i);
     ASSERT_TRUE(r.start_height == 1);


### PR DESCRIPTION
epee: change epee binary output from std::stringstream to byte_stream
p2p: remove peers from grey and anchors lists when blocked
protocol: drop peers we can't download anything from in sync mode
p2p: add aggressive restrictions to pre-handshake p2p buffer limit
epee: restrict duplicate keys in epee binary format
protocol: add a max levin packet size by command type
protocol: command max_bytes moved from dynamic map to static switch
protocol: drop nodes if they claim new data but only give stale data
portable_storage: add some sanity checks on data size
portable_storage: remove overly aggressive cutoff
protocol: fix false positives dropping peers
ssl: buffered handshake detection
portable_storage: remove array element limit
portable_storage: forbid unnamed sections
rpc: limit the number of txes for get_blocks.bin
protocol: don't reset last request time on an idle timer
protocol: fix wrong command in logs
p2p: fix deadlock banning while updating peer lists
portable_storage: check object limit where appropriate
protocol: more sanity checks in new chain block hashes
daemon: header row for peer list in sync_info
portable_storage: better sanity checking
protocol: handle receiving a block hash we've not added yet
blockchain: lock access to m_blocks_hash_of_hashes
p2p: fix accessing an network address in a deleted context
p2p: make REQUEST_SUPPORT_FLAGS optional, pass flags in node data
epee: also limit number of strings in portable_storage
storages: overridable limits for loading portable_storage from binary
p2p: remove obsolete pruning debug code
p2p: fix outgoing and incoming connections limits
daemon: fix status commanf
p2p: fix lingering backpings
p2p: increase idle peer kick time limit
boosted_tcp_server: fix connection lifetime
epee: readline, avoid consecutive duplicates in the history
epee: reduce compilation time of epee/portable_storage.h
p2p: add --max-connections-per-ip daemon option
epee: remove unnecessary atomic operations in levin code
(plus a workflows upgrade to properly use ccache on macos and windows builds) 