### PR TITLE
[wallet2] fix precision of average_output_time and harden code against invalid input types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
       run: |
         git clone https://github.com/libunwind/libunwind
         cd libunwind
-        sudo ./autogen.sh
+        sudo autoreconf -i
         sudo ./configure
         sudo make -j 3
         sudo make install

--- a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
@@ -32,6 +32,7 @@
 #include <deque>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/contains_fwd.hpp>
+#include <boost/mpl/contains.hpp>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "serialization"

--- a/contrib/epee/include/storages/portable_storage.h
+++ b/contrib/epee/include/storages/portable_storage.h
@@ -30,6 +30,7 @@
 #include "portable_storage_val_converters.h"
 #include "misc_log_ex.h"
 #include "span.h"
+#include <boost/mpl/contains.hpp>
 
 namespace epee
 {

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -216,15 +216,8 @@ void BlockchainDB::add_transaction(const crypto::hash& blk_hash, const std::pair
     }
     else
     {
-      LOG_PRINT_L1("Unsupported input type, removing key images and aborting transaction addition");
-      for (const txin_v& tx_input : tx.vin)
-      {
-        if (tx_input.type() == typeid(txin_to_key))
-        {
-          remove_spent_key(boost::get<txin_to_key>(tx_input).k_image);
-        }
-      }
-      return;
+      LOG_PRINT_L1("Unsupported input type, aborting transaction addition");
+      throw std::runtime_error("Unexpected input type, aborting");
     }
   }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1016,6 +1016,8 @@ gamma_picker::gamma_picker(const std::vector<uint64_t> &rct_offsets, double shap
   num_rct_outputs = *(end - 1);
   THROW_WALLET_EXCEPTION_IF(num_rct_outputs == 0, error::wallet_internal_error, "No rct outputs");
   average_output_time = DIFFICULTY_TARGET * blocks_to_consider / outputs_to_consider; // this assumes constant target over the whole rct range
+  if (average_output_time == 0)
+    average_output_time = DIFFICULTY_TARGET * blocks_to_consider / static_cast<double>(outputs_to_consider);   
 };
 
 gamma_picker::gamma_picker(const std::vector<uint64_t> &rct_offsets): gamma_picker(rct_offsets, GAMMA_SHAPE, GAMMA_SCALE) {}


### PR DESCRIPTION
Needs a release.
No need to change the entire output selection distribution pattern for a bit of distribution selection skewing 
Our txs are few, our ring size is enormous and the skewing is insignificant, it wont make any difference so just cover the extreme case of average_output_time == 0 to avoid the division with zero here   `uint64_t output_index = x / average_output_time;`
Funny thing is that on wallet2 header file average_output_time is already declared as double so i guess they forgot to cast it when they introduced that bit of code